### PR TITLE
[Modular] Mining Borg Reverting Nerf

### DIFF
--- a/modular_skyrat/code/game/objects/items/robot/robot_upgrades.dm
+++ b/modular_skyrat/code/game/objects/items/robot/robot_upgrades.dm
@@ -98,4 +98,33 @@
 		R.module.basic_modules += PD
 		R.module.add_module(PD, FALSE, TRUE)
 
+/obj/item/borg/upgrade/premiumka
+	name = "mining cyborg premium KA"
+	desc = "A premium kinetic accelerator replacement for the mining module's standard kinetic accelerator."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = list(/obj/item/robot_module/miner)
 
+/obj/item/borg/upgrade/premiumka/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/KA in R.module)
+			for(var/obj/item/borg/upgrade/modkit/M in KA.modkits)
+				M.uninstall(src)
+			R.module.remove_module(KA, TRUE)
+
+		var/obj/item/gun/energy/kinetic_accelerator/premiumka/cyborg/PKA = new /obj/item/gun/energy/kinetic_accelerator/premiumka/cyborg(R.module)
+		R.module.basic_modules += PKA
+		R.module.add_module(PKA, FALSE, TRUE)
+
+/obj/item/borg/upgrade/premiumka/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		for(var/obj/item/gun/energy/kinetic_accelerator/premiumka/cyborg/PKA in R.module)
+			for(var/obj/item/borg/upgrade/modkit/M in PKA.modkits)
+				M.uninstall(src)
+			R.module.remove_module(PKA, TRUE)
+
+		var/obj/item/gun/energy/kinetic_accelerator/cyborg/KA = new (R.module)
+		R.module.basic_modules += KA
+		R.module.add_module(KA, FALSE, TRUE)

--- a/modular_skyrat/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_skyrat/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -89,6 +89,11 @@ obj/item/robot_module/butler/Initialize()
 	basic_modules += /obj/item/reagent_containers/borghypo/borgshaker/miscshaker
 	. = ..()
 
+/obj/item/robot_module/miner/Initialize()
+	basic_modules += /obj/item/card/id/miningborg
+	. = ..()
+
 /datum/robot_energy_storage/plasma
 	name = "Plasma Buffer Container"
 	recharge_rate = 0
+

--- a/modular_skyrat/code/modules/research/designs/mechfabricator_designs.dm
+++ b/modular_skyrat/code/modules/research/designs/mechfabricator_designs.dm
@@ -24,3 +24,12 @@
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000, /datum/material/bluespace = 500)
 	construction_time = 100
 	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_premiumka
+	name = "Cyborg Upgrade (Premium Kinetic Accelerator)"
+	id = "borg_upgrade_premiumka"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/premiumka
+	materials = list(/datum/material/iron=8000, /datum/material/glass=4000, /datum/material/titanium=2000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")

--- a/modular_skyrat/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/code/modules/research/techweb/all_nodes.dm
@@ -7,3 +7,7 @@
 	design_ids += "bsrpd"
 	design_ids += "borg_upgrade_bsrpd"
 	. = ..()
+
+/datum/techweb_node/adv_robotics/New()
+	design_ids += "borg_upgrade_premiumka"
+	. = ..()


### PR DESCRIPTION

## About The Pull Request

Modularizes the removed stuff in the miner borg nerf from Citadel. If modularized, we can keep using it.

## Why It's Good For The Game

Mining borg doesnt need nerfs... maybe buffs if anything. Do not merge this until https://github.com/Skyrat-SS13/Skyrat13/pull/728 is merged.

## Changelog
:cl:
tweak: Modularized mining borg targeted items.
/:cl:
