### PR TITLE
[READY]Buffs the immortality talisman, by making it smaller

### DIFF
--- a/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
@@ -455,6 +455,8 @@
 	armour_penetration = 25
 	block_chance = 0 //blocky bad
 
+/obj/item/immortality_talisman
+	w_class = WEIGHT_CLASS_SMALL //why the fuck are they large anyways
 //legion
 /obj/structure/closet/crate/necropolis/legion
 	name = "echoing legion crate"


### PR DESCRIPTION
## About The Pull Request

Immortality talismans are now small, meaning they can fit in pockets and be... much more useful.

## Why It's Good For The Game

They're almost useless for combat as is. If you need to grab it from your backpack in an emergency, that is a lot of time for whatever you're fighting to get the upper chance on you.

## Changelog
:cl:
balance: Immortality talismans are now small - they fit in pockets and boxes, etc.
/:cl:
