### PR TITLE
Poisonous meatwheat made no longer poisonous.

### DIFF
--- a/modular_skyrat/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/modular_skyrat/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -1,0 +1,2 @@
+/obj/item/reagent_containers/food/snacks/meat/slab/meatwheat
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/cooking_oil = 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3222,6 +3222,7 @@
 #include "modular_skyrat\code\modules\events\operative.dm"
 #include "modular_skyrat\code\modules\events\radiation_storm.dm"
 #include "modular_skyrat\code\modules\events\spontaneous_appendicitis.dm"
+#include "modular_skyrat\code\modules\food_and_drinks\food\snacks\meat.dm"
 #include "modular_skyrat\code\modules\mob\say.dm"
 #include "modular_skyrat\code\modules\mob\typing_indicator.dm"
 #include "modular_skyrat\code\modules\mob\living\silicon\robot\robot_modules.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, meathwheat contains blood, poisoning people who eat it due to the bloodtype reaction.
I don't think it is intended.

## Changelog
:cl:
tweak: meatwheat-made meat no longer contains blood and therefore is not toxic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
