### PR TITLE
Changes the shambling miner to be butcherable

### DIFF
--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/shamblingminer.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/shamblingminer.dm
@@ -30,5 +30,7 @@
 	pull_force = MOVE_FORCE_VERY_STRONG
 	loot = list(/obj/item/twohanded/kinetic_crusher)
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/mask
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human = 2, /obj/item/stack/sheet/animalhide/human = 1, /obj/item/stack/sheet/bone = 1)
+	robust_searching = FALSE
 	do_footstep = TRUE
 	minimum_distance = 1


### PR DESCRIPTION

![64090c4eaedcd956aff978b5925f27d1](https://user-images.githubusercontent.com/35768639/77599797-49e7a600-6edc-11ea-96fc-e531e7e78afc.png)
## About The Pull Request

Changes the shambling miner simplemob to now be butcherable, which is a silly but effective way to fix a bug where the miner would never drop his mask.

## Why It's Good For The Game

Miners can now obtain the crusher trophy for the shambling miner, showing they are the king of the ring.

## Changelog
:cl:
fix: shambling miner trophy is no longer unobtainable
tweak: shambling miner is now butcherable for human meat/bone/flesh + crusher trophy
/:cl:

