### PR TITLE
[PR FIX]Various ghost role QoL; moving holding facility; removing energy net

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10026,6 +10026,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
+"wZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/obj/effect/landmark/holding_facility,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "xa" = (
 /obj/machinery/door/window/northright{
 	dir = 4;
@@ -12503,6 +12509,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"CQ" = (
+/obj/effect/landmark/holding_facility,
+/mob/living/simple_animal/bot/medbot{
+	name = "Syndicate Hospitality Drone"
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "CR" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -17346,10 +17359,21 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
+"Ql" = (
+/obj/machinery/light,
+/obj/effect/landmark/holding_facility,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "Qm" = (
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
+"Qn" = (
+/obj/machinery/vr_sleeper/hugbox{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "Qo" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
@@ -17907,7 +17931,7 @@
 /area/bluespace_locker)
 "Tn" = (
 /obj/structure/table/wood/fancy,
-/obj/item/candle/infinite{
+/obj/item/candle/infinite/hugbox{
 	pixel_y = 6
 	},
 /turf/open/indestructible/hotelwood,
@@ -17933,7 +17957,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	icon_state = "twindow";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18010,7 +18033,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted{
-	icon_state = "twindow";
 	dir = 1
 	},
 /obj/machinery/washing_machine,
@@ -18058,9 +18080,12 @@
 /obj/vehicle/ridden/janicart,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
-"Ud" = (
-/obj/effect/landmark/holding_facility,
+"Uc" = (
+/obj/machinery/vending/sustenance,
 /turf/open/indestructible/hotelwood,
+/area/centcom/holding)
+"Ud" = (
+/turf/closed/indestructible/wood,
 /area/centcom/holding)
 "Ug" = (
 /obj/machinery/door/poddoor/shuttledock{
@@ -19002,9 +19027,15 @@
 /turf/open/floor/wood,
 /area/syndicate_mothership)
 "ZB" = (
+<<<<<<< HEAD
 /obj/effect/landmark/bluespace_locker_origin,
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
+=======
+/obj/effect/landmark/holding_facility,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
+>>>>>>> 658701bf373... Various ghost role QoL; moving holding facility; removing energy net (#11676)
 "ZE" = (
 /obj/structure/sink{
 	dir = 4;
@@ -43996,11 +44027,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+Ud
+Ud
+Ud
+Ud
+Ud
 aa
 aa
 aa
@@ -44253,11 +44284,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+Ud
+Uc
+ZB
+ZB
+Ud
 aa
 aa
 aa
@@ -44510,11 +44541,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+Ud
+ZB
+CQ
+Ql
+Ud
 aa
 aa
 aa
@@ -44767,11 +44798,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+Ud
+wZ
+ZB
+Qn
+Ud
 aa
 aa
 aa
@@ -45024,11 +45055,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+Ud
+Ud
+Ud
+Ud
+Ud
 aa
 aa
 aa
@@ -46341,8 +46372,8 @@ Sd
 HH
 Nd
 WM
-Ud
-Ud
+Sd
+Sd
 NT
 Nj
 Po
@@ -46598,8 +46629,8 @@ Sd
 XM
 NT
 Sd
-Ud
-Ud
+Sd
+Sd
 NT
 YU
 zT
@@ -46855,8 +46886,8 @@ Sd
 Tn
 NT
 Sd
-Ud
-Ud
+Sd
+Sd
 NT
 YU
 zT
@@ -47112,8 +47143,8 @@ Sd
 GY
 NT
 Sd
-Ud
-Ud
+Sd
+Sd
 NT
 YU
 zT
@@ -47369,8 +47400,8 @@ Qk
 Vu
 Nd
 Gs
-Ud
-Ud
+Sd
+Sd
 NT
 Mt
 PA

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6798,6 +6798,12 @@
 	opacity = 0
 	},
 /area/bluespace_locker)
+"pF" = (
+/obj/machinery/vr_sleeper/hugbox{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "pH" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -9048,6 +9054,9 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
+"uI" = (
+/turf/closed/indestructible/wood,
+/area/centcom/holding)
 "uJ" = (
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/closed/indestructible/riveted,
@@ -11640,6 +11649,12 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Bp" = (
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/obj/effect/landmark/holding_facility,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "Bq" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -16846,6 +16861,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Nn" = (
+/obj/effect/landmark/holding_facility,
+/mob/living/simple_animal/bot/medbot{
+	name = "Syndicate Hospitality Drone"
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "Nt" = (
 /obj/structure/bedsheetbin/color,
 /turf/open/indestructible/hotelwood,
@@ -17509,6 +17531,11 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Rd" = (
+/obj/machinery/light,
+/obj/effect/landmark/holding_facility,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "Re" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/wood,
@@ -17601,6 +17628,10 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"RC" = (
+/obj/machinery/vending/sustenance,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "RD" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -17623,6 +17654,13 @@
 /area/centcom/holding)
 "RL" = (
 /obj/machinery/vending/cola,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
+"RM" = (
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite/hugbox{
+	pixel_y = 6
+	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "RN" = (
@@ -43996,11 +44034,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+uI
+uI
+uI
+uI
+uI
 aa
 aa
 aa
@@ -44253,11 +44291,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+uI
+RC
+Ud
+Ud
+uI
 aa
 aa
 aa
@@ -44510,11 +44548,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+uI
+Ud
+Nn
+Rd
+uI
 aa
 aa
 aa
@@ -44767,11 +44805,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+uI
+Bp
+Ud
+pF
+uI
 aa
 aa
 aa
@@ -45024,11 +45062,11 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
+uI
+uI
+uI
+uI
+uI
 aa
 aa
 aa
@@ -46341,8 +46379,8 @@ Sd
 HH
 Nd
 WM
-Ud
-Ud
+Sd
+Sd
 NT
 Nj
 Po
@@ -46598,8 +46636,8 @@ Sd
 XM
 NT
 Sd
-Ud
-Ud
+Sd
+Sd
 NT
 YU
 zT
@@ -46852,11 +46890,11 @@ Tn
 Xd
 Sd
 Sd
-Tn
+RM
 NT
 Sd
-Ud
-Ud
+Sd
+Sd
 NT
 YU
 zT
@@ -47112,8 +47150,8 @@ Sd
 GY
 NT
 Sd
-Ud
-Ud
+Sd
+Sd
 NT
 YU
 zT
@@ -47369,8 +47407,8 @@ Qk
 Vu
 Nd
 Gs
-Ud
-Ud
+Sd
+Sd
 NT
 Mt
 PA
@@ -47880,7 +47918,7 @@ Sd
 Tu
 Sd
 Sd
-Tn
+RM
 NT
 Sd
 Sd

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10026,12 +10026,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
-"wZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/syndie,
-/obj/effect/landmark/holding_facility,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
 "xa" = (
 /obj/machinery/door/window/northright{
 	dir = 4;
@@ -12509,13 +12503,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"CQ" = (
-/obj/effect/landmark/holding_facility,
-/mob/living/simple_animal/bot/medbot{
-	name = "Syndicate Hospitality Drone"
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
 "CR" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -17359,21 +17346,10 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
-"Ql" = (
-/obj/machinery/light,
-/obj/effect/landmark/holding_facility,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
 "Qm" = (
 /obj/singularity/wizard/mapped,
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
-"Qn" = (
-/obj/machinery/vr_sleeper/hugbox{
-	dir = 8
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
 "Qo" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
@@ -17931,7 +17907,7 @@
 /area/bluespace_locker)
 "Tn" = (
 /obj/structure/table/wood/fancy,
-/obj/item/candle/infinite/hugbox{
+/obj/item/candle/infinite{
 	pixel_y = 6
 	},
 /turf/open/indestructible/hotelwood,
@@ -17957,6 +17933,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
+	icon_state = "twindow";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18033,6 +18010,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/tinted{
+	icon_state = "twindow";
 	dir = 1
 	},
 /obj/machinery/washing_machine,
@@ -18080,12 +18058,9 @@
 /obj/vehicle/ridden/janicart,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
-"Uc" = (
-/obj/machinery/vending/sustenance,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
 "Ud" = (
-/turf/closed/indestructible/wood,
+/obj/effect/landmark/holding_facility,
+/turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "Ug" = (
 /obj/machinery/door/poddoor/shuttledock{
@@ -19027,15 +19002,9 @@
 /turf/open/floor/wood,
 /area/syndicate_mothership)
 "ZB" = (
-<<<<<<< HEAD
 /obj/effect/landmark/bluespace_locker_origin,
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
-=======
-/obj/effect/landmark/holding_facility,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
->>>>>>> 658701bf373... Various ghost role QoL; moving holding facility; removing energy net (#11676)
 "ZE" = (
 /obj/structure/sink{
 	dir = 4;
@@ -44027,11 +43996,11 @@ aa
 aa
 aa
 aa
-Ud
-Ud
-Ud
-Ud
-Ud
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -44284,11 +44253,11 @@ aa
 aa
 aa
 aa
-Ud
-Uc
-ZB
-ZB
-Ud
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -44541,11 +44510,11 @@ aa
 aa
 aa
 aa
-Ud
-ZB
-CQ
-Ql
-Ud
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -44798,11 +44767,11 @@ aa
 aa
 aa
 aa
-Ud
-wZ
-ZB
-Qn
-Ud
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -45055,11 +45024,11 @@ aa
 aa
 aa
 aa
-Ud
-Ud
-Ud
-Ud
-Ud
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46372,8 +46341,8 @@ Sd
 HH
 Nd
 WM
-Sd
-Sd
+Ud
+Ud
 NT
 Nj
 Po
@@ -46629,8 +46598,8 @@ Sd
 XM
 NT
 Sd
-Sd
-Sd
+Ud
+Ud
 NT
 YU
 zT
@@ -46886,8 +46855,8 @@ Sd
 Tn
 NT
 Sd
-Sd
-Sd
+Ud
+Ud
 NT
 YU
 zT
@@ -47143,8 +47112,8 @@ Sd
 GY
 NT
 Sd
-Sd
-Sd
+Ud
+Ud
 NT
 YU
 zT
@@ -47400,8 +47369,8 @@ Qk
 Vu
 Nd
 Gs
-Sd
-Sd
+Ud
+Ud
 NT
 Mt
 PA

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -149,7 +149,9 @@
 #define COMSIG_MOB_DEATH "mob_death"							//from base of mob/death(): (gibbed)
 	#define COMPONENT_BLOCK_DEATH_BROADCAST 1					//stops the death from being broadcasted in deadchat.
 #define COMSIG_MOB_GHOSTIZE "mob_ghostize"						//from base of mob/Ghostize(): (can_reenter_corpse, special, penalize)
-	#define COMPONENT_BLOCK_GHOSTING 1
+	#define COMPONENT_BLOCK_GHOSTING (1<<0)
+	#define COMPONENT_DO_NOT_PENALIZE_GHOSTING (1<<1)
+	#define COMPONENT_FREE_GHOSTING (1<<2)
 #define COMSIG_MOB_ALLOWED "mob_allowed"						//from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
 #define COMSIG_MOB_RECEIVE_MAGIC "mob_receive_magic"			//from base of mob/anti_magic_check(): (mob/user, magic, holy, tinfoil, chargecost, self, protection_sources)
 	#define COMPONENT_BLOCK_MAGIC 1

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -470,7 +470,6 @@
 				/datum/objective/steal,
 				/datum/objective/download,
 				/datum/objective/nuclear,
-				/datum/objective/capture,
 				/datum/objective/absorb,
 				/datum/objective/custom
 			)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -663,7 +663,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	if(count)
 		target_amount = count
 	update_explanation_text()
-
+/*
 /datum/objective/capture
 	name = "capture"
 	var/captured_amount = 0
@@ -709,7 +709,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	if(count)
 		target_amount = count
 	update_explanation_text()
-
+*/
 //Changeling Objectives
 
 /datum/objective/absorb

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -13,6 +13,7 @@
 	var/lit = FALSE
 	var/infinite = FALSE
 	var/start_lit = FALSE
+	var/heats_space = TRUE
 
 /obj/item/candle/Initialize()
 	. = ..()
@@ -35,7 +36,7 @@
 	return ..()
 
 /obj/item/candle/get_temperature()
-	return lit * heat
+	return lit * heat * heats_space
 
 /obj/item/candle/proc/light(show_message)
 	if(!lit)
@@ -67,7 +68,8 @@
 		new /obj/item/trash/candle(loc)
 		qdel(src)
 	update_icon()
-	open_flame()
+	if(heats_space)
+		open_flame()
 
 /obj/item/candle/attack_self(mob/user)
 	if(put_out_candle())
@@ -76,5 +78,8 @@
 /obj/item/candle/infinite
 	infinite = TRUE
 	start_lit = TRUE
+
+/obj/item/candle/infinite/hugbox
+	heats_space = FALSE
 
 #undef CANDLE_LUMINOSITY

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -494,7 +494,7 @@
 		S.ckey = C.ckey
 		S.status_flags |= GODMODE
 		S.language_holder = user.language_holder.copy(S)
-		S.AddElement(/datum/element/ghost_role_eligibility)
+		S.AddElement(/datum/element/ghost_role_eligibility,penalize_on_ghost = TRUE)
 		START_PROCESSING(SSprocessing,src)
 		var/input = stripped_input(S,"What are you named?", ,"", MAX_NAME_LEN)
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -674,17 +674,14 @@
 		O.equip(new_spawn, FALSE, new_spawn.client)
 		SSjob.equip_loadout(null, new_spawn, FALSE)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
-		new_spawn.AddElement(/datum/element/ghost_role_eligibility)
+		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
 		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type,/area/hilbertshotel))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
-		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still elegible for ghost roles popups.
+		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
 		ADD_TRAIT(new_spawn, TRAIT_PACIFISM, GHOSTROLE_TRAIT)
-		to_chat(new_spawn,"<span class='boldwarning'>You may be sharing your cafe with some ninja-captured individuals, so make sure to only interact with the ghosts you hear as a ghost!</span>")
-		to_chat(new_spawn,"<span class='boldwarning'>You can turn yourself into a ghost and freely reenter your body with the ghost action.</span>")
-		var/datum/action/ghost/G = new(new_spawn)
-		G.Grant(new_spawn)
+		to_chat(new_spawn,"<span class='boldwarning'>Ghosting is free!</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
 		D.Grant(new_spawn)
 

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -59,7 +59,7 @@
 		SA.del_on_death = FALSE
 
 		spawned_mobs += SA
-		SA.AddElement(/datum/element/ghost_role_eligibility)
+		SA.AddElement(/datum/element/ghost_role_eligibility, penalize_on_ghost = TRUE)
 		to_chat(SA, "<span class='userdanger'>Hello world!</span>")
 		to_chat(SA, "<span class='warning'>Due to freak radiation and/or chemicals \
 			and/or lucky chance, you have gained human level intelligence \

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -260,14 +260,15 @@ Works together with spawning an observer, noted above.
 */
 
 /mob/proc/ghostize(can_reenter_corpse = TRUE, special = FALSE, penalize = FALSE, voluntary = FALSE)
-	penalize = suiciding || penalize // suicide squad.
+	var/sig_flags = SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, can_reenter_corpse, special, penalize)
+	penalize = !(sig_flags & COMPONENT_DO_NOT_PENALIZE_GHOSTING) && (suiciding || penalize) // suicide squad.
 	voluntary_ghosted = voluntary
-	if(!key || key[1] == "@" || (SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, can_reenter_corpse, special, penalize) & COMPONENT_BLOCK_GHOSTING))
+	if(!key || key[1] == "@" || (sig_flags & COMPONENT_BLOCK_GHOSTING))
 		return //mob has no key, is an aghost or some component hijacked.
 	stop_sound_channel(CHANNEL_HEARTBEAT) //Stop heartbeat sounds because You Are A Ghost Now
 	var/mob/dead/observer/ghost = new(get_turf(src), src)	// Transfer safety to observer spawning proc.
 	SStgui.on_transfer(src, ghost) // Transfer NanoUIs.
-	ghost.can_reenter_corpse = can_reenter_corpse
+	ghost.can_reenter_corpse = can_reenter_corpse || (sig_flags & COMPONENT_FREE_GHOSTING)
 	if (client && client.prefs && client.prefs.auto_ooc)
 		if (!(client.prefs.chat_toggles & CHAT_OOC))
 			client.prefs.chat_toggles ^= CHAT_OOC
@@ -294,12 +295,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
 			penalty = CANT_REENTER_ROUND
 
-	if(SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, (stat == DEAD) ? TRUE : FALSE, FALSE, (stat == DEAD)? penalty : 0, (stat == DEAD)? TRUE : FALSE) & COMPONENT_BLOCK_GHOSTING)
+	var/sig_flags = SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, (stat == DEAD) ? TRUE : FALSE, FALSE, (stat == DEAD)? penalty : 0, (stat == DEAD)? TRUE : FALSE)
+
+	if(sig_flags & COMPONENT_BLOCK_GHOSTING)
 		return
+
+	if(sig_flags & COMPONENT_DO_NOT_PENALIZE_GHOSTING)
+		penalty = 0
 
 	if(stat != DEAD)
 		succumb()
-	if(stat == DEAD)
+	if(stat == DEAD || sig_flags & COMPONENT_FREE_GHOSTING)
 		ghostize(1)
 	else
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst alive you won't be able to re-enter this round [penalty ? "or play ghost roles [penalty == CANT_REENTER_ROUND ? "until the round is over" : "for the next [DisplayTimeText(penalty)]"]" : ""]! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
@@ -318,7 +324,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	if(SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, FALSE, FALSE) & COMPONENT_BLOCK_GHOSTING)
+	var/sig_flags = SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, FALSE, FALSE)
+
+	if(sig_flags & COMPONENT_BLOCK_GHOSTING)
 		return
 
 	var/penalty = CONFIG_GET(number/suicide_reenter_round_timer) MINUTES
@@ -330,10 +338,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
 			penalty = CANT_REENTER_ROUND
 
-	var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst alive you won't be able to re-enter this round [penalty ? "or play ghost roles [penalty == CANT_REENTER_ROUND ? "until the round is over" : "for the next [DisplayTimeText(penalty)]"]" : ""]! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
-	if(response != "Ghost")
-		return
-	ghostize(0, penalize = TRUE)
+	if(sig_flags & COMPONENT_DO_NOT_PENALIZE_GHOSTING)
+		penalty = 0
+
+	if(sig_flags & COMPONENT_FREE_GHOSTING)
+		ghostize(1)
+	else
+		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst alive you won't be able to re-enter this round [penalty ? "or play ghost roles [penalty == CANT_REENTER_ROUND ? "until the round is over" : "for the next [DisplayTimeText(penalty)]"]" : ""]! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+		if(response != "Ghost")
+			return
+		ghostize(0, penalize = TRUE)
 
 
 
@@ -667,7 +681,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0
 
 	transfer_ckey(target, FALSE)
-	target.AddElement(/datum/element/ghost_role_eligibility)
+	target.AddElement(/datum/element/ghost_role_eligibility, penalize_on_ghost = FALSE, free_ghosting = TRUE)
 	target.faction = list("neutral")
 	return 1
 

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -57,12 +57,12 @@ It is possible to destroy the net by the occupant or someone else.
 				continue//So all they're left with are shoes and uniform.
 			H.dropItemToGround(W)
 		H.dna.species.give_important_for_life(H)	// After we remove items, at least give them what they need to live.
+/*
 	var/datum/antagonist/antag_datum
 	for(var/datum/antagonist/ninja/AD in GLOB.antagonists) //Because only ninjas get capture objectives; They're not doable without the suit.
 		if(AD.owner == master)
 			antag_datum = AD
 			break
-
 	for(var/datum/objective/capture/capture in antag_datum)
 		if(istype(affecting, /mob/living/carbon/human)) //Humans.
 			if(affecting.stat == DEAD)//Dead folks are worth less.
@@ -87,7 +87,7 @@ It is possible to destroy the net by the occupant or someone else.
 				capture.captured_amount+=1
 				continue
 			capture.captured_amount+=2
-
+*/
 
 	affecting.revive(1, 1)	//Basically a revive and full heal, including limbs/organs
 							//In case people who have been captured dead want to hang out at the holding area

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -22,7 +22,7 @@ Contents:
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 100, "acid" = 100)
 	strip_delay = 12
 
-	actions_types = list(/datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninjanet, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)
+	actions_types = list(/datum/action/item_action/initialize_ninja_suit, /datum/action/item_action/ninjasmoke, /datum/action/item_action/ninjaboost, /datum/action/item_action/ninjapulse, /datum/action/item_action/ninjastar, /datum/action/item_action/ninja_sword_recall, /datum/action/item_action/ninja_stealth, /datum/action/item_action/toggle_glove)
 
 		//Important parts of the suit.
 	var/mob/living/carbon/human/affecting = null
@@ -174,9 +174,6 @@ Contents:
 		return TRUE
 	if(istype(action, /datum/action/item_action/ninjastar))
 		ninjastar()
-		return TRUE
-	if(istype(action, /datum/action/item_action/ninjanet))
-		ninjanet()
 		return TRUE
 	if(istype(action, /datum/action/item_action/ninja_sword_recall))
 		ninja_sword_recall()


### PR DESCRIPTION
Original PR: Citadel-Station-13/Citadel-Station-13#11676
MIRROR PR: https://github.com/Skyrat-SS13/Skyrat13/pull/1034
## About The Pull Request

fixes map conflict
closes #1034

## Why It's Good For The Game

Fixing mirror PRs

## Changelog
:cl:
add: A new, much more barebones holding facility for contractors.
del: Energy nets are gone.
tweak: Various ghost roles are now easier to ghost as.
tweak: The candles in the dojo no longer make the place hotter and hotter over time.
/:cl:
