### PR TITLE
[READY]Renames "Manlet" trait to "Small". Removes the tiny trait.

### DIFF
--- a/modular_skyrat/code/_DEFINES/traits.dm
+++ b/modular_skyrat/code/_DEFINES/traits.dm
@@ -1,3 +1,2 @@
 #define TRAIT_GIGANTISM			"gigantism"		// large boy
-#define TRAIT_MANLET			"manletism"		// smol boy
-#define TRAIT_TINY			"tiny"				// smollest
+#define TRAIT_SMALL				"small"		// smol boy

--- a/modular_skyrat/code/datums/traits/neutral.dm
+++ b/modular_skyrat/code/datums/traits/neutral.dm
@@ -15,34 +15,18 @@
 	if(H)
 		H.transform = H.transform.Scale(0.8, 0.8)
 
-/datum/quirk/manletism
-	name = "Manlet"
+/datum/quirk/small
+	name = "Small"
 	desc = "You are a bit... small. With none of the benefits."
 	value = 0
-	mob_trait = TRAIT_MANLET
+	mob_trait = TRAIT_SMALL
 
-/datum/quirk/manletism/add()
+/datum/quirk/small/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
 		H.transform = H.transform.Scale(0.9, 0.9)
 
-/datum/quirk/manletism/remove()
+/datum/quirk/small/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
 		H.transform = H.transform.Scale(1.1, 1.1)
-
-/datum/quirk/tiny
-	name = "Tiny"
-	desc = "You are exceptionally small, without the agility of an actual dwarf."
-	value = 0
-	mob_trait = TRAIT_TINY
-
-/datum/quirk/tiny/add()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(H)
-		H.transform = H.transform.Scale(0.8, 0.8)
-
-/datum/quirk/manletism/remove()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(H)
-		H.transform = H.transform.Scale(1.25, 1.25)


### PR DESCRIPTION
## About The Pull Request

Title.
Requested by Xyel.

## Why It's Good For The Game

Less LRP name for manlet, no powergamers abusing tiny hitboxes.

## Changelog
:cl:
del: Removed the "tiny" trait. Goodbye, Mr. Shorty: https://www.youtube.com/watch?v=4bE6K6_u4DA
tweak: Manlet trait is now called "small".
/:cl: