### PR TITLE
Changes Dish Drive

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -13,9 +13,6 @@
 	var/static/list/item_types = list(/obj/item/trash/waffles,
 		/obj/item/trash/plate,
 		/obj/item/trash/tray,
-		/obj/item/reagent_containers/glass/bowl,
-		/obj/item/reagent_containers/food/drinks/drinkingglass,
-		/obj/item/kitchen/fork,
 		/obj/item/shard,
 		/obj/item/broken_bottle)
 	var/time_since_dishes = 0

--- a/modular_skyrat/code/game/machinery/dish_drive.dm
+++ b/modular_skyrat/code/game/machinery/dish_drive.dm
@@ -1,0 +1,20 @@
+/obj/machinery/dish_drive
+	name = "dish drive"
+	desc = "A culinary marvel that uses matter-to-energy conversion to store dishes and shards. Convenient! \
+	Additional features include a vacuum function to suck in nearby dishes, and an automatic transfer beam that empties its contents into nearby disposal bins every now and then. \
+	Or you can just drop your plates on the floor, like civilized folk."
+	icon = 'goon/icons/obj/kitchen.dmi'
+	icon_state = "synthesizer"
+	idle_power_usage = 8 //5 with default parts
+	active_power_usage = 13 //10 with default parts
+	density = FALSE
+	circuit = /obj/item/circuitboard/machine/dish_drive
+	pass_flags = PASSTABLE
+	var/static/list/item_types = list(/obj/item/trash/waffles,
+		/obj/item/trash/plate,
+		/obj/item/trash/tray,
+		/obj/item/shard,
+		/obj/item/broken_bottle)
+	var/time_since_dishes = 0
+	var/suction_enabled = TRUE
+	var/transmit_enabled = TRUE


### PR DESCRIPTION
Changes Dish Drive to not throw away Bowls, Forks, and Drinking Glasses, as they can be re-used.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes drinking glasses, bowls, and forks from the things the dish drive throws away.

## Why It's Good For The Game

Makes the dish drive actually useful and not detrimental. 

## Changelog
:cl:
tweak: Tweaked Dish Drive throwing away useful things.
/:cl:
