### PR TITLE
Makes contractor tablets not spawn invisible.

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -24,7 +24,7 @@
 /obj/item/modular_computer/tablet/syndicate_contract_uplink
 	name = "contractor tablet"
 	icon = 'icons/obj/contractor_tablet.dmi'
-	icon_state = "tablet-red"
+	icon_state = "tablet" // Skyrat edit -- icon state "tablet-red" doesn't exist in icons/obj/contractor_tablet.dmi
 	icon_state_unpowered = "tablet"
 	icon_state_powered = "tablet"
 	icon_state_menu = "assign"


### PR DESCRIPTION
## Changelog
:cl:
fix: contractor tablets spawned with invalid icon_state
/:cl:
