### PR TITLE
[Important] Fixes to lewd verbs, interactions, async say and overlays

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -105,5 +105,6 @@
 		S.sharerDies(gibbed)
 
 	set_ssd_indicator(FALSE) //SKYRAT CHANGE - ssd indicator
+	set_typing_indicator(FALSE) //SKYRAT CHANGE
 
 	return TRUE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -207,10 +207,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		spans |= SPAN_ITALICS
 
 	send_speech(message, message_range, src, bubble_type, spans, language, message_mode)
-	//SKYRAT EDIT
-	if(client && client.prefs.toggles & ASYNCHRONOUS_SAY && typing)
-		set_typing_indicator(FALSE)
-	//END OF SKYRAT EDIT
 
 	if(succumbed)
 		succumb()

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -5,6 +5,10 @@
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
+	//SKYRAT EDIT
+	if(client && client.prefs.toggles & ASYNCHRONOUS_SAY && typing)
+		set_typing_indicator(FALSE)
+	//END OF SKYRAT EDIT
 	if(message)
 		say(message)
 
@@ -36,7 +40,10 @@
 		return
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
-
+	//SKYRAT EDIT
+	if(client && client.prefs.toggles & ASYNCHRONOUS_SAY && typing)
+		set_typing_indicator(FALSE)
+	//END OF SKYRAT EDIT
 	usr.emote("me",1,message,TRUE)
 
 /mob/proc/say_dead(var/message)

--- a/modular_skyrat/code/interactions/_interaction.dm
+++ b/modular_skyrat/code/interactions/_interaction.dm
@@ -69,7 +69,9 @@ var/list/interactions
 			to_chat(user, "<span class = 'warning'>You don't have hands.</span>")
 		return FALSE
 
-	return TRUE
+	if(user.last_interaction_time < world.time)
+		return TRUE
+	return FALSE
 
 /datum/interaction/proc/evaluate_target(mob/living/carbon/human/user, mob/living/carbon/human/target, silent = TRUE)
 	if(require_target_mouth)
@@ -140,6 +142,7 @@ var/list/interactions
 		user.visible_message("<span class='[simple_style]'>[capitalize(use_message)]</span>")
 
 /datum/interaction/proc/post_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	user.last_interaction_time = world.time + 6
 	if(interaction_sound)
 		playsound(get_turf(user), interaction_sound, 50, 1, -1)
 	return

--- a/modular_skyrat/code/interactions/lewd/_lewd.dm
+++ b/modular_skyrat/code/interactions/lewd/_lewd.dm
@@ -17,7 +17,7 @@
   -------------------MOB STUFF----------------------
   --------------------------------------------------
 */
-//I'm sorry, lewd should not have mob procs such as life() and such in it.
+//I'm sorry, lewd should not have mob procs such as life() and such in it. //NO SHIT IT SHOULDNT I REMOVED THEM
 
 /proc/playlewdinteractionsound(turf/turf_source, soundin, vol as num, vary, extrarange as num ,frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, envwet = -10000, envdry = 0, manual_x, manual_y)
 	var/list/hearing_mobs
@@ -41,6 +41,7 @@
 	var/lust = 0
 	var/multiorgasms = 1
 	var/refractory_period = 0
+	var/last_interaction_time = 0
 
 mob/living/Initialize()
 	. = ..()

--- a/modular_skyrat/code/interactions/lewd/lewd_interactions.dm
+++ b/modular_skyrat/code/interactions/lewd/lewd_interactions.dm
@@ -71,12 +71,9 @@
 			return FALSE
 
 		if(require_ooc_consent)
-			if(user.client && user.client.prefs)
-				if(user.client.prefs.toggles & VERB_CONSENT)
-					return TRUE
-				else
-					return FALSE
-		return TRUE
+			if(user.client && user.client.prefs.toggles & VERB_CONSENT)
+				return TRUE
+		return FALSE
 	return FALSE
 
 /datum/interaction/lewd/evaluate_target(mob/living/carbon/human/user, mob/living/carbon/human/target, silent = TRUE)
@@ -121,7 +118,10 @@
 				to_chat(user, "<span class = 'warning'>They don't have breasts.</span>")
 			return FALSE
 
-		return TRUE
+		if(require_ooc_consent)
+			if(target.client && target.client.prefs.toggles & VERB_CONSENT)
+				return TRUE
+		return FALSE
 	return FALSE
 
 /datum/interaction/lewd/post_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)

--- a/modular_skyrat/code/modules/client/preferences_toggles.dm
+++ b/modular_skyrat/code/modules/client/preferences_toggles.dm
@@ -17,7 +17,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, verb_consent)()
 TOGGLE_CHECKBOX(/datum/verbs/menu/Settings, lewd_verb_sound_consent)()
 	set name = "Toggle Lewd Verb Sounds"
 	set category = "Preferences"
-	set desc = "Allow Lewd Verb Sounds"
+	set desc = "Mute Lewd Verb Sounds"
 
 	usr.client.prefs.toggles ^= LEWD_VERB_SOUNDS
 	usr.client.prefs.save_preferences()

--- a/modular_skyrat/code/modules/mob/living/ssd_indicator.dm
+++ b/modular_skyrat/code/modules/mob/living/ssd_indicator.dm
@@ -1,18 +1,14 @@
 /mob/living/var/lastclienttime = 0
-/mob/living/var/obj/effect/decal/ssd_indicator
+var/static/mutable_appearance/ssd_indicator
 
 /mob/living/proc/set_ssd_indicator(var/state)
 	if(!ssd_indicator)
-		ssd_indicator = new
-		ssd_indicator.icon = 'modular_skyrat/icons/mob/ssd_indicator.dmi'
-		ssd_indicator.icon_state = "default0"
-		ssd_indicator.layer = FLY_LAYER
+		ssd_indicator = mutable_appearance('modular_skyrat/icons/mob/ssd_indicator.dmi', "default0", FLY_LAYER)
 
-	ssd_indicator.invisibility = invisibility
 	if(state && stat != DEAD)
-		overlays += ssd_indicator
+		add_overlay(ssd_indicator)
 	else
-		overlays -= ssd_indicator
+		cut_overlay(ssd_indicator)
 	return state
 
 //This proc should stop mobs from having the overlay when someone keeps jumping control of mobs, unfortunately it causes Aghosts to have their character without the SSD overlay, I wasn't able to find a better proc unfortunately

--- a/modular_skyrat/code/modules/mob/typing_indicator.dm
+++ b/modular_skyrat/code/modules/mob/typing_indicator.dm
@@ -4,23 +4,19 @@
 	var/last_typed
 	var/last_typed_time
 
-	var/obj/effect/decal/typing_indicator
+	var/static/mutable_appearance/typing_indicator
 
 /mob/proc/set_typing_indicator(var/state)
 	if(!typing_indicator)
-		typing_indicator = new
-		typing_indicator.icon = 'modular_skyrat/icons/mob/typing_indicator.dmi'
-		typing_indicator.icon_state = "default0"
-		typing_indicator.layer = FLY_LAYER 
+		typing_indicator = mutable_appearance('modular_skyrat/icons/mob/typing_indicator.dmi', "default0", FLY_LAYER)
 	if(client && !stat)
-		typing_indicator.invisibility = invisibility
 		if(state)
 			if(!typing)
-				overlays += typing_indicator
+				add_overlay(typing_indicator)
 				typing = TRUE
 		else
 			if(typing)
-				overlays -= typing_indicator
+				cut_overlay(typing_indicator)
 				typing = FALSE
 		return state
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Requries OOC consent of each part with lewd verbs, if no client is attached to a mob it's not allowed
-Adds a 0.6 cooldown to interactions
-Changes the way the layers are added for SSD and typing indicators so they're at their appropriate layers(above trash that would cover it)
-the Async typing indicator will now be cut if they enter in an empty SAY or ME
-people dying will have their typing indicator cut 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes, QOL and actually makes ooc consent work

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes to lewd verbs, interactions, async say and overlays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
