### PR TITLE
Headsets now require you to be capable of using items to operate.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -299,7 +299,7 @@
 			if (idx && (idx % 2) == (message_mode == MODE_L_HAND))
 				return
 
-	talk_into(speaker, raw_message, , spans, language=message_language)
+	talk_into(speaker, raw_message, , spans, language=message_language, direct=FALSE) // Skyrat edit -- differentiate between things spoken into radios directly vs overheard by an intercom/station-bounced 
 
 // Checks if this radio can receive on the given frequency.
 /obj/item/radio/proc/can_receive(freq, level)

--- a/modular_skyrat/code/game/objects/items/devices/radio/radio.dm
+++ b/modular_skyrat/code/game/objects/items/devices/radio/radio.dm
@@ -1,0 +1,3 @@
+/obj/item/radio/talk_into(mob/living/M, message, channel, list/spans,datum/language/language, direct=TRUE)
+	if (!direct || M?.mobility_flags & MOBILITY_USE) // if can't use items, you can't press the button
+		return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3388,6 +3388,7 @@
 #include "modular_skyrat\code\game\objects\items\devices\radio\electropack.dm"
 #include "modular_skyrat\code\game\objects\items\devices\radio\encryptionkey.dm"
 #include "modular_skyrat\code\game\objects\items\devices\radio\headset.dm"
+#include "modular_skyrat\code\game\objects\items\devices\radio\radio.dm"
 #include "modular_skyrat\code\game\objects\items\implants\implant_stealth.dm"
 #include "modular_skyrat\code\game\objects\items\melee\misc.dm"
 #include "modular_skyrat\code\game\objects\items\plushes\plushes.dm"


### PR DESCRIPTION
## Why It's Good For The Game
Removes free and easy `;help I've been cuffed and kidnapped` and the general headset usage when logically it shouldn't be possible.

## Changelog
:cl:
tweak: Headsets now require MOBILITY_USE flag to operate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
