### PR TITLE
[Tweak]Prisoner Slots

### DIFF
--- a/_maps/map_files/KiloStation/job_changes.dm
+++ b/_maps/map_files/KiloStation/job_changes.dm
@@ -1,0 +1,10 @@
+
+//custom access for some jobs. pasted together from ministation.
+
+#define JOB_MODIFICATION_MAP_NAME "KiloStation"
+
+/datum/job/Prisoner/New()
+	..()
+	total_positions = 3
+	spawn_positions = 3
+

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -10,7 +10,7 @@ Research Director=1,1
 Chief Medical Officer=1,1
 
 Assistant=-1,-1
-Prisoner=4,4
+Prisoner=8,8
 
 Quartermaster=1,1
 Cargo Technician=3,2

--- a/modular_skyrat/code/modules/jobs/job_types/prisoner.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/prisoner.dm
@@ -4,9 +4,11 @@
 	department_head = list("The Security Team")
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 8
+	spawn_positions = 8
 	supervisors = "the security team"
+	exp_requirements = 3000
+	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/prisoner
 


### PR DESCRIPTION

## About The Pull Request

All maps (besides kilo, which has 3 prisoner slots instead) have 8 prisoner slots now.. but they also require 50 hours of CREW playtime.

## Why It's Good For The Game

More prisoners... more fun? Locks prisoners behind a time wall because people need to know the rules before they play a role that requires rule knowledge and RP knowledge.

## Changelog
:cl:
tweak: From 4 slots to 8 slots on almost all maps for Prisoner role.
balance: Prisoners now need 50 hours before being played.
/:cl:
