### PR TITLE
[Modular] station-locked to off-station pin

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -230,11 +230,11 @@
 	return ..()
 
 //Station Locked
-
+/* moved to modular_skyrat
 /obj/item/firing_pin/away
 	name = "station locked pin"
 	desc = "A firing pin that only will fire when off the station."
-
+*/
 /obj/item/firing_pin/away/pin_auth(mob/living/user)
 	var/area/station_area = get_area(src)
 	if(!station_area || is_station_level(station_area.z))

--- a/modular_skyrat/code/modules/projectiles/pins.dm
+++ b/modular_skyrat/code/modules/projectiles/pins.dm
@@ -1,0 +1,4 @@
+// Off-station Pin
+/obj/item/firing_pin/away
+	name = "off-station pin"
+	desc = "A firing pin that only will fire when off the station."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3396,6 +3396,7 @@
 #include "modular_skyrat\code\modules\mob\living\simple_animal\hostile\mining_mobs\elites\fanaticminer.dm"
 #include "modular_skyrat\code\modules\procedural_mapping\mapGenerators\lavaland.dm"
 #include "modular_skyrat\code\modules\projectiles\gun.dm"
+#include "modular_skyrat\code\modules\projectiles\pins.dm"
 #include "modular_skyrat\code\modules\projectiles\ammunition\ballistic\pistol.dm"
 #include "modular_skyrat\code\modules\projectiles\boxes_magazines\ammo_boxes.dm"
 #include "modular_skyrat\code\modules\projectiles\boxes_magazines\external\pistol.dm"


### PR DESCRIPTION

## About The Pull Request

Changes the name of the station-locked pin to off-station pin

## Why It's Good For The Game

Less confusion about what it does. Redtail brought it up.

## Changelog
:cl:
tweak: From station-locked to off-station on the pin
/:cl:
