### PR TITLE
Temporarily disables command bar typing indicator procs

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -70,7 +70,7 @@
 		handle_traits() // eye, ear, brain damages
 	if(stat != DEAD)
 		handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
-		handle_typing_indicator() //skyrat-edit
+		//handle_typing_indicator() //skyrat-edit
 	if(stat != DEAD)
 		return 1
 


### PR DESCRIPTION
## About The Pull Request

Comments out the typing indicator proc from the command bar.
You will still get the typing indicator when using the Say or Emote hotkeys, it just will not show when using 'say' or 'me' in the command bar.

## Why It's Good For The Game

Temporary fix for issues potentially caused by the typing indicator

## Changelog
:cl:
code: Temporarily prevents the typing indicator from appearing when using 'say' or 'me' in the command bar.
/:cl: