### PR TITLE
More character text fluff(records, background, skills) and also better examine for species

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -244,6 +244,12 @@
 			G.fields["gender"]  = "Other"
 		G.fields["photo_front"]	= photo_front
 		G.fields["photo_side"]	= photo_side
+		//Skyrat edit - rp records
+		if(C)
+			G.fields["past_records"] = C.prefs.general_records
+		else
+			G.fields["past_records"] = ""
+		//End of skyrat edit
 		general += G
 
 		//Medical Record
@@ -261,6 +267,12 @@
 		M.fields["cdi"]			= "None"
 		M.fields["cdi_d"]		= "No diseases have been diagnosed at the moment."
 		M.fields["notes"]		= H.get_trait_string(medical)
+		//Skyrat edit - rp records
+		if(C)
+			M.fields["past_records"] = C.prefs.medical_records
+		else
+			M.fields["past_records"] = ""
+		//End of skyrat edit
 		medical += M
 
 		//Security Record
@@ -271,6 +283,12 @@
 		S.fields["mi_crim"]		= list()
 		S.fields["ma_crim"]		= list()
 		S.fields["notes"]		= "No notes."
+		//Skyrat edit - rp records
+		if(C)
+			S.fields["past_records"] = C.prefs.security_records
+		else
+			S.fields["past_records"] = ""
+		//End of skyrat edit
 		security += S
 
 		//Locked Record

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -111,11 +111,13 @@
 						dat += "<tr><td>Fingerprint:</td><td><A href='?src=[REF(src)];field=fingerprint'>&nbsp;[active1.fields["fingerprint"]]&nbsp;</A></td></tr>"
 						dat += "<tr><td>Physical Status:</td><td><A href='?src=[REF(src)];field=p_stat'>&nbsp;[active1.fields["p_stat"]]&nbsp;</A></td></tr>"
 						dat += "<tr><td>Mental Status:</td><td><A href='?src=[REF(src)];field=m_stat'>&nbsp;[active1.fields["m_stat"]]&nbsp;</A></td></tr>"
+						dat += "<tr><td>General Records:</td><td><A href='?src=[REF(src)];choice=View Past General'>View&nbsp;</A></td></tr>" //Skyrat change
 					else
 						dat += "<tr><td>General Record Lost!</td></tr>"
 
 					dat += "<tr><td><br><b><font size='4'>Medical Data</font></b></td></tr>"
 					if(active2 in GLOB.data_core.medical)
+						dat += "<tr><td>Medical Records:</td><td><A href='?src=[REF(src)];choice=View Past Medical'>View&nbsp;</A></td></tr>" //Skyrat change
 						dat += "<tr><td>Blood Type:</td><td><A href='?src=[REF(src)];field=blood_type'>&nbsp;[active2.fields["blood_type"]]&nbsp;</A></td></tr>"
 						dat += "<tr><td>DNA:</td><td><A href='?src=[REF(src)];field=b_dna'>&nbsp;[active2.fields["b_dna"]]&nbsp;</A></td></tr>"
 						dat += "<tr><td><br>Minor Disabilities:</td><td><br><A href='?src=[REF(src)];field=mi_dis'>&nbsp;[active2.fields["mi_dis"]]&nbsp;</A></td></tr>"
@@ -201,6 +203,21 @@
 			active2 = null
 			playsound(src, 'sound/machines/terminal_off.ogg', 50, FALSE)
 		else if(href_list["choice"])
+			//SKYRAT CHANGES
+			if(href_list["choice"] == "View Past Medical")
+				if(istype(active2, /datum/data/record))
+					temp = "<h5>Medical Records:</h5>"
+					temp += "<ul>"
+					temp += "<li>[active2.fields["past_records"]]</li>"
+					temp += "</ul>"
+
+			if(href_list["choice"] == "View Past General")
+				if(istype(active1, /datum/data/record))
+					temp = "<h5>General Records:</h5>"
+					temp += "<ul>"
+					temp += "<li>[active1.fields["past_records"]]</li>"
+					temp += "</ul>"
+			//END OF SKYRAT CHANGES
 			// SORTING!
 			if(href_list["choice"] == "Sorting")
 				// Reverse the order if clicked twice
@@ -518,10 +535,37 @@
 						P.info += text("Name: [] ID: []<BR>\nGender: []<BR>\nAge: []<BR>", active1.fields["name"], active1.fields["id"], active1.fields["gender"], active1.fields["age"])
 						P.info += "\nSpecies: [active1.fields["species"]]<BR>"
 						P.info += text("\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", active1.fields["fingerprint"], active1.fields["p_stat"], active1.fields["m_stat"])
+						//SKYRAT EDIT
+						if(!(active1.fields["past_records"] == ""))
+							P.info += "\nGeneral Records:\n[active1.fields["past_records"]]\n"
+						//END OF SKYRAT EDIT
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
 					if(active2 in GLOB.data_core.medical)
-						P.info += text("<BR>\n<CENTER><B>Medical Data</B></CENTER><BR>\nBlood Type: []<BR>\nDNA: []<BR>\n<BR>\nMinor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nMajor Disabilities: []<BR>\nDetails: []<BR>\n<BR>\nAllergies: []<BR>\nDetails: []<BR>\n<BR>\nCurrent Diseases: [] (per disease info placed in log/comment section)<BR>\nDetails: []<BR>\n<BR>\nImportant Notes:<BR>\n\t[]<BR>\n<BR>\n<CENTER><B>Comments/Log</B></CENTER><BR>", active2.fields["blood_type"], active2.fields["b_dna"], active2.fields["mi_dis"], active2.fields["mi_dis_d"], active2.fields["ma_dis"], active2.fields["ma_dis_d"], active2.fields["alg"], active2.fields["alg_d"], active2.fields["cdi"], active2.fields["cdi_d"], active2.fields["notes"])
+						//Skyrat changes - holy shit this was hell
+						P.info += "<BR>\n<CENTER><B>Medical Data</B></CENTER>"
+						if(!(active2.fields["past_records"] == ""))
+							P.info += "\nMedical Records:\n[active2.fields["past_records"]]<BR>\n"
+						P.info += "<BR>\nBlood Type: [active2.fields["blood_type"]]"
+						P.info += "<BR>\nDNA: [active2.fields["b_dna"]]"
+						P.info += "<BR>\n"
+						P.info += "<BR>\nMinor Disabilities: [active2.fields["mi_dis"]]"
+						P.info += "<BR>\nDetails: [active2.fields["mi_dis_d"]]"
+						P.info += "<BR>\n"
+						P.info += "<BR>\nMajor Disabilities: [active2.fields["ma_dis"]]"
+						P.info += "<BR>\nDetails: [active2.fields["ma_dis_d"]]"
+						P.info += "<BR>\n"
+						P.info += "<BR>\nAllergies: [active2.fields["alg"]]"
+						P.info += "<BR>\nDetails: [active2.fields["alg_d"]]"
+						P.info += "<BR>\n"
+						P.info += "<BR>\nCurrent Diseases: [active2.fields["cdi"]] (per disease info placed in log/comment section)"
+						P.info += "<BR>\nDetails: [active2.fields["cdi_d"]]"
+						P.info += "<BR>\n"
+						P.info += "<BR>\nImportant Notes:"
+						P.info += "<BR>\n\t[active2.fields["notes"]]"
+						P.info += "<BR>\n"
+						//END OF SKYRAT CHANGES
+
 						var/counter = 1
 						while(active2.fields[text("com_[]", counter)])
 							P.info += text("[]<BR>", active2.fields[text("com_[]", counter)])

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -177,6 +177,7 @@
 						<tr><td>Fingerprint:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=fingerprint'>&nbsp;[active1.fields["fingerprint"]]&nbsp;</A></td></tr>
 						<tr><td>Physical Status:</td><td>&nbsp;[active1.fields["p_stat"]]&nbsp;</td></tr>
 						<tr><td>Mental Status:</td><td>&nbsp;[active1.fields["m_stat"]]&nbsp;</td></tr>
+						<tr><td>General Records:</td><td><A href='?src=[REF(src)];choice=View Past General'>View&nbsp;</A></td></tr> //Skyrat change
 						</table></td>
 						<td><table><td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_front'><img src=photo_front height=80 width=80 border=4></a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=print_photo_front'>Print photo</a><br>
@@ -189,6 +190,9 @@
 						dat += "<br>General Record Lost!<br>"
 					if((istype(active2, /datum/data/record) && GLOB.data_core.security.Find(active2)))
 						dat += "<font size='4'><b>Security Data</b></font>"
+						//Skyrat changes
+						dat += "<br>Security Records: <A href='?src=[REF(src)];choice=View Past Security'>View</A>"
+						//End of skyrat changes
 						dat += "<br>Criminal Status: <A href='?src=[REF(src)];choice=Edit Field;field=criminal'>[active2.fields["criminal"]]</A>"
 						dat += "<br><br>Minor Crimes: <A href='?src=[REF(src)];choice=Edit Field;field=mi_crim_add'>Add New</A>"
 
@@ -268,6 +272,21 @@ What a mess.*/
 	if(usr.contents.Find(src) || (in_range(src, usr) && isturf(loc)) || hasSiliconAccessInArea(usr) || IsAdminGhost(usr))
 		usr.set_machine(src)
 		switch(href_list["choice"])
+			//SKYRAT EDIT
+			if("View Past Security")
+				if(istype(active2, /datum/data/record))
+					temp = "<h5>Security Records:</h5>"
+					temp += "<ul>"
+					temp += "<li>[active2.fields["past_records"]]</li>"
+					temp += "</ul>"
+
+			if("View Past General")
+				if(istype(active1, /datum/data/record))
+					temp = "<h5>General Records:</h5>"
+					temp += "<ul>"
+					temp += "<li>[active1.fields["past_records"]]</li>"
+					temp += "</ul>"
+			//END OF SKYRAT EDIT
 // SORTING!
 			if("Sorting")
 				// Reverse the order if clicked twice
@@ -352,10 +371,19 @@ What a mess.*/
 						P.info += text("Name: [] ID: []<BR>\nGender: []<BR>\nAge: []<BR>", active1.fields["name"], active1.fields["id"], active1.fields["gender"], active1.fields["age"])
 						P.info += "\nSpecies: [active1.fields["species"]]<BR>"
 						P.info += text("\nFingerprint: []<BR>\nPhysical Status: []<BR>\nMental Status: []<BR>", active1.fields["fingerprint"], active1.fields["p_stat"], active1.fields["m_stat"])
+						//SKYRAT EDIT
+						if(!(active1.fields["past_records"] == ""))
+							P.info += "\nGeneral Records:\n[active1.fields["past_records"]]\n"
+						//END OF SKYRAT EDIT
 					else
 						P.info += "<B>General Record Lost!</B><BR>"
 					if((istype(active2, /datum/data/record) && GLOB.data_core.security.Find(active2)))
-						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\nCriminal Status: []", active2.fields["criminal"])
+						P.info += text("<BR>\n<CENTER><B>Security Data</B></CENTER><BR>\n") //Skyrat -split
+						//SKYRAT EDIT
+						if(!(active2.fields["past_records"] == ""))
+							P.info += "\nSecurity Records:\n[active2.fields["past_records"]]\n"
+						//END OF SKYRAT EDIT
+						P.info += text("Criminal Status: []", active2.fields["criminal"]) //Skyrat -split
 
 						P.info += "<BR>\n<BR>\nMinor Crimes:<BR>\n"
 						P.info +={"<table style="text-align:center;" border="1" cellspacing="0" width="100%">

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,10 +77,18 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/be_random_body = 0				//whether we'll have a random body every round
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
+	//SKYRAT CHANGES
 	var/ooc_notes
 	var/erppref = "Ask"
 	var/nonconpref = "Ask"
 	var/vorepref = "Ask"
+	var/general_records = ""
+	var/security_records = ""
+	var/medical_records = ""
+	var/flavor_background = ""
+	var/character_skills = ""
+	var/exploitable_info = ""
+	//END OF SKYRAT CHANGES
 	var/underwear = "Nude"				//underwear type
 	var/undie_color = "FFF"
 	var/undershirt = "Nude"				//undershirt type
@@ -340,18 +348,30 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
 			dat += "<h2>Flavor Text</h2>"
-			dat += "<a href='?_src_=prefs;preference=flavor_text;task=input'><b>Set Examine Text</b></a>"
+			dat += "<a href='?_src_=prefs;preference=flavor_text;task=input'><b>Set Examine Text</b></a>" //skyrat - <br> moved one line down
+			//SKYRAT EDIT
 			dat += 	"<a href='?_src_=prefs;preference=ooc_notes;task=input'>Set OOC Notes</a><br>"
 			dat += 	"ERP : <a href='?_src_=prefs;preference=erp_pref'>[erppref]</a>"
 			dat += 	"Non-Con : <a href='?_src_=prefs;preference=noncon_pref'>[nonconpref]</a>"
 			dat += 	"Vore : <a href='?_src_=prefs;preference=vore_pref'>[vorepref]</a><br>"
+			//END OF SKYRAT EDIT
 			if(length(features["flavor_text"]) <= 40)
 				if(!length(features["flavor_text"]))
-					dat += "\[...\]"
+					dat += "\[...\]<BR>" //skyrat - adds <br>
 				else
-					dat += "[features["flavor_text"]]"
+					dat += "[features["flavor_text"]]<BR>" //skyrat - adds <br>
 			else
 				dat += "[TextPreview(features["flavor_text"])]...<BR>"
+			//SKYRAT EDIT
+			dat += 	"Records :"
+			dat += 	"<a href='?_src_=prefs;preference=general_records;task=input'>General</a>"
+			dat += 	"<a href='?_src_=prefs;preference=security_records;task=input'>Security</a>"
+			dat += 	"<a href='?_src_=prefs;preference=medical_records;task=input'>Medical</a><br>"
+			dat += 	"Character :"
+			dat += 	"<a href='?_src_=prefs;preference=flavor_background;task=input'>Background</a>"
+			dat += 	"<a href='?_src_=prefs;preference=character_skills;task=input'>Skills</a><br>"
+			dat += 	"<a href='?_src_=prefs;preference=exploitable_info;task=input'>Exploitable Information</a><br>"
+			//END OF SKYRAT EDIT
 			dat += "<h2>Body</h2>"
 			dat += "<b>Gender:</b><a style='display:block;width:100px' href='?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : (gender == FEMALE ? "Female" : (gender == PLURAL ? "Non-binary" : "Object"))]</a><BR>"
 			if(gender != NEUTER && pref_species.sexes)
@@ -1502,10 +1522,42 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(!isnull(msg))
 						features["flavor_text"] = html_decode(msg)
 
+				//SKYRAT CHANGES
 				if("ooc_notes")
 					var/msg = stripped_multiline_input(usr, "Set your OOC Notes", "OOC Notes", ooc_notes, MAX_FLAVOR_LEN, TRUE)
 					if(msg)
-						ooc_notes = msg
+						ooc_notes = html_decode(msg)
+
+				if("general_records")
+					var/msg = stripped_multiline_input(usr, "Set your general records", "General Records", general_records, MAX_FLAVOR_LEN, TRUE)
+					if(msg)
+						general_records = html_decode(msg)
+
+				if("security_records")
+					var/msg = stripped_multiline_input(usr, "Set your security records", "Security Records", security_records, MAX_FLAVOR_LEN, TRUE)
+					if(msg)
+						security_records = html_decode(msg)
+
+				if("medical_records")
+					var/msg = stripped_multiline_input(usr, "Set your medical records", "Medical Records", medical_records, MAX_FLAVOR_LEN, TRUE)
+					if(msg)
+						medical_records = html_decode(msg)
+
+				if("flavor_background")
+					var/msg = stripped_multiline_input(usr, "Set your background", "Character Background", flavor_background, MAX_FLAVOR_LEN, TRUE)
+					if(msg)
+						flavor_background = html_decode(msg)
+
+				if("character_skills")
+					var/msg = stripped_multiline_input(usr, "Set your skills or hobbies", "Character Skills", character_skills, MAX_FLAVOR_LEN, TRUE)
+					if(msg)
+						character_skills = html_decode(msg)
+
+				if("exploitable_info")
+					var/msg = stripped_multiline_input(usr, "Set your exploitable information, this rarely will be showed to antagonists", "Exploitable Info", exploitable_info, MAX_FLAVOR_LEN, TRUE)
+					if(msg)
+						exploitable_info = html_decode(msg)
+				//END OF SKYRAT CHANGES
 
 				if("hair")
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -414,7 +414,7 @@
 		if(client)
 			. += "OOC Notes: <a href='?src=[REF(src)];ooc_notes=1'>\[View\]</a>" // SKYRAT EDIT -- END
 	//SKYRAT EDIT - admin lookup on records/extra flavor
-	if(client && user.client.holder) //&& isobserver(user)
+	if(client && user.client.holder && isobserver(user))
 		var/line = ""
 		if(!(client.prefs.general_records == ""))
 			line += "<a href='?src=[REF(src)];general_records=1'>\[GEN\]</a>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -7,13 +7,30 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 	var/obscure_name
+	var/species_visible //Skyrat edit
+	var/species_name_string //Skyrat edit
 
 	if(isliving(user))
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_PROSOPAGNOSIA))
 			obscure_name = TRUE
 
-	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
+	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE)) //skyrat - moved this higher
+	//Skyrat stuff
+	if(skipface || get_visible_name() == "Unknown")
+		species_visible = FALSE
+	else
+		species_visible = TRUE
+
+	if(!species_visible)
+		species_name_string = "!"
+	else if (dna.custom_species)
+		species_name_string = ", [prefix_a_or_an(dna.custom_species)] <EM>[dna.custom_species]</EM>!"
+	else
+		species_name_string = ", [prefix_a_or_an(dna.species.name)] <EM>[dna.species.name]</EM>!"
+	//End of skyrat stuff
+
+	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>[species_name_string]") //Skyrat edit
 
 	var/vampDesc = ReturnVampExamine(user) // Vamps recognize the names of other vamps.
 	var/vassDesc = ReturnVassalExamine(user) // Vassals recognize each other's marks.
@@ -23,12 +40,13 @@
 		. += vassDesc
 
 	var/list/obscured = check_obscured_slots()
-	var/skipface = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
+	//Skyrat changes - edited that to only show the extra species tidbit if it's unknown or he's got a custom species
 	if(skipface || get_visible_name() == "Unknown")
 		. += "You can't make out what species they are."
-	else
-		. += "[t_He] [t_is] a [dna.custom_species ? dna.custom_species : dna.species.name]!"
+	else if(dna.custom_species)
+		. += "[t_He] [t_is] [prefix_a_or_an(dna.species.name)] [dna.species.name]!"
+	//End of skyrat changes
 
 	//uniform
 	if(w_uniform && !(SLOT_W_UNIFORM in obscured))
@@ -395,7 +413,25 @@
 	if(!invisible_man)
 		if(client)
 			. += "OOC Notes: <a href='?src=[REF(src)];ooc_notes=1'>\[View\]</a>" // SKYRAT EDIT -- END
+	//SKYRAT EDIT - admin lookup on records/extra flavor
+	if(client && user.client.holder) //&& isobserver(user)
+		var/line = ""
+		if(!(client.prefs.general_records == ""))
+			line += "<a href='?src=[REF(src)];general_records=1'>\[GEN\]</a>"
+		if(!(client.prefs.security_records == ""))
+			line += "<a href='?src=[REF(src)];security_records=1'>\[SEC\]</a>"
+		if(!(client.prefs.medical_records == ""))
+			line += "<a href='?src=[REF(src)];medical_records=1'>\[MED\]</a>"
+		if(!(client.prefs.flavor_background == ""))
+			line += "<a href='?src=[REF(src)];flavor_background=1'>\[BG\]</a>"
+		if(!(client.prefs.character_skills == ""))
+			line += "<a href='?src=[REF(src)];character_skills=1'>\[SKL\]</a>"
+		if(!(client.prefs.exploitable_info == ""))
+			line += "<a href='?src=[REF(src)];exploitable_info=1'>\[EXP\]</a>"
 
+		if(!(line == ""))
+			. += line
+	//END OF SKYRAT EDIT
 	. += "*---------*</span>"
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!

--- a/modular_citadel/code/modules/client/preferences_savefile.dm
+++ b/modular_citadel/code/modules/client/preferences_savefile.dm
@@ -13,6 +13,7 @@
 		features["mcolor3"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
 	features["mcolor2"]	= sanitize_hexcolor(features["mcolor2"], 3, 0)
 	features["mcolor3"]	= sanitize_hexcolor(features["mcolor3"], 3, 0)
+	//SKYRAT CHANGES
 	ooc_notes = sanitize_text(S["ooc_notes"])
 	erppref = sanitize_text(S["erp_pref"], "Ask")
 	if(!length(erppref)) erppref = "Ask"
@@ -20,6 +21,13 @@
 	if(!length(nonconpref)) nonconpref = "Ask"
 	vorepref = sanitize_text(S["vore_pref"], "Ask")
 	if(!length(vorepref)) vorepref = "Ask"
+	security_records = sanitize_text(S["security_records"])
+	medical_records = sanitize_text(S["medical_records"])
+	general_records = sanitize_text(S["general_records"])
+	flavor_background = sanitize_text(S["flavor_background"])
+	character_skills = sanitize_text(S["character_skills"])
+	exploitable_info = sanitize_text(S["exploitable_info"])
+	//END OF SKYRAT CHANGES
 	//gear loadout
 	var/text_to_load
 	S["loadout"] >> text_to_load
@@ -52,10 +60,18 @@
 	WRITE_FILE(S["feature_xeno_head"], features["xenohead"])
 	//flavor text
 	WRITE_FILE(S["feature_flavor_text"], features["flavor_text"])
+	//SKYRAT CHANGES
 	WRITE_FILE(S["ooc_notes"], ooc_notes)
 	WRITE_FILE(S["erp_pref"], erppref)
 	WRITE_FILE(S["noncon_pref"], nonconpref)
 	WRITE_FILE(S["vore_pref"], vorepref)
+	WRITE_FILE(S["security_records"], security_records)
+	WRITE_FILE(S["medical_records"], medical_records)
+	WRITE_FILE(S["general_records"], general_records)
+	WRITE_FILE(S["flavor_background"], flavor_background)
+	WRITE_FILE(S["character_skills"], character_skills)
+	WRITE_FILE(S["exploitable_info"], exploitable_info)
+	//END OF SKYRAT CHANGES
 	//gear loadout
 	if(islist(chosen_gear))
 		if(chosen_gear.len)

--- a/modular_skyrat/code/_HELPERS/text.dm
+++ b/modular_skyrat/code/_HELPERS/text.dm
@@ -1,0 +1,8 @@
+/proc/prefix_a_or_an(text) //I swear there is a proc for this but I can't find it
+	var/start = lowertext(text[1])
+	if(!start)
+		return "a"
+	if(start == "a" || start == "e" || start == "i" || start == "o" || start == "u" || start == "h")
+		return "an"
+	else
+		return "a"

--- a/modular_skyrat/code/_HELPERS/text.dm
+++ b/modular_skyrat/code/_HELPERS/text.dm
@@ -2,7 +2,7 @@
 	var/start = lowertext(text[1])
 	if(!start)
 		return "a"
-	if(start == "a" || start == "e" || start == "i" || start == "o" || start == "u" || start == "h")
+	if(start == "a" || start == "e" || start == "i" || start == "o" || start == "u")
 		return "an"
 	else
 		return "a"

--- a/modular_skyrat/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/human.dm
@@ -2,4 +2,36 @@
 	. = ..()
 	if(href_list["ooc_notes"])
 		if(client)
-			to_chat(usr, "[src]'s OOC Notes : <br> <b>ERP :</b> [client.prefs.erppref] <b>| Non-Con :</b> [client.prefs.nonconpref] <b>| Vore :</b> [client.prefs.vorepref]<br>[client.prefs.ooc_notes]")
+			var/str = "[src]'s OOC Notes : <br> <b>ERP :</b> [client.prefs.erppref] <b>| Non-Con :</b> [client.prefs.nonconpref] <b>| Vore :</b> [client.prefs.vorepref]<br>[client.prefs.ooc_notes]"
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s OOC information", replacetext(str, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s ooc info"))
+			onclose(usr, "[name]'s ooc info")
+	
+	if(href_list["general_records"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s general records", replacetext(client.prefs.general_records, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s gen rec"))
+			onclose(usr, "[name]'s gen rec")
+
+	if(href_list["security_records"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s security records", replacetext(client.prefs.security_records, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s sec rec"))
+			onclose(usr, "[name]'s sec rec")
+
+	if(href_list["medical_records"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s medical records", replacetext(client.prefs.medical_records, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s med rec"))
+			onclose(usr, "[name]'s med rec")
+
+	if(href_list["flavor_background"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s background flavor", replacetext(client.prefs.flavor_background, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s bg flav"))
+			onclose(usr, "[name]'s bg flav")
+
+	if(href_list["character_skills"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s skills and hobbies", replacetext(client.prefs.character_skills, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s char skill"))
+			onclose(usr, "[name]'s char skill")
+
+	if(href_list["exploitable_info"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s exploitable information", replacetext(client.prefs.exploitable_info, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s exp info"))
+			onclose(usr, "[name]'s exp info")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3316,6 +3316,7 @@
 #include "modular_skyrat\code\_globalvars\lists\names.dm"
 #include "modular_skyrat\code\_HELPERS\mobs.dm"
 #include "modular_skyrat\code\_HELPERS\names.dm"
+#include "modular_skyrat\code\_HELPERS\text.dm"
 #include "modular_skyrat\code\controllers\configuration\entries\game_options.dm"
 #include "modular_skyrat\code\controllers\configuration\entries\skyrat_config.dm"
 #include "modular_skyrat\code\controllers\subsystem\bluespace_locker.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now in character prefs you'll be able to choose your general,security and medical records, which will be also shown in the records consoles, and also printed out. 
Background, skills and exploitable informations dont have any use in game yet
Observer admins can easily access those informations by examining someone and pressing a button

For examines, it'll show people's name as like this "This is Yatiyaratachi, a Vox!" or if you have a custom species it'll show like this "This is Yatiyaratachi, a Customspecies!" and "They are a Vox" underneath. SUPPORT FOR  "A" OR "AN" INCLUDED

EDIT: oh yeah this also properly decodes the OOC information aswell as turns it into a popup instead of chat message

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Custom records and more good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added custom records and more character customization
add: Custom species and species show better in examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
