### PR TITLE
Removes minefield component from the emagged minesweeper

### DIFF
--- a/modular_skyrat/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/modular_skyrat/code/game/machinery/computer/arcade/minesweeper.dm
@@ -1,0 +1,5 @@
+/obj/machinery/computer/arcade/minesweeper/explode_EVERYTHING()
+	var/mob/living/user = usr
+	to_chat(user, "<span class='boldwarning'>You feel a great sense of dread wash over you, as if you just unleashed armageddon upon yourself!</span>")
+	message_admins("[key_name_admin(user)] failed an emagged Minesweeper arcade and has exploded at [AREACOORD(user)]!")
+	explosion(loc, 1, 2, rand(1,5), rand(1,10))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3275,6 +3275,7 @@
 #include "modular_skyrat\code\game\area\areas\mining.dm"
 #include "modular_skyrat\code\game\area\areas\ruins\lavaland.dm"
 #include "modular_skyrat\code\game\gamemodes\objective.dm"
+#include "modular_skyrat\code\game\machinery\computer\arcade\minesweeper.dm"
 #include "modular_skyrat\code\game\objects\items.dm"
 #include "modular_skyrat\code\game\objects\items\kitchen.dm"
 #include "modular_skyrat\code\game\objects\items\plushes\plushes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. It used to immediately call UP TO 100 explosions which would somehow get lagged and slowly explode over the course of the round. This ruined one round. The minesweeper machine still explodes, but no longer makes that dumb minesweep.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer ruins rounds, it was ridiculous

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes irl minefield from emagged minesweeper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
