### PR TITLE
Adds diethylamine and saltpetre bottles to the biogenerator's designs

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -664,7 +664,7 @@
 		adjustHealth(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 1))
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 2))
 		if(myseed)
-			myseed.adjust_yield(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 0.02))
+			myseed.adjust_yield(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 0.034)) // skyrat-edit
 		adjustPests(-rand(1,2))
 
 	// Nutriment Compost, effectively

--- a/modular_skyrat/code/modules/reagents/reagent_containers/bottle.dm
+++ b/modular_skyrat/code/modules/reagents/reagent_containers/bottle.dm
@@ -1,0 +1,4 @@
+/obj/item/reagent_containers/glass/bottle/saltpetre
+	name = "saltpetre bottle"
+	desc = "A small bottle of saltpetre."
+	list_reagents = list(/datum/reagent/saltpetre = 30)

--- a/modular_skyrat/code/modules/research/designs/biogenerator_designs.dm
+++ b/modular_skyrat/code/modules/research/designs/biogenerator_designs.dm
@@ -1,0 +1,15 @@
+/datum/design/diethylamine
+	name = "Diethylamine"
+	id = "diethylamine_biogen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 75)
+	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
+	category = list("initial","Botany Chemicals")
+
+/datum/design/saltpetre
+	name = "Saltpetre"
+	id = "saltpetre_biogen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 125)
+	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
+	category = list("initial","Botany Chemicals")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3240,6 +3240,8 @@
 #include "modular_skyrat\code\modules\mob\typing_indicator.dm"
 #include "modular_skyrat\code\modules\mob\dead\new_player\sprite_accessories\snouts.dm"
 #include "modular_skyrat\code\modules\mob\living\silicon\robot\robot_modules.dm"
+#include "modular_skyrat\code\modules\reagents\reagent_containers\bottle.dm"
+#include "modular_skyrat\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_skyrat\code\modules\research\designs\mechfabricator_designs.dm"
 #include "modular_skyrat\code\modules\research\techweb\all_nodes.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request

Tin. This PR also lowers the number of units of diethylamine required to increase a plant's yield by 1 from 50 to 30. The purpose of this is to make it possible to dump one of these 30-unit bottles onto the plant directly instead of needing to pour several of them into beakers and deal with... all that mess.

Diethylamine costs 75 biomatter (three times as much as a bottle of robust harvest)
Saltpetre costs 125 biomatter (five times as much)

## Why It's Good For The Game

The hope is that this change will allow us to wean botanists off of tiding chem dispensers every shift. The ability to synthesize chemicals and medicines should be unique to the chemist or sufficiently trained medical staff; it should not be something every botanist is inherently familiar with. 

## Changelog
:cl: CameronWoof
add: Diethylamine and saltpetre is now available for crafting in the biogenerator.
tweak: Diethylamine will increase the yield of a plant at 30 units, down from 50.
/:cl: