### PR TITLE
Fixes metal duplication

### DIFF
--- a/modular_skyrat/code/modules/research/designs/autolathe_designs/autolathe_designs_sec_and_hacked.dm
+++ b/modular_skyrat/code/modules/research/designs/autolathe_designs/autolathe_designs_sec_and_hacked.dm
@@ -9,6 +9,6 @@
 	name = "9mm Rubber Box"
 	id = "9mm_rubber"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 5000)
+	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c9mm/rubber
 	category = list("initial", "Security")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, you could dupe metal with the 9mmr box from autolathe

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes 9mmr box metal duplication 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
