### PR TITLE
Fixes Ashwalker sprites

### DIFF
--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -1,0 +1,6 @@
+/datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
+	if(copytext_char(C.dna.features["spines"],1,4) == "Vox")
+		C.dna.features["spines"] = "Short + Membrane" //Update body is called in the parent proc
+	if(C.dna.features["legs"] == "Plantigrade")
+		C.dna.features["legs"] = "Digitigrade"
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3426,6 +3426,7 @@
 #include "modular_skyrat\code\modules\mob\living\carbon\human\human.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\humanoid.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\ipc.dm"
+#include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\lizardpeople.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\shadowpeople.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\synthliz.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\vox.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The leg stuff feels like the DIGITIGRADE trait not applying the digitigrade legs, which is most likely upstream issue. Anyway this fixes Vox decals aswell as plantigrade (invisble) legs appearing on ashwalkers

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more broken sprites

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed ashwalker sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
