### PR TITLE
Makes the cross not 2 tiles tall

### DIFF
--- a/modular_skyrat/code/game/objects/structures/kitchen_spike.dm
+++ b/modular_skyrat/code/game/objects/structures/kitchen_spike.dm
@@ -5,7 +5,6 @@
 	icon_state = "cross"
 	desc = "Degenerates like you belong on one of these."
 	anchored = TRUE
-	bound_height = 64
 
 /obj/structure/kitchenspike/cross/crowbar_act(mob/living/user, obj/item/I)
 	if(has_buckled_mobs())


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

Because it's a nuisance.

## Changelog
:cl:
tweak: The cross (structure) is no longet 2 tiles tall, only 1 tile tall.
/:cl:
