### PR TITLE
[READY]USPs can now be emagged.

### DIFF
--- a/modular_skyrat/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -40,3 +40,7 @@
 		icon_state = "[unique_reskin[current_skin]][chambered ? "" : "-e"]"
 	else
 		icon_state = "[initial(icon_state)][chambered ? "" : "-e"]"
+
+/obj/item/gun/ballistic/automatic/pistol/uspm/emag_act(mob/user)
+	if(magazine)
+		magazine.emag_act(user)

--- a/modular_skyrat/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -43,4 +43,5 @@
 
 /obj/item/gun/ballistic/automatic/pistol/uspm/emag_act(mob/user)
 	if(magazine)
-		magazine.emag_act(user)
+		var/obj/item/ammo_box/magazine/M = magazine
+		M.emag_act(user)


### PR DESCRIPTION
## About The Pull Request

Basically a simple fix that makes emagging an usp simply call emag_act on the magazine, thus making it fire lethal rounds.

## Why It's Good For The Game

Makes it easier for smoothbrains to make lethal USPs.

## Changelog
:cl:
tweak: USPs can now be emagged. (It just means that emagging them emags their current magazine)
/:cl:
