### PR TITLE
[READY]Moves the ablative coat to the clothing section of crafting

### DIFF
--- a/modular_skyrat/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/modular_skyrat/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -1,0 +1,12 @@
+/datum/crafting_recipe/ablativecoat
+	name = "Ablative Trenchcoat"
+	result = /obj/item/clothing/suit/hooded/ablative
+	reqs = list(/obj/item/clothing/suit/armor/laserproof = 1,
+				/obj/item/stack/cable_coil = 5,
+				/obj/item/stack/sheet/mineral/diamond = 2,
+				/obj/item/stack/sheet/plasmarglass = 3,
+				/obj/item/clothing/glasses/hud/security/sunglasses = 1,
+				/obj/item/stock_parts/cell/high = 1)
+	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	time = 90
+	category = CAT_CLOTHING

--- a/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -10,20 +10,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/ablativecoat
-	name = "Ablative Trenchcoat"
-	result = /obj/item/clothing/suit/hooded/ablative
-	reqs = list(/obj/item/clothing/suit/armor/laserproof = 1,
-				/obj/item/stack/cable_coil = 5,
-				/obj/item/stack/sheet/mineral/diamond = 2,
-				/obj/item/stack/sheet/plasmarglass = 3,
-				/obj/item/clothing/glasses/hud/security/sunglasses = 1,
-				/obj/item/stock_parts/cell/high = 1)
-	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
-	time = 45
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
 //////////////////
 ///GUNS CRAFTING//
 //////////////////

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3325,6 +3325,7 @@
 #include "modular_skyrat\code\controllers\subsystem\logging.dm"
 #include "modular_skyrat\code\datums\ai_laws.dm"
 #include "modular_skyrat\code\datums\map_config.dm"
+#include "modular_skyrat\code\datums\components\crafting\recipes\recipes_clothing.dm"
 #include "modular_skyrat\code\datums\components\crafting\recipes\recipes_weapon_and_ammo.dm"
 #include "modular_skyrat\code\datums\components\crafting\recipes\recipeswhat.dm"
 #include "modular_skyrat\code\datums\diseases\fluxitus.dm"


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

It makes more sense. The ablative coat is something you wear, not a "weapon".

## Changelog
:cl:
tweak: Ablative coat is now in the clothing section of crafting
/:cl:
