### PR TITLE
[READY]CBT - Crusher Balancing Trophies

### DIFF
--- a/modular_skyrat/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/modular_skyrat/code/modules/mining/equipment/kinetic_crusher.dm
@@ -188,3 +188,11 @@
 	if(.)
 		H.charge_time = 15
 		H.force_wielded = 20
+
+//hierophant crusher nerf "but muh i deserve it after killing hierocunt" yes but its op fuck you you piece of shit
+/obj/effect/temp_visual/hierophant/wall/crusher
+	duration = 45 //this is more than enough time bro
+
+//watcher wing slight buff
+/obj/item/crusher_trophy/watcher_wing
+	bonus_value = 15 // 1 second isn't enough for much, this should be better

--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -1,3 +1,12 @@
 /mob/living/simple_animal/hostile/megafauna/colossus
 	song = sound('modular_skyrat/sound/ambience/theopenedway.ogg', 100) //Shadow of the colossus OST
 	songlength = 1170
+
+/mob/living/simple_animal/hostile/megafauna/colossus/proc/enrage(mob/living/L)
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.mind)
+			if(istype(H.mind.martial_art, /datum/martial_art/the_sleeping_carp) || istype(H.mind.martial_art, /datum/martial_art/the_rising_bass))
+				. = TRUE
+		if(is_species(H, /datum/species/golem/sand))
+			. = TRUE


### PR DESCRIPTION
## About The Pull Request

some slight balances to some broken ass trophies
1. Hierophant trophy wall only lasts 4.5 seconds now you memer
2. Watcher wing effect duration slightly bumped from 1 second to 1.5 seconds, because 1 sec isn't really gonna do much
3. Sandstone golems enrage colossus now

## Why It's Good For The Game

No more megafauna cheesing

## Changelog
:cl:
balance: Watcher wing trophy now lasts 1.5 seconds
balance: Hierophant trophy walls now last 4.5 seconds
balance: Sandstone golems now enrage colossus
removal: Removed crusherbrine
/:cl:
