### PR TITLE
Renames fargoth's ring, again

### DIFF
--- a/modular_skyrat/code/modules/clothing/gloves/ring.dm
+++ b/modular_skyrat/code/modules/clothing/gloves/ring.dm
@@ -1,13 +1,13 @@
 /obj/item/clothing/gloves/ring/silver/fargoth
 	name = "engraved silver ring"
-	desc = "This ring seems to be engraved with a name... but you can't read it."
+	desc = "It seems to have something engraved on it, though you can't read it. You feel like this belonged to someone important, at some point."
 	actions_types = list(/datum/action/item_action/fargoth)
 	var/ringcooldown = 600
 	var/cooldowntime = 0
 
 /datum/action/item_action/fargoth
-	name = "Magic Healing"
-	desc = "Heals some brute damage... not much."
+	name = "Use Ring"
+	desc = "You feel like this ring could help you in a dire situation, though probably it's just your imagination."
 
 /obj/item/clothing/gloves/ring/silver/fargoth/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/fargoth))

--- a/modular_skyrat/code/modules/clothing/gloves/ring.dm
+++ b/modular_skyrat/code/modules/clothing/gloves/ring.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/gloves/ring/silver/fargoth
-	name = "Fargoth's Engraved Ring of Healing"
-	desc = "A tiny enchanted silver ring, from an annoying little elf."
+	name = "engraved silver ring"
+	desc = "This ring seems to be engraved with a name... but you can't read it."
 	actions_types = list(/datum/action/item_action/fargoth)
 	var/ringcooldown = 600
 	var/cooldowntime = 0


### PR DESCRIPTION
## About The Pull Request

Renames the "Fargoth's Engraved Ring of Healing" to "engraved silver ring"

## Why It's Good For The Game

~~azarak is pointing a gun at me~~
It's more rp-friendly and the reference is less obvious.

## Changelog
:cl:
tweak: Renamed "Fargoth's Engraved Ring of Healing" to simply "engraved silver ring" and changed the description.
balance: The nerevarine has murdered Fargoth in cold blood. With this character's death, the thread of prophecy is severed. Restore a saved game to restore the weave of fate, or persist in the doomed world you have created.
/:cl:
