### PR TITLE
Caps toxin damage on dwarven alcohol gland

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -182,7 +182,7 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 		switch(stored_alcohol)
 			if(0 to 24)
 				to_chat(owner, "<span class='userdanger'>DAMNATION INCARNATE, WHY AM I CURSED WITH THIS DRY-SPELL? I MUST DRINK.</span>")
-				owner.adjustToxLoss(35)
+				owner.adjustToxLoss(min(35,max(0,85 - owner.getToxLoss()))) //SKYRAT CHANGE - Dwarves get only up to 85 toxin
 			if(25 to 50)
 				to_chat(owner, "<span class='danger'>Oh DAMN, I need some brew!</span>")
 			if(51 to 75)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, they'll only get up to 85 damage

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dwarves going SSD dying is bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Dwarves only get up to 85 toxin damage from not having alcohol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
