### PR TITLE
[Modular] Addition of shrink module

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -536,13 +536,17 @@
 	name = "borg expander"
 	desc = "A cyborg resizer, it makes a cyborg huge."
 	icon_state = "cyborg_upgrade3"
-
+/* moved to modular_skyrat
 /obj/item/borg/upgrade/expand/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
 
 		if(R.hasExpanded)
 			to_chat(usr, "<span class='notice'>This unit already has an expand module installed!</span>")
+			return FALSE
+
+		if(R.hasShrunk)
+			to_chat(usr, "<span class='notice'>This unit already has an shrink module installed!</span>")
 			return FALSE
 
 		R.notransform = TRUE
@@ -563,7 +567,7 @@
 		R.resize = 2
 		R.hasExpanded = TRUE
 		R.update_transform()
-
+*/
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -722,16 +722,16 @@
 	materials = list(/datum/material/iron=10000, /datum/material/glass=200, /datum/material/titanium=1000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
-
+/* moved to modular_skyrat
 /datum/design/borg_upgrade_expand
 	name = "Cyborg Upgrade (Expand)"
 	id = "borg_upgrade_expand"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/expand
-	materials = list(/datum/material/iron=200000, /datum/material/titanium=5000)
+	materials = list(/datum/material/iron=20000, /datum/material/titanium=5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
-
+*/
 /datum/design/boris_ai_controller
 	name = "B.O.R.I.S. AI-Cyborg Remote Control Module"
 	id = "borg_ai_control"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -728,7 +728,7 @@
 	id = "borg_upgrade_expand"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/expand
-	materials = list(/datum/material/iron=20000, /datum/material/titanium=5000)
+	materials = list(/datum/material/iron=200000, /datum/material/titanium=5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 */

--- a/modular_skyrat/code/game/objects/items/robot/robot_upgrades.dm
+++ b/modular_skyrat/code/game/objects/items/robot/robot_upgrades.dm
@@ -128,3 +128,78 @@
 		var/obj/item/gun/energy/kinetic_accelerator/cyborg/KA = new (R.module)
 		R.module.basic_modules += KA
 		R.module.add_module(KA, FALSE, TRUE)
+
+/obj/item/borg/upgrade/expand/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+
+		if(R.hasExpanded)
+			to_chat(usr, "<span class='notice'>This unit already has an expand module installed!</span>")
+			return FALSE
+
+		if(R.hasShrunk)
+			to_chat(usr, "<span class='notice'>This unit already has an shrink module installed!</span>")
+			return FALSE
+
+		R.notransform = TRUE
+		var/prev_locked_down = R.locked_down
+		R.SetLockdown(1)
+		R.anchored = TRUE
+		var/datum/effect_system/smoke_spread/smoke = new
+		smoke.set_up(1, R.loc)
+		smoke.start()
+		sleep(2)
+		for(var/i in 1 to 4)
+			playsound(R, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, 1, -1)
+			sleep(12)
+		if(!prev_locked_down)
+			R.SetLockdown(0)
+		R.anchored = FALSE
+		R.notransform = FALSE
+		R.resize = 2
+		R.hasExpanded = TRUE
+		R.update_transform()
+
+/obj/item/borg/upgrade/shrink
+	name = "borg shrinker"
+	desc = "A cyborg resizer, it makes a cyborg small."
+	icon_state = "cyborg_upgrade3"
+
+/obj/item/borg/upgrade/shrink/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+
+		if(R.hasShrunk)
+			to_chat(usr, "<span class='notice'>This unit already has an shrink module installed!</span>")
+			return FALSE
+
+		if(R.hasExpanded)
+			to_chat(usr, "<span class='notice'>This unit already has an expand module installed!</span>")
+			return FALSE
+
+
+		R.notransform = TRUE
+		var/prev_locked_down = R.locked_down
+		R.SetLockdown(1)
+		R.anchored = TRUE
+		var/datum/effect_system/smoke_spread/smoke = new
+		smoke.set_up(1, R.loc)
+		smoke.start()
+		sleep(2)
+		for(var/i in 1 to 4)
+			playsound(R, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, 1, -1)
+			sleep(12)
+		if(!prev_locked_down)
+			R.SetLockdown(0)
+		R.anchored = FALSE
+		R.notransform = FALSE
+		R.resize = 0.75
+		R.hasShrunk = TRUE
+		R.update_transform()
+
+/obj/item/borg/upgrade/shrink/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		R.resize = 1.25
+		R.hasShrunk = FALSE
+		R.update_transform()

--- a/modular_skyrat/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_skyrat/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,2 +1,3 @@
 /mob/living/silicon/robot
 	speed = 0.2
+	var/hasShrunk = FALSE

--- a/modular_skyrat/code/modules/research/designs/mechfabricator_designs.dm
+++ b/modular_skyrat/code/modules/research/designs/mechfabricator_designs.dm
@@ -33,3 +33,21 @@
 	materials = list(/datum/material/iron=8000, /datum/material/glass=4000, /datum/material/titanium=2000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_expand
+	name = "Cyborg Upgrade (Expand)"
+	id = "borg_upgrade_expand"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/expand
+	materials = list(/datum/material/iron=20000, /datum/material/glass=5000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_shrink
+	name = "Cyborg Upgrade (shrink)"
+	id = "borg_upgrade_shrink"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/shrink
+	materials = list(/datum/material/iron=20000, /datum/material/glass=5000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")

--- a/modular_skyrat/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/code/modules/research/techweb/all_nodes.dm
@@ -1,5 +1,6 @@
 /datum/techweb_node/cyborg_upg_util/New()
 	design_ids += "borg_upgrade_xwelding"
+	design_ids += "borg_upgrade_shrink"
 	//design_ids += "borg_upgrade_plasma"
 	. = ..()
 


### PR DESCRIPTION

## About The Pull Request

This adds the addition of a Cyborg Shrink module.
Adjusted cost of Expand module to be cheaper 
Adjusted size of Expand borg to not be excessive.

## Why It's Good For The Game

It allows Borgs that wish to not be dummy thicc to be less thick. 
Makes both Expand and Shrink to be cheaper, as they are very niche upgrades.
Reduces Expand size from 2.0 to 1.5, to make it less of a meme.

## Changelog
:cl: harakoniwarhawk
add: Added a new module called shrink.
tweak: Adjusted cost of Expand module to be cheaper.
/:cl:


