### PR TITLE
Xeno-Hybrid and Ash Walker edits

### DIFF
--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -1,0 +1,26 @@
+/datum/species/xeno
+	// A cloning mistake, crossing human and xenomorph DNA
+	name = "Xenomorph Hybrid"
+	id = "xeno"
+	say_mod = "hisses"
+	default_color = "00FF00"
+	icon_limbs = DEFAULT_BODYPART_ICON_CITADEL
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS)
+	mutant_bodyparts = list("xenotail"="Xenomorph Tail","xenohead"="Standard","xenodorsal"="Standard", "mam_body_markings" = "Xeno","mcolor" = "0F0","mcolor2" = "0F0","mcolor3" = "0F0","taur" = "None", "legs" = "Digitigrade")
+	mutanttongue = /obj/item/organ/tongue/alien
+	attack_verb = "slash"
+	attack_sound = 'sound/weapons/slash.ogg'
+	miss_sound = 'sound/weapons/slashmiss.ogg'
+	meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
+	gib_types = list(/obj/effect/gibspawner/xeno/xenoperson, /obj/effect/gibspawner/xeno/xenoperson/bodypartless)
+	skinned_type = /obj/item/stack/sheet/animalhide/xeno
+	exotic_bloodtype = "X*"
+	damage_overlay_type = "xeno"
+	liked_food = MEAT
+
+/datum/species/xeno/after_equip_job(datum/job/J, mob/living/carbon/human/H)
+	H.grant_language(/datum/language/xenocommon)
+
+
+
+

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -4,3 +4,14 @@
 	if(C.dna.features["legs"] == "Plantigrade")
 		C.dna.features["legs"] = "Digitigrade"
 	return ..()
+
+/datum/species/lizard/ashwalker
+	name = "Ash Walker"
+	id = "ashlizard"
+	limbs_id = "lizard"
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
+	inherent_traits = list(TRAIT_CHUNKYFINGERS)
+	mutantlungs = /obj/item/organ/lungs/ashwalker
+	mutanteyes = /obj/item/organ/eyes/night_vision
+	burnmod = 0.7
+	brutemod = 0.8

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3508,6 +3508,7 @@
 #include "modular_skyrat\code\modules\mob\living\ssd_indicator.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\auto_hiss.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\human.dm"
+#include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\furrypeople.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\humanoid.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\ipc.dm"
 #include "modular_skyrat\code\modules\mob\living\carbon\human\species_types\lizardpeople.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Originally done on Lumos Station, ported here

Xeno Hybrids:
- Now have xenomorph tongues
- Can speak xeno language

Ash Walkers:
-Have slightly increased burn resistance, mild brute resistance
-Have natural night vision eyes because Lavaland is fucking dark
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes sense, honestly, for both sides. Makes Ash Walker life a bit less shit and gives xenohybrids more fun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: gave xenohybrids a xeno tongue and xeno language, gave ash walkers night vision eyes
balance: Made ash walkers slightly more resistant to brute and burn damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
