### PR TITLE
Brings back up the expose temperature temp by a bit

### DIFF
--- a/modular_skyrat/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/modular_skyrat/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -11,15 +11,15 @@
 	if(active_hotspot)
 		if(soh)
 			if(tox > 0.5 || trit > 0.5)
-				if(active_hotspot.temperature < exposed_temperature*15)
-					active_hotspot.temperature = exposed_temperature*15
+				if(active_hotspot.temperature < exposed_temperature*35)
+					active_hotspot.temperature = exposed_temperature*35
 				if(active_hotspot.volume < exposed_volume)
 					active_hotspot.volume = exposed_volume
 		return 1
 
 	if((exposed_temperature > PLASMA_MINIMUM_BURN_TEMPERATURE) && (tox > 0.5 || trit > 0.5))
 		active_hotspot = new /obj/effect/hotspot(src)
-		active_hotspot.temperature = exposed_temperature*15
+		active_hotspot.temperature = exposed_temperature*35
 		active_hotspot.volume = exposed_volume*25
 
 		active_hotspot.just_spawned = (current_cycle < SSair.times_fired)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Originally 50, then 15 and now 35. 50 caused fires to start way too violently and 15 made so controlled chambers in cold environments wouldnt start up so this is better. The best way to help that would be re-adjusting values of each item that exposes temperature, but that's hell of a lot changed files

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I nerfed it too hard

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Linda fire expose temperature up to 35
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
