### PR TITLE
Blood-Drunk Accelerator Hotfixes

### DIFF
--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -14,9 +14,9 @@
 		var/obj/item/borg/upgrade/modkit/MK = I
 		for(var/obj/item/borg/upgrade/modkit/M in src.denied_types)
 			if(istype(MK, M))
-				to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for this kind of PKA.</span>")
+				to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for the [src].</span>")
 				return FALSE
-			MK.install(src, user)
+		MK.install(src, user)
 	else
 		..()
 
@@ -26,7 +26,7 @@
 			var/obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer/K = A
 			for(var/obj/item/borg/upgrade/modkit/M in K.denied_types)
 				if(istype(A, M))
-					to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for this kind of PKA.</span>")
+					to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for the [K].</span>")
 					return FALSE
 			install(A, user)
 		else

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -20,6 +20,8 @@
 				return FALSE
 			if(/obj/item/borg/upgrade/modkit/tracer/adjustable)
 				return FALSE
+			else
+				MK.install(src, user)
 	else
 		..()
 

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -13,7 +13,7 @@
 	if(istype(I, /obj/item/borg/upgrade/modkit))
 		var/obj/item/borg/upgrade/modkit/MK = I
 		for(var/obj/item/borg/upgrade/modkit/M in src.denied_types)
-			if(istype(MK, M))
+			if(ispath(M, MK.type))
 				to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for the [src].</span>")
 				return FALSE
 		MK.install(src, user)
@@ -24,8 +24,9 @@
 	if(istype(A, /obj/item/gun/energy/kinetic_accelerator))
 		if(istype(A, /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer))
 			var/obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer/K = A
+			var/obj/item/borg/upgrade/modkit/MK = src
 			for(var/obj/item/borg/upgrade/modkit/M in K.denied_types)
-				if(istype(A, M))
+				if(ispath(M, MK.type))
 					to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for the [K].</span>")
 					return FALSE
 			install(A, user)

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -7,31 +7,36 @@
 	overheat_time = 13
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/premium/bdminer)
 	max_mod_capacity = 125
-	var/list/denied_types = list(/obj/item/borg/upgrade/modkit/chassis_mod, /obj/item/borg/upgrade/modkit/tracer)
 
 /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/borg/upgrade/modkit))
 		var/obj/item/borg/upgrade/modkit/MK = I
-		for(var/obj/item/borg/upgrade/modkit/M in src.denied_types)
-			if(ispath(M, MK.type))
-				to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for the [src].</span>")
+		switch(MK.type)
+			if(/obj/item/borg/upgrade/modkit/chassis_mod)
 				return FALSE
-		MK.install(src, user)
+			if(/obj/item/borg/upgrade/modkit/chassis_mod/orange)
+				return FALSE
+			if(/obj/item/borg/upgrade/modkit/tracer)
+				return FALSE
+			if(/obj/item/borg/upgrade/modkit/tracer/adjustable)
+				return FALSE
 	else
 		..()
 
 /obj/item/borg/upgrade/modkit/attackby(obj/item/A, mob/user)
 	if(istype(A, /obj/item/gun/energy/kinetic_accelerator))
 		if(istype(A, /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer))
-			var/obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer/K = A
 			var/obj/item/borg/upgrade/modkit/MK = src
-			for(var/obj/item/borg/upgrade/modkit/M in K.denied_types)
-				if(ispath(M, MK.type))
-					to_chat(user, "<span class='notice'>The modkit you're trying to install is not rated for the [K].</span>")
+			switch(MK.type)
+				if(/obj/item/borg/upgrade/modkit/chassis_mod)
 					return FALSE
-			install(A, user)
-		else
-			install(A, user)
+				if(/obj/item/borg/upgrade/modkit/chassis_mod/orange)
+					return FALSE
+				if(/obj/item/borg/upgrade/modkit/tracer)
+					return FALSE
+				if(/obj/item/borg/upgrade/modkit/tracer/adjustable)
+					return FALSE
+		install(A, user)
 	else
 		..()
 

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -13,15 +13,18 @@
 		var/obj/item/borg/upgrade/modkit/MK = I
 		switch(MK.type)
 			if(/obj/item/borg/upgrade/modkit/chassis_mod)
+				to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [src]!</span>")
 				return FALSE
 			if(/obj/item/borg/upgrade/modkit/chassis_mod/orange)
+				to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [src]!</span>")
 				return FALSE
 			if(/obj/item/borg/upgrade/modkit/tracer)
+				to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [src]!</span>")
 				return FALSE
 			if(/obj/item/borg/upgrade/modkit/tracer/adjustable)
+				to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [src]!</span>")
 				return FALSE
-			else
-				MK.install(src, user)
+		MK.install(src, user)
 	else
 		..()
 
@@ -31,12 +34,16 @@
 			var/obj/item/borg/upgrade/modkit/MK = src
 			switch(MK.type)
 				if(/obj/item/borg/upgrade/modkit/chassis_mod)
+					to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [A]!</span>")
 					return FALSE
 				if(/obj/item/borg/upgrade/modkit/chassis_mod/orange)
+					to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [A]!</span>")
 					return FALSE
 				if(/obj/item/borg/upgrade/modkit/tracer)
+					to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [A]!</span>")
 					return FALSE
 				if(/obj/item/borg/upgrade/modkit/tracer/adjustable)
+					to_chat(user, "<span class='userdanger'>This modkit is unsuitable for [A]!</span>")
 					return FALSE
 		install(A, user)
 	else

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -8,7 +8,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/premium/bdminer)
 	max_mod_capacity = 125
 
-/obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer/attackby(obj/item/I, mob/user)
+/obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer/attackby(obj/item/I, mob/user) //Intelligent solutions didn't work, i had to shitcode.
 	if(istype(I, /obj/item/borg/upgrade/modkit))
 		var/obj/item/borg/upgrade/modkit/MK = I
 		switch(MK.type)
@@ -25,7 +25,7 @@
 
 /obj/item/borg/upgrade/modkit/attackby(obj/item/A, mob/user)
 	if(istype(A, /obj/item/gun/energy/kinetic_accelerator))
-		if(istype(A, /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer))
+		if(istype(A, /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer)) //Read above.
 			var/obj/item/borg/upgrade/modkit/MK = src
 			switch(MK.type)
 				if(/obj/item/borg/upgrade/modkit/chassis_mod)


### PR DESCRIPTION
## About The Pull Request

Fixes the bug in which you can't install mods on the BDPKA. Also makes it so chassis and tracer mods cannot be installed on the BDPKA, so bugs related to that are not caused.

## Why It's Good For The Game

Bugfix good

## Changelog
:cl:
fix: Blood Drunk PKA now accepts modkits proper.
tweak: Blood Drunk PKA cannot accept tracer and chassis modkits.
/:cl:
