### PR TITLE
Comments out the Valentine's holiday

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -84,14 +84,14 @@
 /datum/holiday/groundhog/getStationPrefix()
 	return pick("Deja Vu") //I have been to this place before
 
-/datum/holiday/valentines
+/* /datum/holiday/valentines // BEGIN skyrat-edit
 	name = VALENTINES
 	begin_day = 13
 	end_day = 15
 	begin_month = FEBRUARY
 
 /datum/holiday/valentines/getStationPrefix()
-	return pick("Love","Amore","Single","Smootch","Hug")
+	return pick("Love","Amore","Single","Smootch","Hug") */ // END skyrat-edit
 
 /datum/holiday/birthday
 	name = "Birthday of Space Station 13"


### PR DESCRIPTION
## About The Pull Request

As it says. The valentine's antag datums are still present for use in admin events, but the holiday itself won't fire anymore. Tested and appears to work.

## Why It's Good For The Game

The antag datums are unfortunately interfering with traits and administrative functions.

## Changelog
:cl: CameronWoof
del: Valentine's Day is temporarily disabled.
/:cl: