### PR TITLE
Synths Rebuilt (not gay ass lizard synths or whatever, like fallout synths get it fuck)

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -439,7 +439,7 @@ ROUNDSTART_RACES dwarf
 #ROUNDSTART_RACES silver
 #ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
-ROUNDSTART_RACES synth
+#ROUNDSTART_RACES synth
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -439,7 +439,7 @@ ROUNDSTART_RACES dwarf
 #ROUNDSTART_RACES silver
 #ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
-#ROUNDSTART_RACES synth
+ROUNDSTART_RACES synth
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton

--- a/modular_skyrat/code/_DEFINES/traits.dm
+++ b/modular_skyrat/code/_DEFINES/traits.dm
@@ -1,2 +1,3 @@
 #define TRAIT_GIGANTISM			"gigantism"		// large boy
 #define TRAIT_SMALL				"small"		// smol boy
+#define TRAIT_SYNTH				"synthetic"		// robotic boy

--- a/modular_skyrat/code/datums/traits/neutral.dm
+++ b/modular_skyrat/code/datums/traits/neutral.dm
@@ -1,3 +1,4 @@
+//gigantism
 /datum/quirk/gigantism
 	name = "Gigantism"
 	desc = "You are exceptionally big."
@@ -15,6 +16,7 @@
 	if(H)
 		H.transform = H.transform.Scale(0.8, 0.8)
 
+//small
 /datum/quirk/small
 	name = "Small"
 	desc = "You are a bit... small. With none of the benefits."
@@ -30,3 +32,27 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	if(H)
 		H.transform = H.transform.Scale(1.1, 1.1)
+
+//synth thing (doing it as an actual species thing would be wayyy harder to do).
+/datum/quirk/synthetic
+	name = "Synthetic"
+	desc = "You're not actually the species you seem to be. You're a synth! You will still have your old species traits, however you will not be infectd by viruses, get hungry, breathe nor process any reagents aside from synthflesh."
+	value = 0
+	mob_trait = TRAIT_SYNTH
+
+/datum/quirk/synthetic/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.set_species(/datum/species/synth) //the synth on_gain stuff handles everything, that's why i made this shit a quirk and not a roundstart race or whatever
+
+/datum/quirk/synthetic/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/synth/synthspecies = H.dna.species
+	if(synthspecies)
+		var/datum/species/oldspecies = synthspecies.fake_species
+		if(oldspecies)
+			H.set_species(oldspecies)
+		else
+			H.set_species(/datum/species/ipc) //we fall back on IPC if something stinky happens. Shouldn't happe but you know.
+			to_chat(H, "<span class='warning'>Uh oh, stinky! Something poopy happened to your fakespecies! You have been set to an IPC as a fallback.</span>") //shouldn't happen. if it does uh oh.
+	else
+		to_chat(H, "<span class='warning'>Uh oh, stinky! Something poopy happened to your synth species datum!</span>") //hopefully won't ever happen. otherwise, uh oh.

--- a/modular_skyrat/code/datums/traits/neutral.dm
+++ b/modular_skyrat/code/datums/traits/neutral.dm
@@ -36,7 +36,7 @@
 //synth thing (doing it as an actual species thing would be wayyy harder to do).
 /datum/quirk/synthetic
 	name = "Synthetic"
-	desc = "You're not actually the species you seem to be. You're a synth! You will still have your old species traits, however you will not be infectd by viruses, get hungry, breathe nor process any reagents aside from synthflesh."
+	desc = "You're not actually the species you seem to be. You're a synth! You will still have your old species traits, however you will not be infectd by viruses, get hungry nor process any reagents aside from synthflesh."
 	value = 0
 	mob_trait = TRAIT_SYNTH
 

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -1,0 +1,18 @@
+/datum/species/synth
+	name = "Synthetic" //inherited from the real species, for health scanners and things
+	id = "synth"
+	say_mod = "beep boops" //inherited from a user's real species
+	sexes = 1 //read below, degenerate
+	species_traits = list(NOTRANSSTING) //all of these + whatever we inherit from the real species. I know you sick fucks want to fuck synths so yes you get genitals. Degenerates.
+	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER,TRAIT_NOBREATH) //Now limbs can be disabled and dismembered. Why the fuck would they not? IT'S A FUCKING ROBOT NOT LIKE A FUCKING GOLEM
+	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
+	dangerous_existence = 0 //not dangerous anymore i guess
+	blacklisted = 0 //not blacklisted anymore
+	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc //fuck it
+	gib_types = /obj/effect/gibspawner/robot
+	damage_overlay_type = "synth"
+	limbs_id = "synth"
+	var/list/initial_species_traits = list(NOTRANSSTING) //for getting these values back for assume_disguise()
+	var/list/initial_inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER,TRAIT_NOBREATH) //blah blah i explained above piss
+	var/disguise_fail_health = 75 //When their health gets to this level their synthflesh partially falls off
+	var/datum/species/fake_species = null //a species to do most of our work for us, unless we're damaged

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -12,7 +12,7 @@
 	gib_types = /obj/effect/gibspawner/robot
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
-	var/list/initial_species_traits = list(NOTRANSSTING) //for getting these values back for assume_disguise()
-	var/list/initial_inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER,TRAIT_NOBREATH) //blah blah i explained above piss
-	var/disguise_fail_health = 75 //When their health gets to this level their synthflesh partially falls off
-	var/datum/species/fake_species = null //a species to do most of our work for us, unless we're damaged
+	initial_species_traits = list(NOTRANSSTING) //for getting these values back for assume_disguise()
+	initial_inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER,TRAIT_NOBREATH) //blah blah i explained above piss
+	disguise_fail_health = 75 //When their health gets to this level their synthflesh partially falls off
+	fake_species = null //a species to do most of our work for us, unless we're damaged

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -4,7 +4,7 @@
 	say_mod = "beep boops" //inherited from a user's real species
 	sexes = 1 //read below, degenerate
 	species_traits = list(NOTRANSSTING) //all of these + whatever we inherit from the real species. I know you sick fucks want to fuck synths so yes you get genitals. Degenerates.
-	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER,TRAIT_NOBREATH) //Now limbs can be disabled and dismembered. Why the fuck would they not? IT'S A FUCKING ROBOT NOT LIKE A FUCKING GOLEM
+	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER) //Now limbs can be disabled and dismembered, and they breathe for balance reasons. Why the fuck would they not? IT'S A FUCKING ROBOT NOT LIKE A FUCKING GOLEM
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
 	dangerous_existence = 0 //not dangerous anymore i guess
 	blacklisted = 0 //not blacklisted anymore

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -16,3 +16,51 @@
 	initial_inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOHUNGER,TRAIT_NOBREATH) //blah blah i explained above piss
 	disguise_fail_health = 75 //When their health gets to this level their synthflesh partially falls off
 	fake_species = null //a species to do most of our work for us, unless we're damaged
+
+/datum/species/synth/assume_disguise(datum/species/S, mob/living/carbon/human/H) //rework the proc for it to NOT fuck up with dunmers/other skyrat custom races
+	if(S && !istype(S, type))
+		name = S.name
+		say_mod = S.say_mod
+		sexes = S.sexes
+		species_traits = initial_species_traits.Copy()
+		inherent_traits = initial_inherent_traits.Copy()
+		species_traits |= S.species_traits
+		inherent_traits |= S.inherent_traits
+		attack_verb = S.attack_verb
+		attack_sound = S.attack_sound
+		miss_sound = S.miss_sound
+		meat = S.meat
+		mutant_bodyparts = S.mutant_bodyparts.Copy()
+		mutant_organs = S.mutant_organs.Copy()
+		nojumpsuit = S.nojumpsuit
+		no_equip = S.no_equip.Copy()
+		icon_limbs = S.icon_limbs //there you go bubsy, now dunmer synths and shit wont be FUCKING INVISIBLE
+		limbs_id = S.limbs_id
+		use_skintones = S.use_skintones
+		fixed_mut_color = S.fixed_mut_color
+		hair_color = S.hair_color
+		fake_species = new S.type
+	else
+		name = initial(name)
+		say_mod = initial(say_mod)
+		species_traits = initial_species_traits.Copy()
+		inherent_traits = initial_inherent_traits.Copy()
+		attack_verb = initial(attack_verb)
+		attack_sound = initial(attack_sound)
+		miss_sound = initial(miss_sound)
+		mutant_bodyparts = list()
+		nojumpsuit = initial(nojumpsuit)
+		no_equip = list()
+		qdel(fake_species)
+		fake_species = null
+		meat = initial(meat)
+		limbs_id = initial(limbs_id)
+		use_skintones = initial(use_skintones)
+		sexes = initial(sexes)
+		fixed_mut_color = ""
+		hair_color = ""
+
+	for(var/X in H.bodyparts) //propagates the damage_overlay changes
+		var/obj/item/bodypart/BP = X
+		BP.update_limb()
+	H.update_body_parts() //to update limb icon cache with the new damage overlays

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3512,6 +3512,7 @@
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\plasmamen.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\shadowpeople.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\synthliz.dm"
+#include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\synths.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\vox.dm"
 #include "modular_skyrat\code\modules\mob\living\silicon\robot\robot.dm"
 #include "modular_skyrat\code\modules\mob\living\silicon\robot\robot_modules.dm"


### PR DESCRIPTION
## About The Pull Request

Basically balances synths so they can be a roundstart race, in a way. Synths are kind of funky so i'll have to do some weird fucking shit to make this work.
Basically, what i did is make it a fucking quirk - This may seem weird, but it is way easier for me since the synth species inherits shit from another species on being gained.
This also helps in one way, as you'll be able to tell who is a synth with a health analyzer by the quirk - but not just by normally examining.

## Why It's Good For The Game

I know for a fact there is some rando who roleplays as a synth (angel rainwater i think), so there is at least some demand for it
its synths they're the funny fallout 4 race or whatever
more roleplay opportunities yada yada
basically expensive IPCs i guess(???)
![prettyhuman](https://user-images.githubusercontent.com/25989101/77995432-28ceed00-7302-11ea-8f69-73679d2dee2d.jpg)

aight bro imma head out
![aightbro](https://user-images.githubusercontent.com/25989101/78006713-b8c96280-7313-11ea-9f04-68b71fffd448.gif)

## Changelog
:cl:
add: Added a synth neutral quirk... which turns you into a synth once you spawn. Upsides and downsides are detailed in the desc. Fallout jokes yada yada yeah.
balance: Synths have been rebalanced for the synth quirk. Now they can be dismembered and their limbs can be disabled, and they breathe.
refactor: Synth species datum has been changed a bit so custom limb icons are taken into account etc.
/:cl:
