### PR TITLE
[Modular]Vendor Prize Limit

### DIFF
--- a/modular_skyrat/code/game/machinery/computer/arcade/arcade.dm
+++ b/modular_skyrat/code/game/machinery/computer/arcade/arcade.dm
@@ -60,3 +60,12 @@
 		/obj/item/clothing/suit/hooded/wintercoat/ratvar/fake = ARCADE_WEIGHT_TRICK,
 		/obj/item/clothing/suit/hooded/wintercoat/narsie/fake = ARCADE_WEIGHT_TRICK
 	)
+	var/prizecharge = 5
+
+/obj/machinery/computer/arcade/prizevend(mob/user, list/rarity_classes)
+	if(prizecharge == 0)
+		to_chat(user, "<span class='notice'>Warning: Maximum amount of prizes have been vended!</span>")
+		return
+	prizecharge--
+	. = ..()
+


### PR DESCRIPTION

## About The Pull Request

Makes Arcade machines only able to vend five prizes before running into an error if they attempt to vend another.

## Why It's Good For The Game

Too many prizes, too many items, too much LAG.

## Changelog
:cl:
add: Added a prize limit to arcade machines.
/:cl:

