### PR TITLE
Makes maroon objective much more clear, plus requires the target alive

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -240,11 +240,11 @@ GLOBAL_LIST_EMPTY(objectives)
 	return target
 
 /datum/objective/maroon/check_completion()
-	return !target || !considered_alive(target) || (!target.current.onCentCom() && !target.current.onSyndieBase())
+	return considered_alive(target) && (!target.current.onCentCom() && !target.current.onSyndieBase()) //Skyrat edit - maroon target has to be alive
 
 /datum/objective/maroon/update_explanation_text()
 	if(target && target.current)
-		explanation_text = "Prevent [target.name], the [!target_role_type ? target.assigned_role : target.special_role], from escaping alive."
+		explanation_text = "Ensure that [target.name], the [!target_role_type ? target.assigned_role : target.special_role] stays marooned on the station." //Skyrat edit - less ambigious
 	else
 		explanation_text = "Free Objective"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, it was way too ambigious and people often chose to just assassinate them instead, this should bring more fun interactions as you have to protect your target in a way

but maybe this should be just removed instead?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pushes people to be more creative than just murder

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked maroon objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
