### PR TITLE
Optimizes 'get_hearers_in_view'

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -224,6 +224,7 @@
 
 	return found_mobs
 
+/* moved to modular_skyrat
 /proc/get_hearers_in_view(R, atom/source)
 	var/turf/T = get_turf(source)
 	. = list()
@@ -248,6 +249,7 @@
 			. += A
 			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, processing, .)
 		processing += A.contents
+*/
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()

--- a/modular_skyrat/code/_HELPERS/game.dm
+++ b/modular_skyrat/code/_HELPERS/game.dm
@@ -1,0 +1,31 @@
+/proc/get_hearers_in_view(R, atom/source, need_client = TRUE, mobs = TRUE, objects = FALSE)
+	var/turf/T = get_turf(source)
+	. = list()
+	if(!T)
+		return
+	var/list/processing = list()
+	if(R == 0)
+		processing += T.contents
+	else
+		var/lum = T.luminosity
+		T.luminosity = 6
+		var/list/cached_view
+		if(objects)
+			cached_view = view(R, T)
+		else
+			cached_view = viewers(R, T)
+		if(mobs)
+			for(var/mob/M in cached_view)
+				if(M.client || !need_client)
+					processing += M
+		if(objects)
+			for(var/obj/O in cached_view)
+				processing += O
+		T.luminosity = lum
+	var/i = 0
+	while(i < length(processing))
+		var/atom/A = processing[++i]
+		if(A.flags_1 & HEAR_1)
+			. += A
+			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, processing, .)
+		processing += A.contents

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3307,6 +3307,7 @@
 #include "modular_skyrat\code\_DEFINES\preferences.dm"
 #include "modular_skyrat\code\_DEFINES\traits.dm"
 #include "modular_skyrat\code\_globalvars\lists\names.dm"
+#include "modular_skyrat\code\_HELPERS\game.dm"
 #include "modular_skyrat\code\_HELPERS\mobs.dm"
 #include "modular_skyrat\code\_HELPERS\names.dm"
 #include "modular_skyrat\code\controllers\configuration\entries\game_options.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Optimizes that proc, using byond call 'viewers' instead of 'view' when objects are not needed for it. It also assumes that clients are nessecary for it too. Will cause SSD people to not get flashbanged but I dont wanna touch core code more and I dont think it's an issue.

That proc gets called like 100,000 times on high pop shifts and contributes a fair bit to the TD, this should help it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
TD man bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: optimizes get_hearers_in_view
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
