### PR TITLE
[Map Edit] Some Security Changes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2745,7 +2745,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afL" = (
-/obj/machinery/computer/operating,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2761,6 +2760,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/blood,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afM" = (
@@ -3656,24 +3658,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ahu" = (
-/obj/structure/table/optable,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ahv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
@@ -55722,6 +55706,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"cSu" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/security/prison)
 "cSA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56128,6 +56116,20 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"cVW" = (
+/obj/structure/fans/tiny,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	name = "Atmospherics Connector";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cXU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light{
@@ -56293,35 +56295,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"dqN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Entrance";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "soli2";
-	name = "Solitary Cell 2";
-	pixel_x = 26;
-	pixel_y = -10;
-	req_access_txt = "3"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "soli2";
-	name = "Solitary 2 door timer";
-	pixel_x = 31;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "drO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56369,6 +56342,10 @@
 	},
 /turf/closed/wall,
 /area/science/circuit)
+"dws" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/security/prison)
 "dxe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/reinforced{
@@ -56465,18 +56442,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"dOj" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
-	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dPk" = (
 /obj/structure/closet{
 	name = "Costume Closet"
@@ -56503,6 +56468,15 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
+"dVe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "dWM" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -56601,16 +56575,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"emL" = (
-/obj/machinery/plate_chute/outputchute{
-	pixel_y = -25
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "enB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -56644,6 +56608,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
+"etV" = (
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "evR" = (
 /turf/open/floor/plating,
 /area/maintenance/bar)
@@ -56776,6 +56743,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eLi" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space southwest";
+	dir = 8;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "eMs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -56814,6 +56790,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"eUO" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleepers";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eVC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
@@ -57067,14 +57055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"fEj" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "fEw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57124,6 +57104,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"fMT" = (
+/obj/machinery/door/poddoor{
+	id = "soli1"
+	},
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
+/area/security/prison)
 "fOA" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -57163,12 +57151,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"fYb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "fZm" = (
 /obj/structure/chair/sofa/left,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57257,6 +57239,10 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"ghC" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "ghD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -57530,15 +57516,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"gXE" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "gZG" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/reagent_containers/glass/beaker/synthflesh,
@@ -57613,20 +57590,6 @@
 /obj/item/reagent_containers/food/snacks/cherrycupcake,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"hiG" = (
-/obj/structure/fans/tiny,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	name = "Atmospherics Connector";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hiV" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -57650,6 +57613,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hlT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "hlV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57701,20 +57669,16 @@
 /obj/structure/destructible/cult/tome,
 /turf/open/floor/carpet,
 /area/library)
+"hsc" = (
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hse" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"htK" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "hwJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57933,6 +57897,26 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/range)
+"ihb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"ihg" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space,
+/area/space/nearstation)
 "iiQ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57970,18 +57954,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ikr" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "imH" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -58055,6 +58027,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"iur" = (
+/obj/structure/fans/tiny,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Atmospherics Connector";
+	req_one_access_txt = "24"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iuJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58236,15 +58223,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"jdL" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jex" = (
 /obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
@@ -58390,6 +58368,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jzA" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "jAD" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -58434,11 +58416,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jDN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "jEc" = (
 /obj/machinery/vr_sleeper{
 	dir = 8
@@ -58923,6 +58900,12 @@
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kNk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "kNv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59030,6 +59013,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"ldT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space,
+/area/space/nearstation)
 "lhh" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -59079,23 +59071,24 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
-"lpM" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"lsg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "lsk" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"ltw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ltK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59114,12 +59107,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"lwX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/security/main)
 "lAa" = (
 /turf/open/floor/plating,
 /area/security/range)
@@ -59161,25 +59148,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"lIh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"lKA" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "lKL" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -59416,15 +59384,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mBO" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -59554,10 +59513,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"mZR" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
+"mYF" = (
+/obj/machinery/plate_chute/outputchute{
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "nat" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -59637,6 +59602,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"ngy" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced,
+/turf/open/space,
+/area/space/nearstation)
 "ngV" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -59671,6 +59641,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"noG" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space,
+/area/space/nearstation)
 "nqz" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -59703,6 +59681,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nwS" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nwX" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
@@ -59731,16 +59718,6 @@
 /obj/item/statuebust,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
-"nBb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nBM" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -59858,17 +59835,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"nSN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "nUV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59918,6 +59884,12 @@
 /obj/item/gun/ballistic/revolver/nagant,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"nZe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "nZE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -59999,14 +59971,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"oiR" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"ohN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Entrance";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/button/door{
+	id = "soli2";
+	name = "Solitary Cell 2";
+	pixel_x = 26;
+	pixel_y = -10;
+	req_access_txt = "3"
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/door_timer{
+	id = "soli2";
+	name = "Solitary 2 door timer";
+	pixel_x = 31;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
+"oiE" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northeast";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oiW" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -60077,6 +60079,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"ouv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/hug,
+/obj/item/razor{
+	pixel_x = -6
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ouQ" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -60226,11 +60240,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"oMT" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/fortunecookie,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "oMZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -60260,15 +60269,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/processing)
-"oPU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
 "oRg" = (
 /obj/structure/bed,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -60313,6 +60313,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/main)
+"oZb" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "oZc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -60339,9 +60342,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"oZv" = (
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "pek" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock"
@@ -60432,21 +60432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"pro" = (
-/obj/structure/fans/tiny,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Atmospherics Connector";
-	req_one_access_txt = "24"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "psk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60593,17 +60578,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"pMj" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 11;
-	height = 18;
-	id = "emergency_home";
-	name = "BoxStation emergency evac bay";
-	width = 30
-	},
-/turf/open/space/basic,
-/area/space)
 "pPi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60666,19 +60640,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"pWX" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"pXK" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qaY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -60784,13 +60745,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"qqx" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
 "qus" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -60808,6 +60762,12 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qwa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "qxq" = (
 /turf/closed/wall,
 /area/security/range)
@@ -60989,10 +60949,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"roQ" = (
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
 "rpS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -61037,6 +60993,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"rqI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "rqW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -61127,18 +61094,6 @@
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"rDu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rFw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61168,12 +61123,6 @@
 /obj/structure/sign/warning/docking,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"rJq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -61206,14 +61155,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"rPH" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
 "rPU" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -61315,6 +61256,15 @@
 	dir = 4
 	},
 /area/crew_quarters/fitness)
+"sdh" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "sea" = (
 /obj/item/melee/baton/cattleprod,
 /obj/item/stock_parts/cell/high,
@@ -61676,17 +61626,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"sVr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "sWR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -62225,11 +62164,24 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"uyW" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/fortunecookie,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "uzs" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
 /area/crew_quarters/fitness/pool)
+"uAx" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "uAH" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 8
@@ -62358,11 +62310,6 @@
 /obj/machinery/pool/drain,
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
-"uUd" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space/nearstation)
 "uVS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62408,6 +62355,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"vck" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vcN" = (
 /obj/machinery/light{
 	dir = 4
@@ -62474,6 +62431,18 @@
 /obj/item/instrument/trumpet,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"vjb" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vjm" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag,
@@ -62776,6 +62745,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"vUw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vZl" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red{
@@ -62880,15 +62853,6 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"wgd" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "wig" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -62898,6 +62862,12 @@
 "wkN" = (
 /turf/closed/wall,
 /area/science/circuit)
+"wmM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/security/main)
 "woR" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -62970,20 +62940,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"wvA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
 "wvX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"wxo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wxT" = (
 /obj/structure/chair/sofa/left,
 /obj/structure/window{
@@ -63013,6 +62975,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"wFd" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Southeast"
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/security/prison)
 "wGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -63210,20 +63179,6 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xez" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xfE" = (
 /obj/machinery/light{
 	light_color = "#c9d3e8"
@@ -63381,6 +63336,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"xrr" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 11;
+	height = 18;
+	id = "emergency_home";
+	name = "BoxStation emergency evac bay";
+	width = 30
+	},
+/turf/open/space/basic,
+/area/space)
 "xrN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -63448,6 +63414,15 @@
 /obj/item/radio/headset/headset_cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xBE" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northwest";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xCp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63509,11 +63484,30 @@
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/carpet,
 /area/library)
+"xHJ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xJT" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Prisoner-side";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xLX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -63576,6 +63570,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"xTM" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "xUe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -63584,12 +63586,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space/station_ruins)
-"xUD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "xUL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -63669,15 +63665,6 @@
 /obj/item/folder/blue,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"yin" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 
 (1,1,1) = {"
 cNd
@@ -84824,9 +84811,9 @@ aaa
 aaa
 aaa
 aaa
+xLX
 aaa
-aaa
-aaa
+xLX
 aaa
 aaa
 aaa
@@ -84889,7 +84876,7 @@ bgu
 bic
 bku
 bmh
-emL
+mYF
 aZE
 brM
 bts
@@ -85080,10 +85067,10 @@ aaj
 aaj
 aaj
 aaj
-aaj
+gXs
+gXs
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -85335,13 +85322,13 @@ gXs
 gXs
 gXs
 gXs
-pXK
+eLi
 gXs
-aaj
+gJi
+gJi
 aaa
-aaa
-aaa
-aaa
+gJi
+gJi
 aaa
 aaa
 aaa
@@ -85594,11 +85581,11 @@ aai
 aai
 aai
 gXs
-aaj
+oZb
+oZb
 aaa
-aaa
-aaa
-aaa
+oZb
+oZb
 aaa
 aaa
 aaa
@@ -85851,11 +85838,11 @@ aNt
 aRw
 aai
 gXs
-aaj
+oZb
 aaa
 aaa
 aaa
-aaa
+oZb
 aaa
 aaa
 aaa
@@ -86085,7 +86072,7 @@ cNd
 cNd
 cNd
 aaj
-wgd
+xBE
 aai
 aai
 aai
@@ -86108,11 +86095,11 @@ aat
 aSj
 aai
 gXs
-aaj
+oZb
 aaa
 aaa
 aaa
-aaa
+oZb
 aaa
 aaa
 aaa
@@ -86365,11 +86352,11 @@ aNG
 aSj
 aai
 gXs
-aaj
+oZb
 aaa
 aaa
 aaa
-aaa
+oZb
 jLl
 aaa
 aaa
@@ -86622,11 +86609,11 @@ abC
 aSo
 aai
 gXs
-aaj
+gXs
 aaa
 aaa
 aaa
-aaa
+gXs
 abc
 abc
 abc
@@ -86883,7 +86870,7 @@ gXs
 aaa
 aaa
 aaa
-aaa
+gXs
 abc
 aea
 aeH
@@ -87369,7 +87356,7 @@ aaj
 aaj
 aaj
 gXs
-pWX
+ghC
 aal
 aaw
 acE
@@ -88393,7 +88380,7 @@ cNd
 cNd
 aaj
 aak
-pWX
+ghC
 aal
 aaw
 aaA
@@ -88678,7 +88665,7 @@ amG
 aSG
 aUf
 aVG
-rDu
+ouv
 acd
 aXA
 bdV
@@ -89448,7 +89435,7 @@ aMp
 acJ
 aTq
 acJ
-dqN
+ohN
 acJ
 bae
 acJ
@@ -89704,7 +89691,7 @@ acd
 aLJ
 amG
 acd
-htK
+fMT
 acd
 aXO
 acd
@@ -89717,7 +89704,7 @@ fLS
 afG
 agj
 afL
-ahu
+aie
 aie
 aiO
 afn
@@ -89935,7 +89922,7 @@ cNd
 cNd
 aaj
 gXs
-pWX
+ghC
 aao
 aaw
 aaA
@@ -90740,7 +90727,7 @@ aaJ
 bgl
 bjW
 blN
-nBb
+vck
 aeT
 ahE
 agj
@@ -90967,7 +90954,7 @@ aaj
 aaj
 aaj
 gXs
-pWX
+ghC
 aao
 aaw
 ade
@@ -90983,7 +90970,7 @@ asY
 awN
 aEr
 amQ
-xez
+ltw
 asY
 alx
 awN
@@ -91504,7 +91491,7 @@ aMH
 aPP
 aai
 aUV
-jdL
+xJT
 aaJ
 bbr
 aaJ
@@ -91748,7 +91735,7 @@ ano
 atl
 aaU
 axm
-fYb
+kNk
 acd
 aBM
 aDJ
@@ -92011,11 +91998,11 @@ aBS
 aDJ
 aEu
 acd
-jDN
-fEj
+hlT
+uAx
 aGp
-oiR
-oMT
+xTM
+uyW
 aai
 aaa
 aai
@@ -92519,7 +92506,7 @@ anx
 ato
 avd
 axs
-fYb
+kNk
 acd
 aCm
 aDS
@@ -92778,7 +92765,7 @@ acd
 acd
 azd
 acd
-nSN
+ihb
 aDV
 aDV
 aFC
@@ -93033,7 +93020,7 @@ anN
 atu
 ave
 axv
-wvA
+dws
 acd
 aCo
 aDV
@@ -93281,7 +93268,7 @@ aaa
 aaa
 aaa
 iDo
-yin
+oiE
 aai
 adH
 ahO
@@ -93289,7 +93276,7 @@ aai
 aop
 aay
 aay
-lKA
+sdh
 azj
 acd
 aCq
@@ -93540,14 +93527,14 @@ aaa
 iDo
 gXs
 aai
-lsg
+dVe
 ahP
 aai
 aoq
 atz
 avf
 axx
-lIh
+xHJ
 acd
 aCx
 aDW
@@ -94063,7 +94050,7 @@ aat
 aos
 aos
 aai
-mZR
+cSu
 gXs
 gXs
 gXs
@@ -94320,7 +94307,7 @@ aWw
 aat
 aat
 aai
-mZR
+cSu
 aaj
 aaj
 aaj
@@ -94575,9 +94562,9 @@ aat
 xUe
 xUe
 xUe
-dOj
+eUO
 aai
-qqx
+wFd
 aaa
 aaa
 aaa
@@ -94825,16 +94812,16 @@ aaa
 iDo
 gXs
 aai
-lsg
+dVe
 aim
 amc
-wxo
-wxo
+vUw
+vUw
 aXs
 aat
 aat
 aai
-mZR
+cSu
 eRz
 ktS
 aaa
@@ -95082,7 +95069,7 @@ aaa
 iDo
 gXs
 aai
-sVr
+rqI
 aiQ
 aai
 apb
@@ -95091,7 +95078,7 @@ avm
 axR
 axR
 aai
-mZR
+cSu
 eRz
 ktS
 aaa
@@ -95116,7 +95103,7 @@ agx
 agZ
 ahI
 aiw
-lwX
+wmM
 jmg
 ake
 ame
@@ -95348,7 +95335,7 @@ aai
 aai
 aai
 aai
-mZR
+cSu
 eRz
 ktS
 aaa
@@ -99318,9 +99305,9 @@ bQA
 bPj
 bOh
 cCQ
-roQ
+hsc
 cyG
-rPH
+noG
 aoV
 aoV
 aoV
@@ -99576,8 +99563,8 @@ cdD
 bOh
 cCG
 cCS
-ikr
-oPU
+vjb
+ihg
 cCI
 cCI
 cCI
@@ -99832,9 +99819,9 @@ ccB
 cbH
 bOh
 aaf
-pro
+iur
 bOd
-hiG
+cVW
 aoV
 aoV
 aoV
@@ -100089,9 +100076,9 @@ ccD
 cbH
 bOh
 aaf
-uUd
-gXE
-rPH
+ngy
+nwS
+noG
 aaf
 aoV
 aoV
@@ -100346,9 +100333,9 @@ bOh
 bOh
 bOh
 aaf
-uUd
+ngy
 ciC
-mBO
+ldT
 bVu
 bVu
 bVu
@@ -101898,7 +101885,7 @@ uPT
 cmY
 cme
 cop
-oZv
+etV
 cmd
 cmd
 cqs
@@ -102155,7 +102142,7 @@ cmf
 cna
 cnC
 cor
-xUD
+qwa
 ciM
 cpN
 cqt
@@ -102412,7 +102399,7 @@ cme
 cmZ
 cme
 coq
-oZv
+etV
 cmd
 cmd
 cqs
@@ -102669,7 +102656,7 @@ dqu
 tXL
 cmd
 cos
-lpM
+jzA
 cmd
 czI
 aag
@@ -109027,7 +109014,7 @@ aJM
 aLa
 aFw
 hsb
-rJq
+nZe
 aQs
 aFu
 aTd
@@ -115969,7 +115956,7 @@ aaa
 aaa
 aaa
 aaa
-pMj
+xrr
 aaa
 aaa
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -265,6 +265,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
+"abx" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plating,
+/area/security/prison)
 "abC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -902,10 +914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"adC" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "adO" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -1223,23 +1231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"afg" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"afh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aft" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -1571,6 +1562,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"agR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "agS" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -1881,20 +1890,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
-"ahZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/flasher{
-	id = "visitflash";
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aid" = (
 /obj/docking_port/stationary{
 	dwidth = 2;
@@ -34221,6 +34216,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/shower{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bme" = (
@@ -34230,10 +34228,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/obj/structure/table/optable,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bmf" = (
@@ -34245,9 +34239,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/computer/operating{
-	dir = 1
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bmg" = (
@@ -117593,6 +117587,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"dSX" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "dSY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/green{
@@ -119495,19 +119499,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"dWY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "dXa" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -124690,55 +124681,72 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"emd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"eik" = (
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"emo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eqc" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"euS" = (
+"eki" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"emI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"epK" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"esa" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"eCG" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+"eye" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/item/reagent_containers/food/snacks/hotdog,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"eAr" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
 /turf/open/floor/plating,
+/area/security/prison)
+"eBd" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "eCJ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -124762,39 +124770,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"eEm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"eDm" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"eFr" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"eFJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"eIu" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "eJc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -124837,7 +124821,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"eMY" = (
+"eOC" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -124845,7 +124833,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/checker,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ePi" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -124854,12 +124842,23 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"eSc" = (
+"ePJ" = (
+/obj/structure/closet/crate/trashcart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"eSi" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "eTv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -124877,35 +124876,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"eTH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+"eWk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"eXd" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"eXR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/prison)
-"fau" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "faI" = (
 /obj/structure/cable/white{
@@ -124927,6 +124903,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"fbv" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Prisoner Arrivals";
+	dir = 8;
+	name = "aft camera"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fdi" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ffr" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fhE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -124964,30 +124969,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fjt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"fkp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"fmI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
+"fks" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "fno" = (
 /obj/effect/turf_decal/stripes/line{
@@ -125010,27 +124994,46 @@
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"fpA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fpQ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
 /area/science/mixing)
-"fxc" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"fBu" = (
+"frp" = (
 /obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/vr_sleeper{
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fti" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/circuit,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"fwb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/computer/security/telescreen{
+	name = "Prisoner Telescreen";
+	network = list("prison");
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "fCs" = (
 /obj/machinery/door/window/northright{
@@ -125042,27 +125045,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/chapel/office)
-"fCR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"fDf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+"fEJ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "fFK" = (
 /obj/machinery/ore_silo,
@@ -125082,23 +125070,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"fGC" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"fJr" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"fJC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/toy/cards/deck,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "fLh" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -125122,27 +125104,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"fOw" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"fRr" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
+"fQe" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/wood,
 /area/security/prison)
 "fRT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -125154,16 +125118,47 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fVi" = (
-/obj/effect/spawner/structure/window/reinforced,
+"fVA" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"fVW" = (
-/obj/structure/bookcase/random,
+"fWs" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/wood,
+/area/security/prison)
+"fWK" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Garden";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fXx" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "fXF" = (
 /obj/machinery/button/crematorium{
@@ -125190,10 +125185,46 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"gaP" = (
-/obj/machinery/plate_press,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plasteel/checker,
+"fYr" = (
+/obj/structure/table,
+/obj/item/paicard,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fYS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"fZm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fZP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "gbV" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -125207,27 +125238,26 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
-"gch" = (
-/obj/effect/turf_decal/tile/blue{
+"gdk" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/washing_machine,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"gcA" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
+"ghS" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
+/area/security/prison)
+"gix" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "giN" = (
 /obj/structure/window/reinforced{
@@ -125236,20 +125266,17 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/chapel/office)
-"glP" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pressing Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "gmj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gnY" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "gut" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -125263,63 +125290,71 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"gxS" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
+"guN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"gvp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"gzh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"gzY" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
+"gAd" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Security - Prison Port"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "gBd" = (
 /turf/open/floor/plasteel,
 /area/security/prison)
-"gBT" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"gFD" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
+"gHx" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleepers";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"gDP" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gDQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gGu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gHg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/security/prison)
 "gKo" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -125336,11 +125371,18 @@
 	},
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
-"gLd" = (
+"gKJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "gLe" = (
 /obj/effect/turf_decal/delivery,
@@ -125375,6 +125417,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"gOg" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gOr" = (
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"gPk" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gPv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -125393,22 +125457,6 @@
 "gSi" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
-"gTf" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gUH" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -125440,14 +125488,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
-"hds" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
+"haq" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/storage/photo_album,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "hdH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -125457,6 +125507,10 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"hfL" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hic" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -125470,38 +125524,17 @@
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/r_wall,
 /area/chapel/office)
-"hpd" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/security/prison)
-"hpu" = (
+"hrf" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hqu" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"hqO" = (
-/obj/structure/chair/stool,
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"hrl" = (
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hrP" = (
@@ -125523,81 +125556,55 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"htx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"huu" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"hBa" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/item/reagent_containers/syringe,
+"htG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/machinery/camera{
+	c_tag = "Permabrig Prisoner Processing";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"hBx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
+/obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hDf" = (
-/obj/effect/turf_decal/stripes/line{
+"hwL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig East Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hEY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = -5
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -125609,6 +125616,12 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/space,
 /area/space/nearstation)
+"hFP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hGT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/white{
@@ -125632,22 +125645,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hIG" = (
-/obj/machinery/shower{
+"hLd" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/item/soap,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"hNi" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+"hNw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hNZ" = (
@@ -125662,17 +125677,6 @@
 /obj/item/restraints/handcuffs/fake,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"hQe" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hSf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -125693,61 +125697,68 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"hVw" = (
+"hXb" = (
+/obj/structure/table,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"hXi" = (
+/obj/machinery/deepfryer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "iaF" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
-"ifV" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
+"idH" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel,
+/area/security/prison)
+"iel" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "iho" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
 /area/medical/surgery)
-"iim" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"iiy" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"iiq" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "ijB" = (
 /obj/structure/reagent_dispensers/keg/aphro/strong,
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"ile" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"ilt" = (
+/obj/structure/chair/stool,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cafeteria";
+	network = list("ss13","prison")
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"ime" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ioW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -125766,18 +125777,36 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"itw" = (
-/obj/effect/turf_decal/tile/red{
+"iqR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
+"irO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ish" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
+/area/security/prison)
+"isr" = (
+/obj/item/caution,
+/obj/item/caution,
+/turf/open/floor/plating,
 /area/security/prison)
 "iwL" = (
 /obj/machinery/status_display/evac{
@@ -125797,51 +125826,75 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"iyP" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"iBQ" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"iDN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"iCl" = (
+/obj/structure/lattice,
 /obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
+	c_tag = "Permabrig Space Northwest";
+	dir = 1;
+	name = "aft camera"
 	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"iGL" = (
-/obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"iIM" = (
-/obj/structure/toilet{
-	dir = 8
+"iHR" = (
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/light/small{
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"iII" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/fortunecookie,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"iIM" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"iJN" = (
-/obj/machinery/hydroponics/constructable,
+"iJZ" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/security/prison)
+"iLM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"iPE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
+"iNx" = (
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"iPL" = (
+/obj/machinery/shower{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"iQe" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -125861,13 +125914,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"iQr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "iQI" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -125892,52 +125938,46 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"iVu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"iUC" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"iVK" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"iWy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"iZz" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
+"iYE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/wood,
 /area/security/prison)
-"jcx" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
+"jbQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/security/prison)
+"jca" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 3;
+	name = "Docking Beacon";
+	picked_color = "Burgundy"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jdO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -125950,6 +125990,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jdQ" = (
+/obj/machinery/plate_press,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"jdY" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jeu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -125959,17 +126014,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
-"jiJ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"jfn" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jjN" = (
 /obj/structure/table/reinforced,
@@ -125987,13 +126042,14 @@
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
-"jnL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"joY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/white,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jqM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -126012,18 +126068,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
-"jrI" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "juf" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/effect/turf_decal/stripes/line{
@@ -126070,6 +126114,29 @@
 /mob/living/simple_animal/pet/bumbles,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jxP" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"jyc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jzS" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Showers"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "jBE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -126084,30 +126151,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
-"jBH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+"jDx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison)
+"jDy" = (
+/obj/machinery/shower{
 	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"jHY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/prison)
-"jCS" = (
+"jIX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/cryopod{
 	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"jEX" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -126132,6 +126197,15 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"jQw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jRy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -126142,6 +126216,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"jRK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jSe" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/spawner/structure/window/reinforced,
@@ -126152,10 +126235,42 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/science/mixing)
-"jXq" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
+"jSf" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
+"jWF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jWU" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/plate_chute/outputchute{
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "kam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
@@ -126164,19 +126279,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"kgu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"kfX" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "kiJ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -126194,25 +126305,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"knK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"klA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"knS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kpO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"knU" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"kok" = (
+/obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"kpF" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northeast";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "krb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -126229,17 +126348,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"krH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/jukebox{
-	req_one_access = null
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ktm" = (
-/obj/item/toy/beach_ball/holoball,
+"ktI" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole,
 /turf/open/floor/wood,
 /area/security/prison)
 "kvf" = (
@@ -126253,18 +126364,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"kxo" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/security/prison)
-"kyc" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kyo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -126279,75 +126378,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"kzG" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"kBy" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kCb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"kEx" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kEQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kFt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"kHV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
+"kIu" = (
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
-/area/security/prison)
-"kHZ" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "kKn" = (
 /obj/structure/window/reinforced{
@@ -126362,12 +126395,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"kKK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "kLu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -126383,18 +126410,49 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"kOb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"kNU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"kYk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kPJ" = (
-/obj/machinery/door/airlock/glass{
-	name = "Storage"
-	},
+"kYo" = (
+/obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"kZw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -126403,64 +126461,68 @@
 	dir = 10
 	},
 /area/science/circuit)
-"laI" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/security/prison)
-"lde" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"lfj" = (
-/obj/effect/turf_decal/tile/red{
+"laq" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"lbk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lid" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"lcM" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"loe" = (
+"llG" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"lmR" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"lnA" = (
 /obj/structure/rack,
 /obj/item/flashlight,
 /obj/item/storage/bag/trash,
 /obj/item/radio/off,
 /turf/open/floor/plating,
-/area/security/prison)
-"loi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"loG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/security/prison)
 "loI" = (
 /obj/machinery/autolathe,
@@ -126479,33 +126541,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"lpk" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lqp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lti" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped,
 /obj/effect/turf_decal/tile/neutral{
@@ -126520,23 +126555,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"lue" = (
-/obj/structure/lattice,
+"luC" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
+	c_tag = "Permabrig Space West";
+	dir = 8;
 	name = "aft camera"
 	},
-/turf/open/space/basic,
+/turf/open/space,
 /area/space/nearstation)
-"luB" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
+"lvb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"lwS" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "lyU" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
@@ -126544,11 +126587,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
-"lzq" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space/basic,
-/area/space/nearstation)
+"lzi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lzF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -126565,6 +126607,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"lBi" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lDl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -126576,10 +126631,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
-"lEd" = (
-/obj/item/bedsheet/rd/royal_cape,
-/obj/structure/bed/pod,
-/turf/open/floor/plasteel/vaporwave,
+"lEk" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "lEl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -126608,11 +126671,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"lGl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"lFE" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"lIs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "lKu" = (
 /obj/effect/turf_decal/stripes/line{
@@ -126634,33 +126706,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"lNz" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"lNL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lOu" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "lOY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -126670,23 +126715,20 @@
 	dir = 6
 	},
 /area/science/circuit)
-"lPd" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/wood,
-/area/security/prison)
-"lQZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lRf" = (
-/obj/machinery/shower{
+"lRC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"lRW" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/item/instrument/accordion,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "lTo" = (
 /obj/docking_port/stationary{
@@ -126719,18 +126761,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"lVc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"lVh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
 "lXF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -126750,13 +126785,16 @@
 	dir = 1
 	},
 /area/science/circuit)
-"lYa" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+"lZP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -126770,27 +126808,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"mdU" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"mcK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/security/prison)
+"meg" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"mep" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"mhQ" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
+"mfX" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Sleepers"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -126812,25 +126844,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"mmo" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"moj" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"moT" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"mpj" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "mpP" = (
 /obj/structure/cable/white{
@@ -126847,12 +126882,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"mtd" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
+"msd" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"muv" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/circuit,
+/area/security/prison)
+"muR" = (
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -126871,14 +126917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
-"mvq" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mvx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -126888,100 +126926,59 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"mvO" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"mwy" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mxm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
-"mzu" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
+"mxY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"mCF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"mze" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"mDL" = (
-/obj/item/caution,
-/obj/item/caution,
-/turf/open/floor/plating,
-/area/security/prison)
-"mDY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"mBo" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
 "mIi" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"mIB" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
+"mIX" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"mJh" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"mIJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+"mJt" = (
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"mLc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"mLw" = (
+/obj/machinery/shower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/item/soap,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "mLI" = (
 /obj/machinery/door/airlock/external{
@@ -126994,13 +126991,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"mOh" = (
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "mPj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/chapel/office)
-"mPR" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "mQE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -127013,24 +127010,42 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mUA" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"mQN" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "sexroom"
 	},
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/turf/open/floor/plasteel,
+/area/security/prison)
+"mTY" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/glass/bottle/charcoal,
+/obj/item/reagent_containers/syringe,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
+"mWd" = (
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"mVH" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+"mWl" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -127045,81 +127060,134 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
-"mZq" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"mYL" = (
+/obj/machinery/door/poddoor{
+	id = "soli1"
 	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
+/area/security/prison)
+"naw" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "nbW" = (
 /obj/structure/grille,
 /turf/open/space,
 /area/space/nearstation)
-"nhw" = (
+"ncl" = (
 /obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ndS" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"neb" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nfP" = (
+/obj/machinery/door/airlock/glass{
+	name = "Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
-"nmD" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
+"nlg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/open/floor/circuit,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
-"nnZ" = (
-/obj/structure/window/reinforced,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nvu" = (
+"nmE" = (
+/obj/structure/punching_bag,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nnk" = (
+/obj/structure/bookcase/random,
 /turf/open/floor/wood,
+/area/security/prison)
+"npQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "nyN" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"nAS" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Visitation - Visitors";
-	req_access_txt = "3"
+"nyV" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nCQ" = (
+"nAz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"nBk" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nDl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+"nCC" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nFW" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -127128,57 +127196,60 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/office)
-"nKM" = (
+"nGc" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nId" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"nJo" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nLM" = (
-/obj/effect/turf_decal/tile/red{
+"nLr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/machinery/vr_sleeper{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/circuit,
+/area/security/prison)
+"nMa" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nLP" = (
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Processing";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "nNX" = (
@@ -127189,15 +127260,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
-"nOk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nQR" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/shuttle/mining/common,
@@ -127220,77 +127282,129 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ohk" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
+"nWc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
-"omZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"oww" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oxO" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"oyY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ozi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oAB" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oBW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oEA" = (
+"oef" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
+/area/security/prison)
+"oeh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ofR" = (
+/obj/machinery/computer/security/telescreen{
+	name = "Prisoner Telescreen";
+	network = list("prison");
+	pixel_y = 32
+	},
+/turf/open/space/basic,
+/area/space)
+"ohq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
+"ojB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"okb" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"okV" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"opV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"osQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"ovs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oDD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oFs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oFu" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"oGT" = (
+/obj/structure/chair/stool,
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "oHk" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -127308,6 +127422,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"oIk" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/security/prison)
 "oIl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -127331,30 +127449,17 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
-"oJt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"oLT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"oKi" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"oLu" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall/r_wall,
 /area/security/prison)
 "oMw" = (
 /obj/docking_port/stationary/public_mining_dock{
@@ -127382,12 +127487,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"oNj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"oQM" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleeper Hallway";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"oRG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -127424,11 +127539,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"oVB" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space,
-/area/space/nearstation)
+"oVk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "oYI" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -127463,22 +127580,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"pcP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"pcG" = (
+/obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
+"pdq" = (
+/obj/structure/table,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"pdv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"pdz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "pfC" = (
 /obj/machinery/seed_extractor,
@@ -127498,26 +127629,6 @@
 /area/hydroponics/garden/abandoned{
 	name = "Maintenance Garden"
 	})
-"pme" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pmH" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "pmQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
@@ -127528,10 +127639,6 @@
 	dir = 1
 	},
 /area/science/circuit)
-"pmT" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "pnK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/brown{
@@ -127548,6 +127655,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"pnW" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "poI" = (
 /obj/structure/bed,
 /obj/item/tank/internals/anesthetic,
@@ -127555,26 +127673,33 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"pqo" = (
+"ppo" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pqx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"ppr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"prl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "psi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -127593,6 +127718,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"ptv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Pressing Room";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ptI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -127600,76 +127736,7 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
-"puB" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pxJ" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
-"pDf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pDz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pEm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"pGV" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"pJJ" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pKk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pMo" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/security/prison)
-"pPs" = (
+"ptJ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -127678,13 +127745,64 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pPJ" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+"ptK" = (
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/wood,
+/area/security/prison)
+"pwm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"pAb" = (
+/obj/structure/lattice,
+/obj/machinery/camera,
+/turf/open/space/basic,
+/area/space/nearstation)
+"pHs" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pJo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"pMe" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"pMf" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space East";
+	dir = 4;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"pMN" = (
+/turf/open/floor/plasteel/elevatorshaft,
 /area/security/prison)
 "pQm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -127703,37 +127821,82 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
-"pUE" = (
-/obj/machinery/holopad,
+"pRV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pUP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pVn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pWa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"qcv" = (
+"pUT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pUZ" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"pYn" = (
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"pZk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pZq" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Pressing Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"pZN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qeN" = (
@@ -127751,6 +127914,17 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"qgJ" = (
+/obj/structure/bed,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "qhc" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -127760,37 +127934,22 @@
 	dir = 9
 	},
 /area/science/circuit)
-"qkK" = (
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
+"qlO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"qlq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "qnx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"qnG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "qoc" = (
 /obj/machinery/door/window/northleft{
 	name = "Mass Driver"
@@ -127801,39 +127960,67 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
+"qol" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "qpq" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
 /area/science/circuit)
-"qsI" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+"qru" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"quZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/conveyor/auto{
-	dir = 8
+/obj/machinery/button/flasher{
+	id = "permalock";
+	pixel_x = 6;
+	pixel_y = 36;
+	req_access_txt = "3"
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qts" = (
-/obj/structure/table,
+"qvf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"qxg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/button/door{
+	id = "visitexit";
+	name = "Visitation Prisoner Lockdown";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qym" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	network = list("ss13","prison")
+"qzh" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "qAV" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -127843,133 +128030,80 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"qBF" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qBG" = (
 /obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"qBO" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"qCP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/computer/security/telescreen{
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qGl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+"qDd" = (
 /turf/open/floor/wood,
 /area/security/prison)
-"qJm" = (
-/obj/machinery/holopad,
+"qDh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qQY" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"qRi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qSg" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/plate_chute/outputchute{
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"qSl" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleeper Hallway";
-	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"qTI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"qTS" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Visitor-side";
-	dir = 8;
-	network = list("s13","prison");
-	start_active = 1
+"qKr" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/obj/machinery/button/door{
-	id = "sexroom";
-	name = "Conjugal Visits";
-	pixel_x = 27;
-	pixel_y = 1;
-	req_access_txt = "3"
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/security/prison)
+"qKF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qKL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qTZ" = (
+"qMl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qMX" = (
 /obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
+/obj/machinery/camera,
+/turf/open/space,
 /area/space/nearstation)
-"qUx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
+"qOt" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
 /area/security/prison)
 "qYM" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space/station_ruins)
-"rag" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ray" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -127991,25 +128125,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"rdr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"rek" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rhO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -128018,13 +128133,14 @@
 	dir = 9
 	},
 /area/science/circuit)
-"rih" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"riR" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "rjr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -128033,40 +128149,44 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"rjE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Sleepers"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rjW" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Arrivals";
-	dir = 8;
-	name = "aft camera"
-	},
+"rmQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rpt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "rqh" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"rAH" = (
+"rqk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rrw" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"rrL" = (
+/obj/machinery/plate_chute/inputchute{
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"rAu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -128082,48 +128202,13 @@
 	dir = 6
 	},
 /area/science/circuit)
-"rDu" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera{
-	c_tag = "Permabrig Library";
-	network = list("ss13","prison")
+"rHi" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
-"rDN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rER" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rGk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rGN" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "rIi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -128138,20 +128223,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"rKr" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"rKv" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+"rJD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "rKU" = (
 /obj/structure/cable/white{
@@ -128166,51 +128244,63 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"rMS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"rLY" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"rPJ" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"rMo" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space West";
+	dir = 8;
+	name = "aft camera"
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"rPP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/turf/open/space/basic,
+/area/space/nearstation)
+"rMr" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rQK" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rTq" = (
-/obj/structure/holohoop,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rNk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Laundry";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rPB" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"rQg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "rUD" = (
 /obj/machinery/meter,
@@ -128246,81 +128336,41 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"rVg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
-"rVX" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rWQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rXf" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"rZL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/button/flasher{
-	id = "permalock";
-	pixel_x = 6;
-	pixel_y = 36;
-	req_access_txt = "3"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"rYL" = (
+/obj/machinery/newscaster,
+/turf/closed/wall,
 /area/security/prison)
 "saw" = (
 /turf/closed/wall,
 /area/science/circuit)
-"sbn" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
-	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sbQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"seO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"sbI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"scu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"sdc" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"seh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "sfo" = (
 /obj/effect/decal/remains/xeno,
@@ -128329,85 +128379,47 @@
 "sfL" = (
 /turf/open/space,
 /area/space)
-"shX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sjy" = (
-/obj/machinery/deepfryer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"slV" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"sjU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+"smZ" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"sny" = (
+/obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/security/prison)
-"suh" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
+"spl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
+/area/security/prison)
+"spm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "svv" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"swp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sww" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/chapel/office)
-"syh" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"sza" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"szr" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/security/prison)
-"sAA" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"sBc" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/turf/open/floor/plating,
 /area/security/prison)
 "sCQ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -128423,59 +128435,72 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"sDj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
+"sFN" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Showers";
 	dir = 4;
-	light_color = "#c1caff"
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sIF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sLO" = (
 /obj/structure/sign/poster/official/random{
-	pixel_y = -32
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"sOe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"sHi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"sSu" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/jukebox{
+	req_one_access = null
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"sTP" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sUa" = (
+"sHY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"sNC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/flasher{
+	id = "visitflash";
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"sOx" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
+"sPC" = (
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sTH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "sVX" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -128496,83 +128521,89 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"sZF" = (
-/obj/machinery/shower{
-	dir = 8
+"sXF" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"tbd" = (
-/obj/structure/table,
+"sYd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/camera{
+	c_tag = "Permabrig Kitchen";
+	network = list("ss13","prison")
+	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
-"tbT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"taK" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"tdi" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel,
+"tdF" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"tfH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tfL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"tfO" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plating,
-/area/security/prison)
-"thA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"tiw" = (
+"tfA" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"tkT" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+"tgs" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"thf" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"tih" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tiE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"tjR" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tmi" = (
@@ -128581,11 +128612,52 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"tmj" = (
+"tng" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tni" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tpd" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"tul" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tuP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/checker,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "twt" = (
 /obj/machinery/vr_sleeper,
@@ -128594,31 +128666,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"twT" = (
+"txs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"txS" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"txX" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"tyb" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"tys" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"tzW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/reagent_containers/dropper,
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"tyY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+"tAO" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "visitexit";
-	name = "Visitation Prisoner Lockdown";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tBE" = (
@@ -128639,43 +128720,24 @@
 "tCh" = (
 /turf/closed/wall,
 /area/science/misc_lab)
-"tCV" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"tFw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"tHP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"tHn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tJW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"tLr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"tJD" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Visitation - Visitors";
+	req_access_txt = "3"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tMk" = (
@@ -128683,36 +128745,12 @@
 	dir = 10
 	},
 /area/science/misc_lab)
-"tNi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tNq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"tNz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+"tPj" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
 /turf/open/floor/plasteel/white,
-/area/security/prison)
-"tNI" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
 /area/security/prison)
 "tRT" = (
 /obj/effect/turf_decal/tile/blue{
@@ -128724,6 +128762,17 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tSX" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tVN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -128740,72 +128789,69 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"tZN" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/security/prison)
-"uar" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ugk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"tWu" = (
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
 	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"uhs" = (
-/obj/machinery/hydroponics/constructable,
+"ucM" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ujT" = (
-/obj/effect/turf_decal/tile/blue{
+"udb" = (
+/obj/structure/holohoop,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"udw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"ujZ" = (
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/turf/open/floor/wood,
+/area/security/prison)
+"uke" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"ulp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
 /area/security/prison)
 "upk" = (
 /obj/machinery/door/airlock/public/glass{
@@ -128839,9 +128885,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"uqa" = (
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "uuP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -128855,60 +128898,56 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"uwL" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"uCb" = (
-/obj/structure/bed,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+"uyR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"uCR" = (
-/obj/machinery/light{
+/obj/machinery/firealarm{
 	dir = 1;
-	light_color = "#cee5d2"
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"uJJ" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
+"uzW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
-"uKo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"uMj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"uAi" = (
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uCa" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uEN" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uMd" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "uNP" = (
@@ -128928,24 +128967,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"uPx" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
+"uRL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
-"uPV" = (
+"uTm" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"uRP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -128953,12 +128988,23 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"uXe" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uXt" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "uYS" = (
 /obj/machinery/door/airlock/atmos/glass/critical{
@@ -128971,38 +129017,69 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"vaB" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/holopad,
+"vaw" = (
+/obj/structure/weightmachine/weightlifter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"vgj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"vha" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "vhA" = (
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"vjZ" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"vkn" = (
+"vik" = (
 /obj/machinery/light,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"vkF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vmA" = (
+"vjh" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"vkX" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"vpb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vpn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vqK" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -129010,20 +129087,20 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vnm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"vsC" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"voI" = (
+"vxd" = (
+/obj/item/bedsheet/rd/royal_cape,
+/obj/structure/bed/pod,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison)
+"vyH" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
 	c_tag = "Permabrig Space North";
@@ -129032,42 +129109,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"vpu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vqc" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vrI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vAb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -129077,17 +129118,36 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"vAO" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "vAW" = (
 /obj/machinery/requests_console{
 	department = "Prison";
 	departmentType = 1
 	},
 /turf/closed/wall,
+/area/security/prison)
+"vBX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/obj/machinery/button/door{
+	id = "soli1";
+	name = "Solitary Cell 1";
+	pixel_x = 26;
+	pixel_y = 10;
+	req_access_txt = "3"
+	},
+/obj/machinery/door_timer{
+	id = "soli1";
+	name = "Solitary 1 door timer";
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "vEq" = (
 /obj/structure/cable/white{
@@ -129105,190 +129165,156 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"vEA" = (
+"vOv" = (
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vRG" = (
 /obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"vGe" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"vGF" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vNU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+"vTA" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"vTG" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
+"vWt" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/space,
-/area/space/nearstation)
-"vWh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vWu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"waM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wei" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"weG" = (
-/obj/machinery/cryopod{
+"weT" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"wfb" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Security - Prison Port"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wgE" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/security/prison)
-"wiA" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wmt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"woC" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"wrf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"wuX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wwM" = (
+"wfW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Laundry"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wiA" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"wlQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"woS" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/security/prison)
+"wpn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wps" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"wqq" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"wqU" = (
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wwj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wwo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison)
 "wAA" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"wBe" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wBr" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wBv" = (
-/obj/structure/sink{
+"wAU" = (
+/obj/machinery/light{
 	dir = 4;
-	pixel_x = 11
+	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "wBO" = (
 /obj/structure/cable/white{
@@ -129301,51 +129327,39 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"wCC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"wCe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wCo" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"wEL" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "wIf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wKm" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
-/area/security/prison)
-"wLW" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wNo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"wPg" = (
-/obj/machinery/computer/security/telescreen{
-	name = "Prisoner Telescreen";
-	network = list("prison");
-	pixel_y = 32
-	},
-/turf/open/space/basic,
-/area/space)
-"wSF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xaf" = (
@@ -129366,28 +129380,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"xaH" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge West";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xby" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xbV" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "xdp" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -129399,20 +129391,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"xdL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xdZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -129427,6 +129405,36 @@
 	heat_capacity = 1e+006
 	},
 /area/maintenance/port/aft)
+"xfA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xit" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"xkr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/security/prison)
+"xlv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "xmt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -129436,45 +129444,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"xtU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"xnZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 0
 	},
-/obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xuu" = (
 /obj/effect/landmark/barthpot,
 /turf/open/floor/wood,
 /area/library)
-"xuB" = (
-/obj/effect/turf_decal/tile/blue{
+"xwk" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xvs" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xwy" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/instrument/accordion,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xwK" = (
@@ -129492,6 +129485,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"xxH" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/security/prison)
 "xze" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -129502,13 +129499,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
-"xCi" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xCB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -129526,12 +129516,16 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"xCK" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+"xDX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "xDZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -129558,21 +129552,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xJI" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/fortunecookie,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"xKc" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xKS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -129586,6 +129565,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"xKW" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xMn" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -129594,49 +129577,34 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
-"xMU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "xOo" = (
 /obj/machinery/light/small,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
-"xPJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xQs" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xVr" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"xWx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"xRb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"xRi" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge West";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xUc" = (
 /obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -129645,21 +129613,35 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"xZD" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
-/area/security/prison)
 "xZM" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
-"yax" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
+"xZV" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ydO" = (
+"ygN" = (
+/obj/structure/filingcabinet,
+/obj/machinery/camera{
+	c_tag = "Permabrig Library";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/wood,
 /area/security/prison)
 "yiv" = (
@@ -129676,6 +129658,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"yiA" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "yjc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research/abandoned";
@@ -129688,15 +129677,38 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
-"ylm" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"ylA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"yjz" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Visitor-side";
+	dir = 8;
+	network = list("s13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/button/door{
+	id = "sexroom";
+	name = "Conjugal Visits";
+	pixel_x = 27;
+	pixel_y = 1;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ykd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"ykW" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ylh" = (
+/obj/structure/window/reinforced,
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 
 (1,1,1) = {"
@@ -174751,7 +174763,7 @@ aoE
 aty
 auH
 aoF
-qSg
+jWU
 ayB
 azE
 azE
@@ -178097,7 +178109,7 @@ aaa
 abj
 abj
 abj
-vTG
+luC
 abj
 abj
 abj
@@ -178338,21 +178350,21 @@ oZp
 oZp
 oZp
 oZp
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
+smZ
 rqh
 aFm
 aFm
@@ -178361,8 +178373,8 @@ aFm
 aFm
 aFm
 aFm
-lzq
-xVr
+pAb
+smZ
 aaa
 aaa
 aaa
@@ -178595,7 +178607,7 @@ oZp
 oZp
 oZp
 oZp
-xVr
+smZ
 rqh
 rqh
 rqh
@@ -178606,20 +178618,20 @@ rqh
 rqh
 rqh
 rqh
-pGV
+rMo
 rqh
 rqh
 rqh
 rqh
 aFm
-iiy
-puB
-uhs
-ifV
-jiJ
+weT
+iQe
+fWK
+rMr
+xwk
 aFm
 rqh
-xVr
+smZ
 aaa
 aaa
 aaa
@@ -178852,8 +178864,8 @@ oZp
 oZp
 oZp
 oZp
-xVr
-rGN
+smZ
+iCl
 aFm
 aFm
 aFm
@@ -178869,14 +178881,14 @@ aFm
 aFm
 aFm
 aFm
-wBr
+kfX
 gBd
-iJN
+knU
 gBd
-afg
+mJh
 aFm
 rqh
-xVr
+smZ
 aaa
 aaa
 aaa
@@ -179109,31 +179121,31 @@ oZp
 oZp
 oZp
 oZp
-xVr
+smZ
 rqh
 aFm
-gaP
-omZ
-qkK
+jdQ
+ptv
+rrL
 aFm
-iVK
-xbV
-woC
-iVK
-hIG
+jxP
+rPB
+sFN
+jxP
+mLw
 aKV
-ujT
-vpu
-iVu
+llG
+rNk
+qKF
 aKV
-tdi
-qRi
-vaB
-sIF
-afg
+eDm
+rqk
+meg
+vpn
+mJh
 aFm
 rqh
-xVr
+smZ
 aaa
 aaa
 aaa
@@ -179366,31 +179378,31 @@ oZp
 oZp
 oZp
 oZp
-xVr
+smZ
 rqh
 aFm
-gaP
-ohk
-jrI
+jdQ
+laq
+tgs
 aFm
-uCR
-eqc
-eqc
-rdr
-kzG
+oFu
+txS
+txS
+iel
+iHR
 aKV
-gch
-wLW
-mIB
+lBi
+qzh
+vik
 aKV
-wiA
-sUa
+uMd
+opV
 gBd
-kOb
-xQs
+mze
+lEk
 aFm
 rqh
-xVr
+smZ
 aaa
 aaa
 aaa
@@ -179405,7 +179417,7 @@ aaa
 bgZ
 biz
 bkk
-rAH
+rAu
 bnG
 bpf
 brg
@@ -179621,33 +179633,33 @@ aaa
 aaa
 oZp
 oZp
-xVr
-xVr
-xVr
+smZ
+smZ
+smZ
 rqh
 aFm
-gaP
-eMY
-tmj
+jdQ
+sHY
+qvf
 aFm
-lRf
-tCV
-eqc
-sZF
-tCV
+iPL
+jDy
+txS
+naw
+jDy
 aKV
-gch
-xuB
-emo
+lBi
+jQw
+lmR
 aKV
-fOw
-suh
-tkT
-jEX
-wBv
+ucM
+eOC
+uCa
+jdY
+tul
 aFm
 rqh
-pxJ
+wqq
 aaa
 aaa
 aaa
@@ -179660,8 +179672,8 @@ aFm
 aFm
 aaa
 bgZ
-hBa
-xCK
+mTY
+sOx
 bmd
 bnG
 bpg
@@ -179878,29 +179890,29 @@ aaa
 aaa
 oZp
 oZp
-xVr
+smZ
 rqh
 rqh
 rqh
 aFm
 aFm
-ulp
-glP
+emI
+pZq
 aFm
-eXR
+jDx
 aKV
-wrf
-tiw
-aKV
-aKV
-eXR
-wwM
-tiw
+jzS
+wwo
 aKV
 aKV
-eXR
-xZD
-uPV
+jDx
+wfW
+wwo
+aKV
+aKV
+jDx
+oIk
+klA
 aFm
 aFm
 rqh
@@ -180133,31 +180145,31 @@ aaa
 aaa
 aaa
 aaa
-xVr
-xVr
-xVr
+smZ
+smZ
+smZ
 rqh
-jXq
-tfL
-uwL
-vGF
-fDf
-mDY
-wBe
-itw
-rVX
-qcv
-pcP
-tNi
-vmA
-itw
-qcv
-nDl
-vrI
-qcv
-iWy
-qcv
-fCR
+kok
+ojB
+okV
+frp
+xUc
+qlO
+vqK
+hrf
+lFE
+gdk
+oDD
+gKJ
+xfA
+hrf
+gdk
+oLT
+jWF
+gdk
+kYk
+gdk
+jyc
 aFm
 aFm
 rqh
@@ -180390,40 +180402,40 @@ aaa
 aaa
 aaa
 aaa
-xVr
+smZ
 rqh
 rqh
 rqh
-kCb
-xtU
+sTH
+pZN
 gBd
-tLr
-vWh
-xvs
-seO
-kBy
-mIJ
-oAB
-mIJ
-kBy
-mIJ
-kBy
-mIJ
-oAB
-mIJ
-mIJ
-swp
-qJm
-rER
+qKL
+sza
+tfA
+tng
+nyV
+nJo
+ffr
+nJo
+nyV
+nJo
+nyV
+nJo
+ffr
+nJo
+nJo
+nGc
+esa
+uyR
 aFm
-lzq
+pAb
 rqh
-pxJ
-pxJ
-pxJ
-pxJ
-pxJ
-pxJ
+wqq
+gFD
+wqq
+wqq
+wqq
+wqq
 aFm
 aZm
 bbb
@@ -180645,19 +180657,19 @@ aaa
 aaa
 aaa
 oZp
-xVr
-xVr
-xVr
+smZ
+smZ
+smZ
 rqh
 aFm
-tfL
+ojB
 aFm
-xby
+sXF
 gBd
-iim
-fxc
-kHZ
-uJJ
+pRV
+ykW
+vRG
+woS
 aKV
 aKV
 aKV
@@ -180670,8 +180682,8 @@ aKV
 aKV
 aKV
 aKV
-lYa
-kyc
+hLd
+idH
 aFm
 rqh
 rqh
@@ -180902,32 +180914,32 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 rqh
 rqh
-kCb
-rag
-xaH
-hVw
-lQZ
-kEQ
-kEx
-mUA
+sTH
+vOv
+xRi
+hFP
+lbk
+pHs
+uEN
+fJr
 aKV
-uCb
-pmH
+qgJ
+tWu
 aKV
-mpj
-pmH
+jfn
+tWu
 aKV
-uCb
-pmH
+qgJ
+tWu
 aKV
-mpj
-pmH
+jfn
+tWu
 aKV
-pqo
+riR
 gBd
 aFm
 aFm
@@ -181159,38 +181171,38 @@ aaa
 aaa
 aaa
 oZp
-xVr
-voI
-jXq
-tfL
-uwL
-hQe
+smZ
+vyH
+kok
+ojB
+okV
+ime
 gBd
-hVw
+hFP
 gBd
-iim
-jcx
-qts
+pRV
+fdi
+lcM
 aKV
-gLd
-ugk
+irO
+sbI
 aKV
-gLd
-ugk
+irO
+sbI
 aKV
-gLd
-ugk
+irO
+sbI
 aKV
-gLd
-ugk
+irO
+sbI
 aKV
-pqo
+riR
 gBd
 aKV
-lqp
+pUT
 aMc
 aaq
-mhQ
+tih
 aaq
 aMc
 aUu
@@ -181416,43 +181428,43 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
-tfL
-fRr
+ojB
+nmE
 gBd
-hVw
+hFP
 gBd
-hVw
+hFP
 gBd
-iim
-fxc
-kHZ
+pRV
+ykW
+vRG
 aKV
-eXR
-oJt
+jDx
+spm
 aKV
-eXR
-oJt
+jDx
+spm
 aKV
-eXR
-oJt
+jDx
+spm
 aKV
-eXR
-oJt
-uJJ
-xKc
-pJJ
+jDx
+spm
+woS
+uke
+xKW
 vAW
-nnZ
-pVn
+ylh
+vTA
 aNy
 aKV
-hDf
-vkF
-qsI
+wwj
+waM
+okb
 aKV
-rZL
+quZ
 aZq
 bbf
 aFm
@@ -181673,40 +181685,40 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
-kFt
-oww
+xDX
+vaw
 gBd
-qGl
-sjU
-fmI
-sjU
-afh
-jBH
-fJC
-wuX
-qUx
-wSF
-iPE
-qUx
-wSF
-nKM
-knS
-wSF
-sbQ
-qUx
-wSF
-wuX
-lfj
-nKM
-fau
+udw
+vha
+pJo
+vha
+tpd
+xlv
+iqR
+tAO
+fks
+scu
+jIX
+fks
+scu
+spl
+gOg
+scu
+jRK
+fks
+scu
+tAO
+txs
+spl
+gPk
 wIf
-nKM
-nKM
+spl
+spl
 aPh
-nKM
-vWh
+spl
+sza
 aar
 aWd
 aXM
@@ -181930,32 +181942,32 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
-kFt
-krH
+xDX
+sHi
 gBd
-rTq
-ydO
-nvu
-ydO
-gHg
-ktm
-eSc
-pJJ
-sUa
-kOb
+udb
+qDd
+vWu
+qDd
+tiE
+fQe
+iYE
+xKW
+opV
+mze
 gBd
-sUa
-kOb
-vqc
-sUa
-kOb
+opV
+mze
+hfL
+opV
+mze
 gBd
-sUa
-kOb
-pJJ
-pqo
+opV
+mze
+xKW
+riR
 gBd
 aJA
 gBd
@@ -181963,11 +181975,11 @@ gBd
 aNA
 aKV
 aRa
-vqc
+hfL
 gBd
 aKV
 aXN
-hNi
+pnW
 bbg
 aFm
 bet
@@ -182187,41 +182199,41 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
-dWY
-rek
-oEA
-uKo
-eFJ
-qnG
-eFJ
-pqx
-loG
-kHV
-rDN
-mLc
-rGk
-lVc
-mLc
-rGk
-xPJ
-mLc
-rGk
-sDj
-mLc
-rGk
-rDN
-gGu
-iQr
-hEY
-iQr
+kZw
+wqU
+wpn
+agR
+pdz
+guN
+pdz
+pwm
+fYS
+ohq
+oef
+npQ
+fZP
+neb
+npQ
+fZP
+pZk
+npQ
+fZP
+iLM
+npQ
+fZP
+oef
+oFs
+fVA
+vBX
+fVA
 aMf
-iQr
+fVA
 aPj
-iQr
-oNj
-iQr
+fVA
+gzh
+fVA
 aWf
 aXO
 aZs
@@ -182444,43 +182456,43 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
-fVi
-oww
+nId
+vaw
 gBd
-hVw
+hFP
 gBd
-hVw
+hFP
 gBd
-iim
-nhw
-mvq
-uJJ
-eXR
-oJt
+pRV
+sPC
+ncl
+woS
+jDx
+spm
 aKV
-eXR
-oJt
+jDx
+spm
 aKV
-eXR
-oJt
+jDx
+spm
 aKV
-eXR
-oJt
+jDx
+spm
 aKV
-xKc
-pJJ
+uke
+xKW
 aKV
-gzY
+mYL
 aKV
 aNC
 aKV
 aRc
-rWQ
-mvO
+joY
+mWd
 aKV
-qCP
+fwb
 aZt
 bbi
 bcO
@@ -182701,32 +182713,32 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
-jXq
-fVi
-uwL
-hQe
+kok
+nId
+okV
+ime
 gBd
-hVw
+hFP
 gBd
-iim
-pme
-sTP
+pRV
+hXb
+haq
 aKV
-kKK
-xMU
+wlQ
+fpA
 aKV
-kKK
-xMU
+wlQ
+fpA
 aKV
-kKK
-xMU
+wlQ
+fpA
 aKV
-kKK
-xMU
+wlQ
+fpA
 aKV
-pqo
+riR
 gBd
 aKV
 aKW
@@ -182734,10 +182746,10 @@ aKV
 aND
 aKV
 aRd
-nLP
+htG
 aav
 aKV
-xWx
+prl
 aZu
 bbd
 bcP
@@ -182958,32 +182970,32 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 rqh
 rqh
-kCb
-lpk
+sTH
+eik
 gBd
-hVw
+hFP
 gBd
-eEm
-rQK
-xwy
+ovs
+fYr
+lRW
 aKV
-mpj
-iIM
+jfn
+pMe
 aKV
-uCb
-iIM
+qgJ
+pMe
 aKV
-mpj
-iIM
+jfn
+pMe
 aKV
-uCb
-iIM
+qgJ
+pMe
 aKV
-pqo
+riR
 aIf
 aFm
 aFm
@@ -183215,18 +183227,18 @@ aaa
 aaa
 aaa
 oZp
-xVr
-xVr
-xVr
+smZ
+smZ
+smZ
 rqh
 aFm
-fVi
-oLu
-hVw
+nId
+rrw
+hFP
 gBd
-iim
-nhw
-mvq
+pRV
+sPC
+ncl
 aKV
 aKV
 aKV
@@ -183239,19 +183251,19 @@ aKV
 aKV
 aKV
 aKV
-uJJ
-pqo
-kyc
+woS
+riR
+idH
 aFm
-pqo
+riR
 gBd
-fxc
+ykW
 aPn
-fxc
+ykW
 gBd
 aUA
 aKV
-uMj
+qMl
 aZB
 bbk
 aKV
@@ -183474,43 +183486,43 @@ aaa
 oZp
 oZp
 oZp
-xVr
+smZ
 rqh
 rqh
-rGN
-kCb
-rMS
-mVH
-tLr
-pKk
-syh
-tHP
-hBx
-uRP
-uar
-lNL
-lNL
-hBx
-lNL
-hBx
-xdL
-lNL
-hBx
-lNL
+iCl
+sTH
+fZm
+qBF
+qKL
+tHn
+vWt
+wEL
+ppr
+pUP
+lwS
+hNw
+hNw
+ppr
+hNw
+ppr
+uTm
+hNw
+ppr
+hNw
 aGL
 aIh
 aJC
-lfj
-pDf
-fxc
+txs
+vpb
+ykW
 aPo
-fxc
-shX
-mdU
-nAS
-mLc
+ykW
+lvb
+jSf
+tJD
+npQ
 aZx
-ozi
+uXe
 bcR
 aFm
 aaa
@@ -183731,41 +183743,41 @@ aaa
 aaa
 aaa
 aaa
-xVr
-xVr
-xVr
+smZ
+smZ
+smZ
 rqh
-jXq
-fVi
-uwL
-mwy
-nLM
-nCQ
-pPs
-loi
-nCQ
-rPP
-pDz
-gBT
-loi
-rPP
-hpu
-pPs
-wmt
-loi
-nCQ
-rPP
-hrl
-kpO
-ahZ
-mCF
+kok
+nId
+okV
+xZV
+mWl
+rJD
+ptJ
+eSi
+rJD
+qDh
+hwL
+tni
+eSi
+qDh
+nBk
+ptJ
+moT
+eSi
+rJD
+qDh
+uAi
+lIs
+sNC
+oRG
 gBd
 aKV
-lQZ
-pUE
-tyY
+lbk
+msd
+qxg
 aWi
-tfH
+ppo
 aZy
 bbd
 bcS
@@ -183990,41 +184002,41 @@ aaa
 aaa
 rqh
 rqh
-xVr
+smZ
 rqh
 rqh
 rqh
 aFm
-ulp
-kOb
+emI
+mze
 aFm
 aKV
-eXR
-tZN
-tiw
-tiw
+jDx
+qKr
+wwo
+wwo
 aKV
-eXR
-eTH
+jDx
+tzW
 aKV
 aKV
 aKV
-eXR
-mtd
-tiw
+jDx
+eWk
+wwo
 aKV
 aFm
-pqo
+riR
 gBd
-fxc
+ykW
 aPo
-fxc
+ykW
 gBd
 aUB
 aKV
 aXQ
 aZq
-nOk
+ish
 bcT
 aFm
 aaa
@@ -184245,43 +184257,43 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 aFm
 aFm
 aFm
 aFm
 aFm
-ulp
-gDP
+emI
+tjR
 aFm
-fVW
-ile
-ydO
-rPJ
-rPJ
+nnk
+ptK
+qDd
+ujZ
+ujZ
 aKV
-mmo
-tbT
-vkn
+ndS
+tuP
+gOr
 aKV
-rXf
-lNz
-mPR
-vEA
-hqO
+tdF
+thf
+mJt
+iIM
+oGT
 aFm
 aFn
 aMn
-fxc
+ykW
 aPn
-fxc
-qTS
+ykW
+yjz
 aUC
 aKV
-gTf
+nMa
 aZA
-nOk
+ish
 aFm
 aFm
 aad
@@ -184502,43 +184514,43 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 aFm
-hqu
-uqa
-vjZ
-hqu
-tLr
-rpt
+pYn
+mOh
+pUZ
+pYn
+qKL
+xnZ
 aFm
-fGC
-thA
-ydO
-knK
-sOe
+mBo
+mcK
+qDd
+lVh
+jHY
 aKV
-sjy
-tbT
-xCi
+hXi
+tuP
+tPj
 aKV
-vAO
-iBQ
-mPR
-sSu
-oxO
+eBd
+eye
+mJt
+kYo
+pdq
 aFm
 aFm
 aFm
-yax
+mQN
 aFm
-yax
+mQN
 aFm
 aFm
 aFm
 aFm
 aZA
-nOk
+ish
 aFm
 aaa
 aad
@@ -184759,31 +184771,31 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 aFm
-uqa
-laI
-laI
-uqa
-sUa
-oKi
+mOh
+pMN
+pMN
+mOh
+opV
+tSX
 aFm
-fVW
-fVW
-tNI
-fVW
-rPJ
+nnk
+nnk
+iJZ
+nnk
+ujZ
 aKV
-tys
-tbT
-mzu
+vjh
+tuP
+fEJ
 aKV
-qBO
-tbd
-mPR
-rih
-xJI
+osQ
+fti
+mJt
+slV
+iII
 aFm
 aaa
 aFm
@@ -184795,7 +184807,7 @@ rqh
 rqh
 aFm
 aZC
-emd
+rQg
 aFm
 aaa
 aad
@@ -185016,43 +185028,43 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 aFm
-uqa
-laI
-laI
-uqa
-sUa
-tJW
+mOh
+pMN
+pMN
+mOh
+opV
+wCe
 aFm
-rDu
-ydO
-ydO
-ydO
-iZz
+ygN
+qDd
+qDd
+qDd
+iNx
 aKV
-uPx
-ylA
-hds
+yiA
+pdv
+fXx
 aKV
-qym
-lNz
-mPR
-vEA
-rXf
+ilt
+thf
+mJt
+iIM
+tdF
 aFm
 aaa
 aFm
 aNK
-lEd
+vxd
 aNK
 aFm
 rqh
 rqh
 aFm
-oyY
-htx
+iUC
+lZP
 aFm
 aaa
 aad
@@ -185273,31 +185285,31 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 aFm
-hqu
-uqa
-fjt
-hqu
-rjW
-gDQ
+pYn
+mOh
+ykd
+pYn
+fbv
+oeh
 aFm
-lPd
-pMo
-hpd
-pPJ
-sOe
+ktI
+sny
+kIu
+fWs
+jHY
 aKV
-iDN
-rKr
+sYd
+xit
 aSD
-xZD
-mPR
-pEm
-adC
-qlq
-eIu
+oIk
+mJt
+qol
+wiA
+mxY
+rLY
 aFm
 aad
 aFm
@@ -185309,7 +185321,7 @@ rqh
 rqh
 aFm
 aZA
-nOk
+ish
 aFm
 aaa
 aad
@@ -185530,31 +185542,31 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 aFm
 aFm
 aFm
 aFm
 aFm
-ulp
-gDP
+emI
+tjR
 aFm
 aKV
-wKm
+rYL
 aKV
 aKV
-kPJ
+nfP
 aKV
-euS
+seh
 aSD
 aSD
-lde
-mPR
-wNo
-mPR
-mep
-mPR
+nWc
+mJt
+wps
+mJt
+lRC
+mJt
 aFm
 aac
 aFm
@@ -185566,7 +185578,7 @@ rqh
 rqh
 aFm
 aZA
-nOk
+ish
 aFm
 aaa
 aaa
@@ -185787,33 +185799,33 @@ aaa
 aaa
 aaa
 oZp
-xVr
+smZ
 rqh
 rqh
 rqh
 rqh
 rqh
 aFm
-pWa
-fkp
+vgj
+nAz
 aFm
-loe
-mDL
-wgE
-eCG
-rVg
+lnA
+isr
+qOt
+ePJ
+xkr
 aKV
-kgu
+rmQ
 aSD
 aSD
-tNz
-mPR
-mPR
-mPR
-mPR
-mPR
+ghS
+mJt
+mJt
+mJt
+mJt
+mJt
 aFm
-oVB
+qMX
 aad
 aac
 rqh
@@ -185823,7 +185835,7 @@ rqh
 rqh
 aFm
 aZA
-nOk
+ish
 aFm
 aaa
 aaa
@@ -186048,27 +186060,27 @@ aaa
 aaa
 aaa
 aaa
-iGL
-qTZ
+txX
+kpF
 aFm
-wCC
-qQY
+oVk
+gvp
 aFm
-sBc
+eAr
 bbt
 bbt
-huu
-kxo
+wCo
+pcG
 aKV
-jnL
+nlg
 aSD
 aSD
-eXd
-mPR
-mPR
-mPR
-mPR
-sLO
+qru
+mJt
+mJt
+mJt
+mJt
+vsC
 aFm
 aad
 aad
@@ -186080,7 +186092,7 @@ rqh
 rqh
 aFm
 aZA
-nOk
+ish
 aFm
 aaa
 aaa
@@ -186305,27 +186317,27 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-tNq
-lGl
+uRL
+xRb
 aFm
-tfO
-vGe
-szr
-luB
-vNU
+abx
+gnY
+xxH
+moj
+jbQ
 aKV
-gcA
-twT
-rKv
+uXt
+tyb
+taK
 aKV
-mZq
-pmT
-iyP
-ylm
-ylm
+mIX
+iiq
+sdc
+vkX
+vkX
 aFm
 aaa
 rqh
@@ -186562,11 +186574,11 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-tFw
-lGl
+eki
+xRb
 aFm
 aFm
 aFm
@@ -186819,17 +186831,17 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-tFw
-lGl
+eki
+xRb
 aFm
-nmD
-fBu
+muv
+nLr
 gBd
-nmD
-nmD
+muv
+muv
 aFm
 rqh
 rqh
@@ -186850,7 +186862,7 @@ aSI
 aUD
 aWl
 aFm
-wfb
+gAd
 bbm
 bcM
 aad
@@ -187076,28 +187088,28 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-lid
-qSl
+rHi
+oQM
 aXS
-nKM
-nKM
-pDf
+spl
+spl
+vpb
 gBd
 gBd
 aFm
 rqh
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-xVr
-pxJ
-aJD
+smZ
+smZ
+nCC
+gFD
+gFD
+gFD
+aad
+aad
+aad
 aKZ
 aKZ
 aKZ
@@ -187333,28 +187345,28 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-tFw
-lGl
-rjE
+eki
+xRb
+mfX
 gBd
 aZL
 aZL
 aZL
-sbn
+gHx
 aFm
-sAA
+rqh
+jca
+rqh
+nCC
+gFD
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aad
 aLa
 aMq
 aNL
@@ -187590,20 +187602,20 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-tNq
-lOu
-kpO
-oBW
-oBW
-mCF
+uRL
+epK
+lIs
+lzi
+lzi
+oRG
 gBd
 gBd
 aFm
 rqh
-pxJ
+wqq
 aaa
 aaa
 aaa
@@ -187847,28 +187859,28 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
-qTI
-vnm
+kNU
+uzW
 aFm
-eFr
-jCS
-gxS
-weG
-weG
+dSX
+wAU
+muR
+gix
+gix
 aFm
 rqh
-pxJ
+jca
+rqh
+nCC
+gFD
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aad
 aLa
 aMs
 aNN
@@ -188104,7 +188116,7 @@ aaa
 aaa
 aaa
 aaa
-iGL
+txX
 rqh
 aFm
 aFm
@@ -188117,15 +188129,15 @@ aFm
 aFm
 aFm
 rqh
-pxJ
+wqq
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aJD
+nCC
+gFD
+gFD
+gFD
+aad
+aad
+aad
 aKZ
 aKZ
 aKZ
@@ -188361,20 +188373,20 @@ oZp
 oZp
 oZp
 aaa
-iGL
+txX
 rqh
 rqh
 rqh
 rqh
 rqh
-lue
+pMf
 rqh
 rqh
 rqh
 rqh
 rqh
 rqh
-pxJ
+wqq
 aaa
 aaa
 aaa
@@ -188618,20 +188630,20 @@ oZp
 oZp
 oZp
 aaa
-pxJ
-pxJ
-pxJ
-pxJ
-pxJ
-pxJ
-pxJ
-pxJ
+wqq
+wqq
+wqq
+wqq
+wqq
+wqq
+wqq
+wqq
 rqh
-iGL
-iGL
-iGL
-iGL
-iGL
+txX
+txX
+txX
+txX
+txX
 aaa
 aaa
 aaa
@@ -188656,7 +188668,7 @@ aKV
 aaa
 aaa
 aaa
-wPg
+ofR
 aaa
 aaa
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2641,6 +2641,16 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"aeC" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hallway/primary/central)
 "aeD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
@@ -5936,6 +5946,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ajC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ajD" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/office{
@@ -5965,6 +5984,15 @@
 	luminosity = 2
 	},
 /area/ai_monitored/turret_protected/ai)
+"ajF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "ajG" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
@@ -6275,6 +6303,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"akl" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/central)
 "akm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6287,6 +6318,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"akn" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ako" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -7710,6 +7761,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"amy" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Emergency Storage"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "amz" = (
 /turf/closed/wall/r_wall/rust,
 /area/maintenance/port)
@@ -9028,6 +9085,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/toilet/restrooms)
+"aoH" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/radio/intercom{
+	pixel_x = -28
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/hallway/primary/aft)
 "aoI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9340,6 +9407,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"apl" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "apm" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue{
@@ -9448,6 +9529,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/solars/port/fore)
+"apt" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "apu" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -9533,6 +9625,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/solars/port/fore)
+"apA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
 "apB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -11597,6 +11699,15 @@
 "asF" = (
 /turf/closed/wall,
 /area/security/courtroom)
+"asG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/aft)
 "asH" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11932,6 +12043,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"atn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/gloves/color/black,
+/obj/item/wrench,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "ato" = (
 /obj/item/storage/box/rxglasses{
 	pixel_x = 3;
@@ -12122,6 +12249,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"atA" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/weldingtool{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/welding{
+	pixel_y = 5
+	},
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "atB" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -12327,6 +12475,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
+"atP" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/hallway/primary/aft)
 "atQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -12647,6 +12803,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"aup" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "auq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12791,6 +12959,10 @@
 "auE" = (
 /turf/closed/wall,
 /area/storage/primary)
+"auF" = (
+/obj/structure/sign/poster/contraband/random,
+/turf/closed/wall,
+/area/hallway/primary/aft)
 "auG" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -12976,6 +13148,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"auZ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "ava" = (
 /turf/closed/wall/rust,
 /area/maintenance/starboard)
@@ -14136,6 +14315,17 @@
 	name = "mainframe floor"
 	},
 /area/tcommsat/server)
+"awL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "awM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -14214,6 +14404,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"awV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/hallway/primary/aft)
 "awW" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
@@ -14230,6 +14429,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
+"awZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/hallway/primary/aft)
 "axa" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -14786,9 +14994,43 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"axS" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/primary/aft";
+	dir = 8;
+	name = "Aft Hallway APC";
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/hallway/primary/aft)
+"axT" = (
+/obj/structure/grille/broken,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/hallway/primary/aft)
 "axU" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"axV" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Emergency Storage"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "axW" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -15097,12 +15339,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"ayA" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Emergency Storage"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "ayB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -16496,6 +16732,27 @@
 /obj/structure/beebox,
 /turf/open/floor/grass,
 /area/chapel/main)
+"aAy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aAz" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
@@ -16510,6 +16767,16 @@
 	},
 /turf/open/floor/engine,
 /area/security/nuke_storage)
+"aAA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aAB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17192,6 +17459,31 @@
 	},
 /turf/open/floor/engine,
 /area/security/nuke_storage)
+"aBG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/sign/warning/securearea{
+	name = "EMERGENCY STORAGE";
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aBH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -19093,13 +19385,6 @@
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
 /area/hallway/secondary/entry)
-"aEL" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "aEM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -19829,16 +20114,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/fore)
-"aGe" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Emergency Storage"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "aGf" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/tile/neutral,
@@ -47639,9 +47914,6 @@
 /obj/item/seeds/wheat,
 /turf/open/floor/grass,
 /area/chapel/main)
-"bws" = (
-/turf/closed/wall/rust,
-/area/security/detectives_office)
 "bwt" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/poppy,
@@ -50944,10 +51216,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"bBy" = (
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall,
-/area/hallway/primary/aft)
 "bBz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55327,16 +55595,6 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/port)
-"bIt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hallway/primary/central)
 "bIu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56784,15 +57042,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"bKE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
 "bKF" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
@@ -56894,40 +57143,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"bKO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/securearea{
-	name = "EMERGENCY STORAGE";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"bKP" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bKQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -58299,25 +58514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bMG" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
-"bMH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/hallway/primary/aft)
 "bMI" = (
 /obj/machinery/door/airlock/external{
 	name = "Science Escape Pod"
@@ -59019,16 +59215,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"bNS" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/hallway/primary/aft)
 "bNT" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -59094,20 +59280,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"bNX" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "bNY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -61357,41 +61529,6 @@
 	dir = 1
 	},
 /area/hallway/primary/central)
-"bRg" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bRh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bRi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bRj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -61853,27 +61990,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"bRS" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/weldingtool{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/clothing/head/welding{
-	pixel_y = 5
-	},
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "bRT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -61921,26 +62037,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bRW" = (
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/hallway/primary/aft)
-"bRX" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "bRY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -63526,35 +63622,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
-"bUz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/hallway/primary/aft)
-"bUA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/hallway/primary/aft)
-"bUB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "bUC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
@@ -64590,19 +64657,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"bWg" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/primary/aft";
-	dir = 8;
-	name = "Aft Hallway APC";
-	pixel_x = -26
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/aft)
 "bWh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64618,27 +64672,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/aft)
-"bWi" = (
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/hallway/primary/aft)
-"bWj" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "bWk" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -65962,62 +65995,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bYn" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bYo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bYp" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/structure/sign/warning/securearea{
-	name = "EMERGENCY STORAGE";
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bYq" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -67367,17 +67344,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cag" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "cah" = (
 /obj/structure/flora/rock/pile,
 /obj/machinery/light{
@@ -68053,22 +68019,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"cbh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/effect/decal/cleanable/blood/old,
-/obj/item/clothing/gloves/color/black,
-/obj/item/wrench,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/aft)
 "cbi" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -87274,6 +87224,21 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/port/fore)
+"eui" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "evx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -87444,9 +87409,26 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"him" = (
+/turf/closed/wall/rust,
+/area/security/detectives_office)
 "hqv" = (
 /turf/closed/wall/rust,
 /area/crew_quarters/kitchen)
+"hrf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/securearea{
+	name = "EMERGENCY STORAGE";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "hvb" = (
 /turf/closed/wall/r_wall/rust,
 /area/tcommsat/computer)
@@ -87559,9 +87541,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"iRL" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/aft)
 "iSg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -88110,6 +88089,17 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/hallway/secondary/entry)
+"rSa" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "swG" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = 4;
@@ -88142,6 +88132,9 @@
 "sPG" = (
 /turf/closed/wall/rust,
 /area/crew_quarters/heads/hor)
+"tdt" = (
+/turf/closed/wall/rust,
+/area/hallway/primary/aft)
 "tgw" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall/rust,
@@ -88149,9 +88142,6 @@
 "tqw" = (
 /turf/closed/wall/rust,
 /area/lawoffice)
-"tyb" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/central)
 "tCi" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood{
@@ -88168,6 +88158,16 @@
 "tYn" = (
 /turf/closed/wall/rust,
 /area/janitor)
+"uaq" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/aft)
 "uda" = (
 /turf/closed/wall/rust,
 /area/security/warden)
@@ -113962,7 +113962,7 @@ bEd
 wvq
 bGq
 bOP
-bIt
+aeC
 bOU
 abA
 bMr
@@ -114484,7 +114484,7 @@ aaY
 aaY
 aaY
 aaY
-bws
+him
 aaY
 aaY
 bHk
@@ -114734,17 +114734,17 @@ auP
 bIK
 bOT
 bOP
-bRg
-bKE
-ayA
-bNS
-bMG
-bRS
-bBy
-bUz
-bWg
+rSa
+ajF
+amy
+aoH
+apA
+atA
+auF
+awV
+axS
 axF
-bYn
+aAy
 bBf
 cae
 bVo
@@ -114991,17 +114991,17 @@ auP
 auP
 bOV
 bQv
-bRg
-bKO
+rSa
+hrf
 axF
-bNX
-bMH
-bRW
-aEL
-bUA
-bWi
-aGe
-bYo
+apl
+asG
+atP
+auZ
+awZ
+axT
+axV
+aAA
 bHy
 cHi
 bFa
@@ -115248,17 +115248,17 @@ bFv
 auP
 bQx
 bOP
-bRh
-tyb
-iRL
-cag
-cbh
-bRX
+eui
+akl
+tdt
+apt
+atn
+aup
 axF
-bUB
-bWj
+awL
+uaq
 axF
-bYp
+aBG
 bEA
 cHh
 bFa
@@ -115505,8 +115505,8 @@ asW
 awd
 bHJ
 bOP
-bRi
-bKP
+ajC
+akn
 axF
 axF
 axF

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8037,6 +8037,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"aqe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "aqf" = (
 /obj/structure/closet/lasertag/blue,
 /obj/effect/turf_decal/tile/neutral{
@@ -15878,13 +15888,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/storage/wing)
-"aFU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/construction/storage/wing)
 "aFV" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -16478,6 +16481,11 @@
 /obj/structure/cable/white,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"aHb" = (
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "aHc" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16660,17 +16668,6 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/construction/storage/wing)
-"aHt" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage/wing)
@@ -48260,12 +48257,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
-"bSL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -79923,6 +79914,13 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard/fore)
+"doq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "dou" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -79941,6 +79939,18 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dpp" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Prisoner Arrivals";
+	dir = 8;
+	name = "aft camera"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dps" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating{
@@ -79959,6 +79969,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"dpS" = (
+/obj/machinery/deepfryer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dqe" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -79968,24 +79985,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
-"dqs" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dqu" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -80000,35 +79999,12 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"drb" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "drp" = (
 /obj/item/folder/blue,
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
-"dry" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plating,
-/area/security/prison)
 "drQ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -80058,6 +80034,21 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dsG" = (
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/storage/bag/trash,
+/obj/item/radio/off,
+/turf/open/floor/plating,
+/area/security/prison)
+"dsP" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/hotdog,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "dtl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -80211,12 +80202,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dwn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "dwv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -80404,12 +80389,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/aft)
-"dBt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "dBu" = (
 /turf/closed/wall,
 /area/engine/gravity_generator)
@@ -81176,9 +81155,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dFH" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/cafeteria,
+"dEY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"dGz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "dGH" = (
 /obj/effect/landmark/event_spawn,
@@ -81194,15 +81185,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"dJc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dJG" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
 "dLK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -81212,51 +81194,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dMl" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
+"dRg" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dMv" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dOs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
-	},
-/obj/machinery/processor,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"dOO" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"dTE" = (
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dTS" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
-"dWl" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
+"dUc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "dYu" = (
 /obj/machinery/door/airlock/external{
@@ -81267,68 +81226,41 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"eah" = (
+"ebg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"egc" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eaW" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ebZ" = (
+"eiS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/toilet/auxiliary)
+"eko" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"eca" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"edD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"eik" = (
+"emx" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -81341,41 +81273,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"eiS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/toilet/auxiliary)
-"ejf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"ekv" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"elZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"enW" = (
-/turf/open/floor/circuit/green,
 /area/security/prison)
 "eoK" = (
 /obj/structure/disposalpipe/segment{
@@ -81392,15 +81289,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"epa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eqq" = (
 /obj/item/screwdriver,
 /obj/structure/table/reinforced,
@@ -81413,22 +81301,19 @@
 /obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"eqA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"erz" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "etr" = (
 /obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
@@ -81437,44 +81322,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
-"eBv" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"eCr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"evB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/security/prison)
-"eCB" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"eCS" = (
+"ezj" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -81493,49 +81351,48 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"eGr" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "eHn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
-"eJS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
-"eLc" = (
+"eHo" = (
+/obj/structure/lattice,
 /obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
+	c_tag = "Permabrig Space West";
+	dir = 8;
+	name = "aft camera"
 	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
+/turf/open/space/basic,
+/area/space/nearstation)
+"eJB" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"eKB" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eMf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/security/prison)
-"eNI" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+"eOE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eQf" = (
@@ -81551,23 +81408,29 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
-"eTs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"eQR" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Showers";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"eTU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"eTC" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
 /area/security/prison)
 "eZe" = (
 /obj/structure/cable/yellow{
@@ -81582,47 +81445,107 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"fig" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+"feZ" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"fkP" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"fnr" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"fnB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
+	},
+/obj/machinery/button/door{
+	id = "soli1";
+	name = "Solitary Cell 1";
+	pixel_x = 26;
+	pixel_y = 10;
+	req_access_txt = "3"
+	},
+/obj/machinery/door_timer{
+	id = "soli1";
+	name = "Solitary 1 door timer";
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"foI" = (
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "fpY" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
-"fwS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"fre" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"frH" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fzn" = (
+"fuH" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"fwp" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/security/prison)
+"fyl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fyE" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"fyH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -81636,31 +81559,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"fBg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"fCN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/security/prison)
-"fDA" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"fAR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "fDD" = (
 /obj/machinery/light_switch{
@@ -81683,51 +81586,121 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"fHt" = (
+"fHv" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fHX" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fKQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"fLe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/hug,
+/obj/item/razor{
+	pixel_x = -6
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fLV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fMu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fWl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fWm" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fXN" = (
+/obj/structure/holohoop,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"fZg" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"gcc" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gcK" = (
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#cee5d2"
 	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"fIg" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"fMR" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"fOX" = (
-/obj/machinery/shower{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"fTX" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"fZr" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "gde" = (
 /obj/structure/cable/yellow{
@@ -81735,22 +81708,44 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"gfa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"gdL" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"ghu" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Arrivals";
-	dir = 8;
-	name = "aft camera"
+"gdO" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gec" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"ggk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ghM" = (
@@ -81760,9 +81755,50 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gjW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
+"giB" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gmO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gnp" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gnY" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gnZ" = (
@@ -81771,12 +81807,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"gpC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"gqs" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/turf/open/floor/wood,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "gqA" = (
 /obj/machinery/button/door{
@@ -81790,35 +81827,6 @@
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gqE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gqO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -81846,43 +81854,45 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gtq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"gsY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Laundry"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gtB" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"gvD" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"gxP" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"gzm" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gtV" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gxY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gzg" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/fortunecookie,
 /turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"gAw" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "gEk" = (
 /obj/structure/cable/yellow{
@@ -81897,16 +81907,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"gGX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gHh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -81915,39 +81915,10 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gHW" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gIi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "gJs" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"gKh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -81958,17 +81929,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gNR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gOy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -81995,77 +81955,121 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"gQY" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "gRS" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"gTE" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+"gRV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gUz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood,
 /area/security/prison)
+"gXP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/construction/storage/wing)
 "gXY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"hdy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "heE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"hgM" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
+"hhC" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge West";
 	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/security/prison)
-"hlk" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hqd" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
+"hiy" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hlN" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hqD" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/instrument/accordion,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"huY" = (
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hvB" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/storage/photo_album,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hwb" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -82075,36 +82079,49 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"hCL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+"hzu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"hDu" = (
-/obj/machinery/conveyor/auto{
+"hAn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/plasticflaps/opaque,
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hAp" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
-	id = "locklock"
+	id = "permalock2"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hHp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"hCi" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hFf" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "hIt" = (
 /obj/structure/table/reinforced,
@@ -82113,113 +82130,92 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hJO" = (
+"hNL" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
-"hMh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hPL" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"hQX" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pressing Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"hSl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"hWr" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/security/prison)
-"hYt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+"hSF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hYT" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+"hYP" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Garden";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"ibJ" = (
+"ien" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ieD" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ihj" = (
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"iir" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"ijp" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"ijA" = (
-/obj/machinery/light{
+/obj/machinery/firealarm{
 	dir = 1;
-	light_color = "#cee5d2"
+	pixel_y = -24
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ikW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ilx" = (
+/turf/open/floor/plasteel/vaporwave,
 /area/security/prison)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -82232,18 +82228,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"iuY" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"isd" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "ivu" = (
 /obj/structure/cable/yellow{
@@ -82251,28 +82238,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"ivM" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
+"ixP" = (
 /obj/effect/turf_decal/tile/red,
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"izr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/prison)
 "izu" = (
 /obj/machinery/autolathe{
@@ -82300,49 +82271,42 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"iEJ" = (
+/obj/machinery/door/airlock/glass{
+	name = "Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"iHu" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"iJU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/security/execution/education)
 "iLj" = (
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"iMX" = (
-/obj/structure/holohoop,
-/obj/structure/cable{
-	icon_state = "4-8"
+"iOK" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"iNa" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/vr_sleeper{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"iOk" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/security/prison)
-"iPt" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/storage/bag/trash,
-/obj/item/radio/off,
-/turf/open/floor/plating,
-/area/security/prison)
-"iPQ" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"iSh" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/circuit,
 /area/security/prison)
 "iSt" = (
 /obj/machinery/door/airlock/grunge,
@@ -82351,52 +82315,68 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/vacantoffice)
-"iUv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"iUE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Showers"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"iVT" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"iXr" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
+"iVz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jcI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jef" = (
-/obj/structure/filingcabinet,
 /obj/machinery/camera{
-	c_tag = "Permabrig Library";
+	c_tag = "Permabrig West Hallway 1";
+	dir = 4;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"jel" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"iWd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/white,
+/area/security/prison)
+"iWB" = (
+/obj/structure/closet/secure_closet/brig,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jcg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jcu" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"jcX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"jdF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/security/prison)
 "jeV" = (
 /obj/machinery/conveyor/inverted{
@@ -82412,116 +82392,69 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"jib" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jjI" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jkw" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"jlo" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
+"jka" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
-"jlF" = (
-/obj/structure/table,
+"jkE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 5
 	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"jou" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "visitexit";
-	name = "Visitation Prisoner Lockdown";
-	pixel_y = -26;
-	req_access_txt = "3"
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jpG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
+"jla" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"jpI" = (
+"jpF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/prison)
-"jpM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
+"jqX" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plating,
 /area/security/prison)
-"jrr" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"jrW" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"jwf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jwW" = (
@@ -82549,6 +82482,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"jzd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/vending/kink,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jAG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jBe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82561,29 +82518,42 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jDH" = (
+"jBv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jCm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"jEt" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"jGq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"jDg" = (
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"jJk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"jHx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jKK" = (
 /obj/machinery/door/airlock/external{
@@ -82610,6 +82580,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"jNs" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "jPu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -82623,99 +82603,133 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jWm" = (
+"jQt" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"jTS" = (
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jVW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"jXl" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"kdi" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/security/prison)
+"kdZ" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"kev" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"kfj" = (
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"kiU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"kif" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kjY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/security/execution/education)
-"kkr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"koP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"koT" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"kpm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"kqP" = (
-/obj/machinery/cryopod{
-	dir = 8
+"kiC" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/circuit/green,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/turf/open/floor/plating,
+/area/security/prison)
+"kiU" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
-"ktD" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kwH" = (
-/obj/effect/turf_decal/tile/green{
+"ktN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/vending/hydroseeds,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kwI" = (
@@ -82726,9 +82740,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"kwW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"kwQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kxk" = (
@@ -82752,6 +82771,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"kzm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kzn" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -82762,29 +82798,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kzy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"kzM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
-"kCG" = (
+"kAM" = (
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/button/door{
+	id = "visitexit";
+	name = "Visitation Prisoner Lockdown";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/plasteel,
+/area/security/prison)
+"kBX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/wood,
+/area/security/prison)
+"kCw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -82800,85 +82841,38 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kGJ" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+"kEV" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kIM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"kJW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"kKw" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"kLm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
 	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"kGc" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"kML" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"kNI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"kOb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
 /area/security/prison)
 "kOt" = (
 /obj/item/multitool,
@@ -82889,22 +82883,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"kPg" = (
-/obj/machinery/door/poddoor{
-	id = "soli2"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
-"kQn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kQP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82918,16 +82896,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"kTC" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82936,50 +82904,56 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kVA" = (
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"kXf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"kYJ" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lal" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"lay" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
+"lcI" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/security/prison)
-"laI" = (
-/obj/effect/turf_decal/tile/red,
+"ldG" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/closed/wall,
-/area/security/prison)
-"lgU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"llb" = (
-/obj/structure/table/reinforced,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"lnf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Sleepers"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"loL" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"lpq" = (
+"lfg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -82989,19 +82963,17 @@
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lqD" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+"llb" = (
+/obj/structure/table/reinforced,
+/obj/item/integrated_circuit_printer,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"lrW" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "lsv" = (
 /obj/machinery/power/apc{
@@ -83020,6 +82992,12 @@
 "lws" = (
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
+"lyu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -83033,66 +83011,55 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"lAE" = (
-/obj/machinery/shower{
-	dir = 8
-	},
+"lBJ" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"lDB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
-"lDD" = (
-/obj/machinery/deepfryer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"lDG" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"lEW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"lGR" = (
-/obj/effect/turf_decal/tile/red{
+"lGp" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"lKn" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
+"lLr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"lKK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/plasteel/white,
+"lLw" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/toy/cards/deck,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "lMz" = (
 /obj/structure/falsewall,
@@ -83102,29 +83069,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lNk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lNL" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "lNZ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -83150,56 +83094,60 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"lSI" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
+"lPs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"lRB" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/security/prison)
+"lRO" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
+"lRW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"lSA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"lTS" = (
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
+"lTI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
+/turf/open/floor/wood,
+/area/security/prison)
+"lVF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lUd" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"lUj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"lVN" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "lWL" = (
 /obj/machinery/smartfridge/organ/preloaded,
@@ -83218,28 +83166,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"lXX" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"lZV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "maM" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -83273,24 +83199,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"mgA" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+"mfA" = (
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"mgU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
 /area/security/prison)
 "mjJ" = (
 /obj/machinery/nuclearbomb/beer{
@@ -83299,51 +83216,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"mkg" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"mlg" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"mnu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mnV" = (
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
-"mty" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mvj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -83353,6 +83229,9 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"myn" = (
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "mzh" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -83367,19 +83246,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"mBi" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
+"mAX" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
 /area/security/prison)
-"mDS" = (
+"mBw" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mEe" = (
@@ -83392,47 +83268,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mGY" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"mLd" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"mOd" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"mHh" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+"mUt" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
 /area/security/prison)
-"mHr" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Laundry"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"mKx" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"mUW" = (
-/obj/item/bedsheet/rd/royal_cape,
-/obj/structure/bed/pod,
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
-"mVT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+"mUU" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mWg" = (
@@ -83442,56 +83301,35 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"mXy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"nbz" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ndG" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/security/prison)
-"nea" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/vending/kink,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ngj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+"mWM" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nam" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"nbu" = (
+/obj/structure/sink{
 	dir = 4;
-	network = list("ss13","prison")
+	pixel_x = 11
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/turf/open/floor/plating,
+/area/security/prison)
+"nbv" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "nhy" = (
@@ -83508,6 +83346,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"njQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nka" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nkk" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nnK" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/paper_bin,
@@ -83525,61 +83385,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/circuit)
-"noN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+"noJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
-"nqA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"nss" = (
-/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"ntb" = (
+"nwr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ntK" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/wood,
-/area/security/prison)
-"nwH" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge West";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nye" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "nyo" = (
@@ -83603,25 +83422,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"nBf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nHL" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
+"nGR" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "sexroom"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -83637,24 +83440,52 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage/wing)
-"nLh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"nKR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nSJ" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
+"nNF" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"nSS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"nPy" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nQJ" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/construction/storage/wing)
+"nSz" = (
+/obj/structure/chair/stool,
 /turf/open/floor/wood,
+/area/security/prison)
+"nUL" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "nWb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -83672,16 +83503,6 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/engine/cult,
 /area/library)
-"nYm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "obb" = (
 /obj/structure/target_stake,
 /obj/effect/turf_decal/stripes/line{
@@ -83702,11 +83523,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"ocM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ocT" = (
 /obj/machinery/light{
 	dir = 1
@@ -83722,16 +83538,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"ofW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"oeg" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "ohj" = (
 /obj/item/integrated_electronics/analyzer,
@@ -83740,96 +83552,115 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oiA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+"ohN" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole,
+/turf/open/floor/wood,
 /area/security/prison)
 "omz" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"orz" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+"osT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "oub" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
 /area/hydroponics)
-"ovw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oxY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"oyx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"oCL" = (
-/obj/effect/turf_decal/tile/red,
+"ovO" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oFq" = (
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/cryopod)
-"oFA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation - Prisoners"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "visitexit"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oIL" = (
-/obj/machinery/shower{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oxH" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Perma Wing";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ozC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oBL" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northeast";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"oFh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"oFq" = (
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopod)
+"oHz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
+"oIr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oJV" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap/homemade,
 /turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"oLo" = (
+/obj/structure/chair/stool,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cafeteria";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "oLq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -83850,21 +83681,18 @@
 /obj/item/integrated_electronics/debugger,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oOC" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+"oNC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"oQi" = (
+/obj/structure/chair/stool,
+/obj/machinery/light,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "oRp" = (
 /turf/open/space/basic,
 /area/space/station_ruins)
-"oRr" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oRL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -83876,6 +83704,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"oSF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oUA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83885,23 +83723,30 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oUF" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
+"oUG" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
 /area/security/prison)
-"oWl" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
+"oUV" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oWJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "oWR" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -83914,6 +83759,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"oXx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
+"oXI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oZg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -83925,41 +83789,20 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pgf" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/security/prison)
-"pii" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
+"pdH" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"pjD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pkq" = (
-/obj/machinery/shower{
-	dir = 8
+"plw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"pkz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pmc" = (
@@ -83968,18 +83811,39 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"pmz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"pne" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pun" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
+"pqU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"psi" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"puH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83997,27 +83861,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pvG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/jukebox{
-	req_one_access = null
+"pvY" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pxa" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "applebush"
+"pxx" = (
+/obj/machinery/plate_chute/inputchute{
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pyQ" = (
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "pzj" = (
 /obj/machinery/door/airlock/external,
@@ -84026,12 +83883,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"pBt" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"pzz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/closed/wall,
 /area/security/prison)
 "pCV" = (
 /obj/structure/cable/yellow{
@@ -84050,73 +83906,36 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"pFU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+"pFr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/security/prison)
+"pHs" = (
+/obj/item/bedsheet/rd/royal_cape,
+/obj/structure/bed/pod,
+/turf/open/floor/plasteel/vaporwave,
 /area/security/prison)
 "pHS" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"pIK" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"pJy" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pKn" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"pLT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pMK" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pMV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+"pJS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pKv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"pKz" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pMX" = (
@@ -84142,16 +83961,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"pSD" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -84161,47 +83970,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"pXU" = (
-/obj/machinery/light{
+"pTy" = (
+/obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pYH" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"pYM" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pYS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pZb" = (
 /obj/structure/cable/yellow{
@@ -84209,23 +83985,12 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"qdR" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"qdZ" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleeper Hallway";
+"pZt" = (
+/obj/machinery/firealarm{
 	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
@@ -84233,58 +83998,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"qhy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"qiD" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qhC" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qkW" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qnj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"qpC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = -5
+"qph" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Prisoner-side";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -84294,22 +84036,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"qqL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"qsK" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Pressing Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel/checker,
-/area/security/prison)
-"qvk" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/circuit/green,
 /area/security/prison)
 "qvY" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -84325,12 +84060,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"qAq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qBh" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -84343,38 +84072,51 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
-"qGI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"qEn" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qFr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qFw" = (
+/obj/structure/lattice,
+/obj/machinery/camera,
+/turf/open/space,
+/area/space/nearstation)
+"qFB" = (
+/obj/item/caution,
+/obj/item/caution,
+/turf/open/floor/plating,
+/area/security/prison)
+"qGb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/security/prison)
-"qHB" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
-/area/security/prison)
-"qIV" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qJd" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+"qIM" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "qJZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -84382,6 +84124,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qKV" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qLf" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -84392,21 +84139,38 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
-"qMw" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"qMY" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"qQR" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qOH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+"qRx" = (
+/obj/structure/bed,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"qRB" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall,
+/area/security/prison)
+"qRD" = (
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qRM" = (
@@ -84433,22 +84197,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"qXN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rax" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+"qXO" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qYb" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "rbE" = (
 /obj/effect/turf_decal/tile/blue{
@@ -84456,38 +84221,69 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"rbS" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rfD" = (
-/obj/machinery/plate_press,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"ris" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
+"rgj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/light{
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"riH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"riJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Kitchen";
+	network = list("ss13","prison")
+	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"rmc" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"rmx" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"rmR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "roa" = (
 /obj/structure/cable{
@@ -84518,27 +84314,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rqz" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
+"rqV" = (
+/obj/machinery/door/poddoor{
+	id = "soli2"
 	},
-/turf/open/floor/circuit,
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
+	},
 /area/security/prison)
-"rst" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"rvM" = (
-/obj/effect/turf_decal/tile/red{
+"ruq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rwB" = (
+/obj/structure/weightmachine/weightlifter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rzr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rzX" = (
@@ -84554,37 +84358,38 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"rBF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"rEA" = (
+/obj/machinery/shower{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"rGs" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"rFp" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rGF" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+"rFs" = (
+/obj/structure/table,
+/obj/item/paicard,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"rIl" = (
-/obj/structure/chair/stool,
+"rGw" = (
+/obj/item/toy/beach_ball/holoball,
 /turf/open/floor/wood,
 /area/security/prison)
-"rJL" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel,
+"rIx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "rMS" = (
 /obj/machinery/status_display/supply,
@@ -84606,13 +84411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"rQm" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84632,32 +84430,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"rQZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "rSL" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"rUo" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
+"rYn" = (
+/obj/machinery/door/poddoor{
+	id = "soli1"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"sbK" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/mineral/titanium/white{
+	name = "secure isolation floor"
 	},
-/turf/open/floor/wood,
+/area/security/prison)
+"rYv" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "sdi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -84668,61 +84455,35 @@
 "sdw" = (
 /turf/open/space/basic,
 /area/space/nearstation)
-"seS" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "siF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"siY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sjx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"sjK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"skT" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"slB" = (
+"sjg" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"snT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"sks" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 8
+/turf/open/floor/wood,
+/area/security/prison)
+"sna" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -84744,29 +84505,57 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"sox" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
+"sqI" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sqg" = (
-/obj/machinery/door/firedoor,
+"srU" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"srS" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ssk" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
+"svF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"swc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sws" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "syk" = (
 /obj/machinery/door/airlock{
@@ -84778,12 +84567,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
-"syX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"sAD" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sAM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"sBq" = (
+/obj/machinery/plate_press,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"sEe" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleepers";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "sFv" = (
@@ -84824,6 +84641,25 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"sIH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sJB" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
@@ -84837,29 +84673,39 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"sPs" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/security/prison)
-"sRa" = (
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/wood,
-/area/security/prison)
-"sTy" = (
-/obj/effect/turf_decal/tile/red,
+"sMH" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sXZ" = (
+"sSP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"sTz" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"sWJ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/fortunecookie,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "tap" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -84868,54 +84714,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
-"teM" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/cryopod{
+"tdd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"tis" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tjr" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tkA" = (
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"tmi" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"tmA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"tnj" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"toK" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"tjH" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
 	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/turf/open/floor/plasteel/cafeteria,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"tpQ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "tre" = (
 /obj/effect/turf_decal/tile/blue{
@@ -84954,37 +84773,39 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"ttc" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "txj" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"tzb" = (
-/obj/effect/turf_decal/tile/red{
+"txH" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"tzk" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+"tAA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
-"tAZ" = (
-/turf/open/floor/wood,
+"tDt" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "applebush"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
@@ -84997,9 +84818,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"tED" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
+"tES" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
@@ -85007,6 +84831,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tIa" = (
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "tIS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -85023,53 +84850,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"tLX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
+"tNT" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Sleepers"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"tMM" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"tPG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tRb" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"tTc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tVC" = (
-/obj/machinery/door/airlock/glass{
-	name = "Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"tQI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
+/area/security/prison)
+"tQW" = (
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tVc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "tVY" = (
 /obj/structure/closet/crate,
@@ -85083,59 +84889,11 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"tWT" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "tXK" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"tZz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"uba" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"ubn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ugc" = (
-/obj/machinery/cryopod,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/cryopod)
-"ugl" = (
+"tYS" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -85156,6 +84914,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"tZY" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"uad" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"ubR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ugc" = (
+/obj/machinery/cryopod,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopod)
 "ujT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -85173,16 +84951,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uom" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"ulC" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space North";
+	dir = 1;
+	name = "aft camera"
 	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"umk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"unV" = (
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"uog" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"uoG" = (
+/turf/open/floor/wood,
 /area/security/prison)
 "upN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -85190,26 +84989,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"uqI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/security/prison)
-"ury" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"urD" = (
-/obj/item/caution,
-/obj/item/caution,
-/turf/open/floor/plating,
 /area/security/prison)
 "usf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -85225,47 +85012,81 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/security/checkpoint/supply)
-"uty" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
+"uuf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig East Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uun" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"uwF" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"uvp" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space East";
+	dir = 4;
+	name = "aft camera"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/space/basic,
+/area/space/nearstation)
+"uvs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"uxa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/security/prison)
-"uzR" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
+"uwe" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
 	},
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/security/prison)
+"uxr" = (
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uzi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Pressing Room";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"uBl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "uGW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -85285,6 +85106,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"uHk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uJz" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "uJU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85292,43 +85131,61 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"uKC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"uJW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uKS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/red,
+"uKE" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uOl" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"uPk" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uPM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"uPP" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"uNd" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"uOD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"uRg" = (
-/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "uRM" = (
@@ -85350,28 +85207,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"uUq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uYk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"uZp" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"vcz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair{
 	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vdJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -85392,6 +85251,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vkh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vlx" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/neutral{
@@ -85399,23 +85267,51 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vmZ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"vnK" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Perma Wing";
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vqq" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
+"vrj" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"vsN" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
+/area/security/prison)
+"vtl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"vuK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "vxG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85434,6 +85330,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
+"vxZ" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/security/prison)
 "vyx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -85441,83 +85343,64 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"vDw" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+"vyX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vEg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"vAg" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vEv" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vFk" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vFy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"vHJ" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
-/area/security/prison)
-"vLa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"vGC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"vIl" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"vUh" = (
-/obj/machinery/light{
-	dir = 4
+"vWN" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northwest";
+	dir = 1;
+	name = "aft camera"
 	},
-/turf/open/floor/circuit/green,
+/turf/open/space/basic,
+/area/space/nearstation)
+"vYU" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"vVS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+"wcF" = (
+/turf/open/floor/plasteel/elevatorshaft,
 /area/security/prison)
 "wdu" = (
 /obj/structure/grille,
@@ -85530,22 +85413,35 @@
 	},
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
+"wel" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"wfX" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleeper Hallway";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "wgw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"whm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"whd" = (
+/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wiZ" = (
@@ -85563,56 +85459,89 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"wmn" = (
-/obj/structure/bed,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
+"wlT" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "wmt" = (
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wnM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"wpS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"wqf" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wrj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/button/flasher{
-	id = "permalock";
-	pixel_x = 6;
-	pixel_y = 36;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wtv" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
+"wnI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/item/instrument/accordion,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"woP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Visitation - Prisoners"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "visitexit"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"woU" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wpv" = (
+/obj/structure/filingcabinet,
+/obj/machinery/camera{
+	c_tag = "Permabrig Library";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"wqD" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"wsD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison)
+"wti" = (
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wxc" = (
@@ -85625,20 +85554,128 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"wyA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "wzH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
-"wFn" = (
+"wDC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Laundry";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wFH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"wKo" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/closed/wall,
+/area/science/circuit)
+"wKH" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wOE" = (
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"wOY" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
+"wPk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"wQj" = (
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wRy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/science/misc_lab)
+"wSP" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wYp" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xeC" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopod)
+"xfI" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"xgP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -85674,99 +85711,10 @@
 /obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wFH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"wKo" = (
-/obj/effect/turf_decal/stripes/line,
+"xiv" = (
+/obj/machinery/newscaster,
 /turf/closed/wall,
-/area/science/circuit)
-"wMF" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall/r_wall,
 /area/security/prison)
-"wNF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"wOE" = (
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"wOY" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/space)
-"wPk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"wQX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wRy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/science/misc_lab)
-"wUk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wVO" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space,
-/area/space/nearstation)
-"wWh" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xew" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xeC" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/cryopod)
-"xfI" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "xkG" = (
 /obj/item/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
@@ -85782,6 +85730,53 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xnu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xop" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xox" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xoZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/flasher{
+	id = "permalock";
+	pixel_x = 6;
+	pixel_y = 36;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xpO" = (
+/obj/structure/table,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "xse" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -85795,17 +85790,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"xsj" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xtS" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space/station_ruins)
-"xtT" = (
+"xwk" = (
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "xwG" = (
 /obj/machinery/door/airlock/maintenance{
@@ -85818,6 +85824,29 @@
 	},
 /turf/open/floor/plating,
 /area/library)
+"xxn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/security/prison)
+"xxZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xyb" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xyp" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -85856,65 +85885,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xEP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xEW" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space North";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"xGj" = (
-/obj/structure/chair/stool,
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"xHJ" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xIi" = (
 /obj/machinery/flasher{
 	id = "permalock";
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xIm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"xKA" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xLL" = (
@@ -85929,21 +85904,40 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"xMP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"xNd" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "xRp" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vaporwave,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"xTR" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+"xRs" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "xTV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -85954,17 +85948,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xUi" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -85975,33 +85958,41 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"xYl" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"xZP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
+"xXU" = (
+/obj/structure/sink{
+	dir = 4;
 	pixel_x = 11
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xYD" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ybn" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine/cult,
 /area/library)
-"ybz" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/cafeteria,
+"ycv" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood,
 /area/security/prison)
 "ydn" = (
 /obj/structure/table,
@@ -86013,14 +86004,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"yfI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+"yet" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
@@ -86031,13 +86023,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"ygA" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
+"yjm" = (
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
+/turf/open/floor/wood,
 /area/security/prison)
 "ykE" = (
 /obj/machinery/light,
@@ -104088,17 +104079,17 @@ aaa
 aaa
 aaa
 aaa
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
 aaa
 aaa
 aaa
@@ -104345,7 +104336,7 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
 lMJ
 lMJ
@@ -104353,9 +104344,9 @@ lMJ
 lMJ
 lMJ
 lMJ
-rUo
 lMJ
-lDG
+lMJ
+vIl
 aaa
 aaa
 aaa
@@ -104588,21 +104579,21 @@ oRp
 oRp
 oRp
 oRp
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
 lMJ
 aax
 aax
@@ -104845,7 +104836,7 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 lMJ
 lMJ
@@ -104856,17 +104847,17 @@ lMJ
 lMJ
 lMJ
 lMJ
-eBv
+eHo
 lMJ
 lMJ
 lMJ
 lMJ
 aax
-iuY
-dOO
-dqs
-pYM
-eTC
+nkk
+ieD
+hYP
+wYp
+qkW
 aax
 aaf
 aaf
@@ -105102,8 +105093,8 @@ oRp
 oRp
 oRp
 oRp
-lDG
-rst
+vIl
+vWN
 aax
 aax
 aax
@@ -105119,11 +105110,11 @@ aax
 aax
 aax
 aax
-vDw
+kYJ
 aaR
-wqf
+fWm
 aaR
-hlk
+nUL
 aax
 aaa
 aaa
@@ -105359,28 +105350,28 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
-rfD
-tZz
-tkA
+sBq
+uzi
+pxx
 aax
-fOX
-uba
-xUi
-fOX
-iVT
+rEA
+oJV
+eQR
+rEA
+gQY
 abe
-gtq
-ngj
-qXN
+gmO
+wDC
+fyl
 abe
-kwH
-dJc
-srS
-eca
-hlk
+fHv
+fWl
+kiU
+ruq
+nUL
 aax
 aaa
 aaa
@@ -105616,28 +105607,28 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
-rfD
-mlg
-ekv
+sBq
+sjg
+fnr
 aax
-erz
-pyQ
-pyQ
-kzy
-xYl
+jNs
+tZY
+tZY
+jcX
+kVA
 abe
-mty
-kTC
-orz
+xnu
+eKB
+lGp
 abe
-xKA
-pmz
+uPk
+oWJ
 aaR
 acJ
-mgA
+xYD
 aax
 aaa
 aaa
@@ -105871,30 +105862,30 @@ aaa
 aaa
 oRp
 oRp
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
 lMJ
 aax
-rfD
-qqL
-jpM
+sBq
+gec
+lyu
 aax
-oIL
-pkq
-pyQ
-lAE
-pkq
+psi
+kdZ
+tZY
+kev
+kdZ
 abe
-mty
-vmZ
-fzn
+xnu
+sAD
+kzm
 abe
-kGJ
-fkP
-eNI
-qMw
-lqD
+kif
+vAg
+sTz
+gdO
+xXU
 aax
 aaa
 aaa
@@ -106128,29 +106119,29 @@ aaa
 aaa
 oRp
 oRp
-lDG
+vIl
 lMJ
 lMJ
 lMJ
 aax
 aax
-dBt
-hQX
+evB
+qsK
 aax
-hHp
+jdF
 abe
-rQZ
-mgU
-abe
-abe
-hHp
-mHr
-mgU
+iUE
+pzz
 abe
 abe
-hHp
-hqd
-wUk
+jdF
+gsY
+pzz
+abe
+abe
+jdF
+lRB
+ozC
 aax
 aax
 aaa
@@ -106383,31 +106374,31 @@ aaa
 aaa
 aaa
 aaa
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
 lMJ
-mkg
-eCS
-wMF
-eCB
-gKh
-eah
-mDS
-kCG
-wWh
-pYS
-mnu
-eCr
-lUj
-kCG
-pYS
-kLm
-hYt
-pYS
-whm
-pYS
-lGR
+gxP
+dEY
+iHu
+nPy
+ovO
+xRp
+sMH
+wnI
+qEn
+jBv
+jVW
+uHk
+qFr
+wnI
+jBv
+vdJ
+iVz
+jBv
+xsj
+jBv
+rzr
 aax
 aax
 aaa
@@ -106423,7 +106414,7 @@ adq
 adN
 aej
 aeK
-pxa
+tDt
 aax
 aax
 aio
@@ -106640,31 +106631,31 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
 lMJ
 lMJ
-kOb
-nea
+tQI
+jzd
 aaR
-qAq
-uUq
-qhC
-lgU
-oCL
-sjK
-tzk
-sjK
-oCL
-sjK
-oCL
-sjK
-tzk
-sjK
-sjK
-kiU
-rQm
-vEg
+lRW
+pJS
+woU
+jcg
+wKH
+xyb
+hiy
+xyb
+wKH
+xyb
+wKH
+xyb
+hiy
+xyb
+xyb
+jla
+uKE
+oIr
 aax
 lMJ
 aaf
@@ -106675,7 +106666,7 @@ aaa
 aaa
 aaa
 aaZ
-kjY
+iJU
 adr
 adr
 aek
@@ -106895,19 +106886,19 @@ aaa
 aaa
 aaa
 aaa
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
 lMJ
 aax
-eCS
+dEY
 aax
-tis
+gnp
 aaR
-pLT
+eOE
 abD
-uom
-iOk
+srU
+fwp
 abe
 abe
 abe
@@ -106920,8 +106911,8 @@ abe
 abe
 abe
 abe
-jlo
-tnj
+uPP
+mUU
 aax
 lMJ
 aaa
@@ -106938,7 +106929,7 @@ aaa
 abe
 aeV
 afG
-rJL
+iWB
 aax
 aaf
 aaf
@@ -107152,32 +107143,32 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
 lMJ
 lMJ
-kOb
-nbz
-nwH
-nLh
-izr
-sox
-sXZ
-fDA
+tQI
+huY
+hhC
+vuK
+osT
+jwf
+jXl
+lLw
 abe
-wmn
-jrr
+qRx
+kfj
 abe
-hYT
-jrr
+fZg
+kfj
 abe
-wmn
-jrr
+qRx
+kfj
 abe
-hYT
-jrr
+fZg
+kfj
 abe
-nBf
+sna
 aaR
 aax
 aax
@@ -107195,7 +107186,7 @@ aax
 abe
 aeV
 afG
-rJL
+iWB
 aax
 aaa
 aaf
@@ -107409,50 +107400,50 @@ aaa
 aaa
 aaa
 aaa
-lDG
-xEW
-mkg
-eCS
-wMF
-jrW
+vIl
+ulC
+gxP
+dEY
+iHu
+feZ
 aaR
-nLh
+vuK
 aaR
-pLT
+eOE
 acb
-uwF
+egc
 abe
-uOD
-jHx
+kXf
+fAR
 abe
-uOD
-jHx
+kXf
+fAR
 abe
-uOD
-jHx
+kXf
+fAR
 abe
-uOD
-jHx
+kXf
+fAR
 abe
-nBf
+sna
 aaR
 abe
 ujT
 gOy
 tIS
-hDu
+mfA
 tIS
 gOy
 abY
 abe
-ebZ
-seS
-eik
-seS
+ktN
+fHX
+emx
+fHX
 ada
 aeV
 afG
-rJL
+iWB
 aax
 aaa
 aaf
@@ -107666,43 +107657,43 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
-eCS
-gtV
+dEY
+tQW
 aaR
-nLh
+vuK
 aaR
-nLh
+vuK
 aaR
-pLT
+eOE
 abD
-uom
+srU
 abe
-hHp
-gUz
+jdF
+vGC
 abe
-hHp
-gUz
+jdF
+vGC
 abe
-hHp
-gUz
+jdF
+vGC
 abe
-hHp
-gUz
-iOk
-nYm
-ktD
-qHB
+jdF
+vGC
+fwp
+hlN
+qRD
+qRB
 gQG
-pkz
-xEP
+hAn
+fLe
 abe
 abi
 abB
-xHJ
+qYb
 abe
-wrj
+xoZ
 ada
 ada
 ada
@@ -107923,47 +107914,47 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
-pii
-dMl
+ezj
+rwB
 aaR
-kpm
-wpS
-qGI
-wpS
-nSS
-gpC
-noN
-kwW
-tjr
-iUv
-tLX
-tjr
-iUv
-fwS
-gHW
-iUv
-gxY
-tjr
-iUv
-kwW
-gGX
-fwS
-xtT
-gjW
-fwS
-fwS
-rbS
-fwS
-uUq
+sks
+qGb
+uPM
+qGb
+gRV
+tES
+oHz
+nKR
+nka
+umk
+eqA
+nka
+umk
+dUc
+vYU
+umk
+pKv
+nka
+umk
+nKR
+nwr
+dUc
+hAp
+njQ
+dUc
+dUc
+oxH
+dUc
+pJS
 abZ
 acq
 acD
-lZV
+ien
 aad
 adO
-kQn
+vyX
 aeM
 afH
 agF
@@ -108180,32 +108171,32 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
-pii
-pvG
+ezj
+vkh
 aaR
-iMX
-tAZ
-oyx
-tAZ
-koP
-sRa
-kzM
-ktD
-pmz
-acJ
-aaR
-pmz
-acJ
-uRg
-pmz
+fXN
+uoG
+tVc
+uoG
+uog
+rGw
+oXx
+qRD
+oWJ
 acJ
 aaR
-pmz
+oWJ
 acJ
-ktD
-nBf
+pKz
+oWJ
+acJ
+aaR
+oWJ
+acJ
+qRD
+sna
 aaR
 aay
 aaR
@@ -108213,13 +108204,13 @@ aaR
 abC
 abe
 xIi
-uRg
+pKz
 aaR
 abe
 acE
 adb
-uKS
-nHL
+jAG
+sJB
 ada
 aeN
 afI
@@ -108244,7 +108235,7 @@ awW
 awW
 awW
 aaf
-aFU
+gXP
 aHs
 aIA
 aJQ
@@ -108437,44 +108428,44 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
-iir
-vEv
-fBg
-kNI
-yfI
-lEW
-yfI
-qnj
-jpI
-eJS
-qJd
-qhy
-hMh
-kkr
-qhy
-hMh
-jcI
-qhy
-hMh
-ovw
-qhy
-hMh
-qJd
-jWm
-siY
-qpC
-siY
+pqU
+wti
+xop
+riH
+kBX
+jpF
+kBX
+uvs
+lPs
+eTU
+rFp
+uBl
+ubR
+ggk
+uBl
+ubR
+kCw
+uBl
+ubR
+fyH
+uBl
+ubR
+rFp
+ebg
+xxZ
+fnB
+xxZ
 roa
-siY
-pMK
-siY
-jGq
-siY
+xxZ
+vnK
+xxZ
+dGz
+xxZ
 aaI
 acF
-gNR
+lLr
 adt
 adP
 adP
@@ -108502,7 +108493,7 @@ aaa
 aaa
 aaa
 aFN
-aHt
+nQJ
 aIB
 aJO
 aLi
@@ -108694,47 +108685,47 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
-hSl
-dMl
+doq
+rwB
 aaR
-nLh
+vuK
 aaR
-nLh
+vuK
 aaR
-pLT
-lTS
-iXr
-iOk
-hHp
-gUz
+eOE
+whd
+sqI
+fwp
+jdF
+vGC
 abe
-hHp
-gUz
+jdF
+vGC
 abe
-hHp
-gUz
+jdF
+vGC
 abe
-hHp
-gUz
+jdF
+vGC
 abe
-nYm
-ktD
+hlN
+qRD
 abe
-ygA
+rYn
 abe
-kPg
+rqV
 abe
 abm
-epa
-dTS
+vcz
+gcc
 abe
 acG
-lZV
-lZV
-lZV
-syX
+ien
+ien
+ien
+qXO
 aeP
 afK
 agH
@@ -108951,32 +108942,32 @@ aaa
 aaa
 aaa
 aaa
-lDG
+vIl
 lMJ
-mkg
-hSl
-wMF
-jrW
+gxP
+doq
+iHu
+feZ
 aaR
-nLh
+vuK
 aaR
-pLT
-pSD
-fTX
+eOE
+xRs
+hvB
 abe
-jDH
-wnM
+rgj
+nam
 abe
-jDH
-wnM
+rgj
+nam
 abe
-jDH
-wnM
+rgj
+nam
 abe
-jDH
-wnM
+rgj
+nam
 abe
-nBf
+sna
 aaR
 abe
 aaA
@@ -108984,13 +108975,13 @@ abe
 aaP
 abe
 abn
-wFn
-gqE
+xgP
+wSP
 abe
 acH
-nHL
-nHL
-nHL
+sJB
+sJB
+sJB
 ada
 aeQ
 afL
@@ -109208,33 +109199,33 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 lMJ
 lMJ
-kOb
-tWT
+tQI
+wQj
 aaR
-nLh
+vuK
 aaR
-tPG
-qIV
-wtv
+plw
+rFs
+hqD
 abe
-hYT
-eaW
+fZg
+pTy
 abe
-wmn
-eaW
+qRx
+pTy
 abe
-hYT
-eaW
+fZg
+pTy
 abe
-wmn
-eaW
+qRx
+pTy
 abe
-nBf
-gTE
+sna
+pZt
 aax
 aax
 aax
@@ -109465,18 +109456,18 @@ oRp
 oRp
 oRp
 oRp
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
 lMJ
 aax
-hSl
-pun
-nLh
+doq
+tjH
+vuK
 aaR
-pLT
-lTS
-iXr
+eOE
+whd
+sqI
 abe
 abe
 abe
@@ -109489,22 +109480,22 @@ abe
 abe
 abe
 abe
-iOk
-nBf
-tnj
+fwp
+sna
+mUU
 aax
-nBf
+sna
 aaR
 abD
 abb
 abD
 aaR
-dMv
+qQR
 abe
-xew
-lZV
-lZV
-lZV
+oXI
+ien
+ien
+ien
 ada
 aeV
 afM
@@ -109724,44 +109715,44 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 lMJ
 lMJ
-kOb
-lpq
-oUF
-uKC
-hdy
-vFk
-jib
-pMV
-hCL
-ury
-oiA
-oiA
-pMV
-oiA
-pMV
-pXU
-oiA
-pMV
-oiA
-rGs
-qOH
-oFA
-gGX
-pjD
+tQI
+lfg
+pvY
+pne
+uJW
+pdH
+ldG
+jJk
+kEV
+oUV
+oSF
+oSF
+jJk
+oSF
+jJk
+wlT
+oSF
+jJk
+oSF
+xox
+fMu
+woP
+nwr
+sIH
 abD
 abc
 abD
 acc
-sTy
+nbv
 acv
-qhy
+uBl
 adb
 adb
-ubn
+swc
 ada
 aeY
 afN
@@ -109981,45 +109972,45 @@ oRp
 oRp
 oRp
 oRp
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
 lMJ
-mkg
-hSl
-wMF
-ivM
-lNk
-rvM
-nye
-ofW
-rvM
-tTc
-edD
-pJy
-ofW
-tTc
-tzb
-nye
-ntb
-ofW
-rvM
-tTc
-elZ
+gxP
+doq
+iHu
+gcK
+mLd
+hCi
+ikW
+sws
+hCi
+mWM
+uuf
+giB
+sws
+mWM
+qiD
+ikW
+fLV
+sws
+hCi
+mWM
+kML
 aek
 aaE
-wQX
+puH
 aaR
 abe
-izr
+osT
 abI
-jou
+kAM
 adc
 acL
-jjI
+jTS
 ada
 adU
-kQn
+vyX
 aeU
 afO
 abe
@@ -110240,42 +110231,42 @@ oRp
 oRp
 aaa
 aaa
-lDG
+vIl
 lMJ
 lMJ
 lMJ
 aax
-dBt
+evB
 acJ
 aax
 abe
-hHp
-eMf
-mgU
-mgU
+jdF
+uwe
+pzz
+pzz
 abe
-hHp
-sqg
+jdF
+aqe
 abe
 abe
 abe
-hHp
-wyA
-mgU
+jdF
+gdL
+pzz
 abe
 aax
-nBf
+sna
 aaR
 abD
 abc
 abD
 aaR
-mHh
+frH
 abe
-ugl
+tYS
 ade
-ris
-snT
+hSF
+jkE
 ada
 aeV
 afP
@@ -110495,34 +110486,34 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
 aax
 aax
 aax
 aax
-dBt
-iNa
+evB
+mBw
 aax
-ssk
-sbK
-tAZ
-pKn
-pKn
+mUt
+yjm
+uoG
+unV
+unV
 abe
-pYH
-wNF
-skT
+rmx
+iWd
+aHb
 abe
-iSh
-koT
-loL
-mGY
-xGj
+qIM
+gzm
+foI
+rmc
+oQi
 aax
-uZp
-uNd
+gnY
+qph
 abD
 abb
 abD
@@ -110530,10 +110521,10 @@ abK
 ace
 abe
 acM
-laI
-laI
+ixP
+ixP
 adT
-fCN
+xxn
 aeP
 afK
 agJ
@@ -110752,37 +110743,37 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
-lKn
-enW
-qvk
-lKn
-uKC
-vLa
+jDg
+myn
+lrW
+jDg
+pne
+lVF
 aax
-ijA
-fig
-tAZ
-rBF
-ejf
+gAw
+vtl
+uoG
+lTI
+rIx
 abe
-lDD
-wNF
-tMM
+dpS
+iWd
+wqD
 abe
-dWl
-toK
-loL
-oOC
-lVN
+mOd
+dsP
+foI
+txH
+xpO
 aax
 aax
 aax
-lay
+nGR
 aax
-lay
+nGR
 aax
 aax
 aax
@@ -111009,37 +111000,37 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
-enW
-pgf
-pgf
-enW
-pmz
-drb
+myn
+wcF
+wcF
+myn
+oWJ
+ihj
 aax
-ssk
-ssk
-nSJ
-ssk
-pKn
+mUt
+mUt
+mAX
+mUt
+unV
 abe
-vqq
-wNF
-jpG
+hNL
+iWd
+fuH
 abe
-xIm
-jlF
-loL
-ijp
-gzg
+nNF
+kGc
+foI
+uOl
+sWJ
 aax
 lMJ
 aax
-dJG
-xRp
-dJG
+ilx
+wsD
+ilx
 aax
 abL
 acy
@@ -111266,37 +111257,37 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
-enW
-pgf
-pgf
-enW
-pmz
-mVT
+myn
+wcF
+wcF
+myn
+oWJ
+kwQ
 aax
-jef
-tAZ
-tAZ
-tAZ
-xTR
+wpv
+uoG
+uoG
+uoG
+dTE
 abe
-pBt
-nqA
-lSI
+vsN
+fKQ
+gvD
 abe
-fZr
-koT
-loL
-mGY
-iSh
+oLo
+gzm
+foI
+rmc
+qIM
 aax
-lDG
+vIl
 aax
-dJG
-mUW
-dJG
+ilx
+pHs
+ilx
 aax
 abL
 aax
@@ -111523,37 +111514,37 @@ oRp
 oRp
 oRp
 oRp
-lDG
+vIl
 lMJ
 aax
-lKn
-enW
-vUh
-lKn
-ghu
+jDg
+myn
+gtB
+jDg
+dpp
 acK
 aax
-ntK
-rIl
-ndG
-lXX
-ejf
+ohN
+nSz
+ycv
+lcI
+rIx
 abe
-dOs
-slB
-jEt
-hqd
-loL
-tmA
-ybz
-ibJ
-fIg
+riJ
+qMY
+tIa
+lRB
+foI
+eko
+lBJ
+noJ
+xNd
 aax
 aaf
 aax
-dJG
-dJG
-dJG
+ilx
+ilx
+ilx
 aax
 abL
 aax
@@ -111780,31 +111771,31 @@ aaa
 aaa
 aaa
 oRp
-lDG
+vIl
 lMJ
 aax
 aax
 aax
 aax
 aax
-dBt
-iNa
+evB
+mBw
 aax
 abe
-vHJ
+xiv
 abe
 abe
-tVC
+iEJ
 abe
-uxa
-jEt
-jEt
-lKK
-loL
-dwn
-loL
-pFU
-loL
+sSP
+tIa
+tIa
+lSA
+foI
+uqI
+foI
+hzu
+foI
 aax
 anT
 aax
@@ -112037,33 +112028,33 @@ aaa
 aaa
 aaa
 oRp
-lDG
+vIl
 lMJ
 lMJ
 lMJ
 lMJ
 lMJ
 aax
-rax
-kIM
+xMP
+yet
 aax
-iPt
-urD
-sPs
-mKx
-tED
+dsG
+qFB
+oUG
+tpQ
+pFr
 abe
-kJW
-jEt
-jEt
-ocM
-loL
-loL
-loL
-loL
-loL
+rmR
+tIa
+tIa
+xwk
+foI
+foI
+foI
+foI
+foI
 aax
-wVO
+qFw
 aaa
 aaa
 aaa
@@ -112298,27 +112289,27 @@ aaa
 aaa
 aaa
 aaa
-oRr
-hPL
+fyE
+oBL
 aax
-sjx
-tmi
+fre
+ttc
 aax
-uzR
+kiC
 abL
 abL
-oWl
-hWr
+jka
+lRO
 abe
-gIi
-jEt
-jEt
-bSL
-loL
-loL
-loL
-loL
-fMR
+tdd
+tIa
+tIa
+tAA
+foI
+foI
+foI
+foI
+eGr
 aax
 aaa
 aaa
@@ -112555,27 +112546,27 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-vFy
-eTs
+oFh
+lDB
 aax
-dry
-pIK
-mBi
-lUd
-oxY
+jqX
+nbu
+kdi
+jQt
+sAM
 abe
-jel
-kKw
-xZP
+dRg
+rYv
+hwb
 abe
-fHt
-nss
-qdR
-dFH
-dFH
+gqs
+isd
+uJz
+wel
+wel
 aax
 aaa
 aaa
@@ -112812,11 +112803,11 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-hJO
-eTs
+uad
+lDB
 aax
 aax
 aax
@@ -113069,17 +113060,17 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-hJO
-eTs
+uad
+lDB
 aax
-rqz
-hgM
+vxZ
+iOK
 aaR
-rqz
-rqz
+vxZ
+vxZ
 aax
 lMJ
 lMJ
@@ -113326,28 +113317,28 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-tRb
-qdZ
-vVS
-fwS
-fwS
-pjD
+oeg
+wfX
+oNC
+dUc
+dUc
+sIH
 aaR
 aaR
 aax
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
 aaa
 aaa
 urv
@@ -113583,17 +113574,17 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-hJO
-eTs
-lnf
+uad
+lDB
+tNT
 aaR
 agL
 agL
 agL
-eLc
+sEe
 aax
 aaa
 aaa
@@ -113840,19 +113831,19 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-vFy
-lNL
+oFh
+jcu
 aek
 aaS
 aaS
-wQX
+puH
 aaR
 aaR
 aax
-uty
+qKV
 sdw
 aaa
 aaa
@@ -113860,13 +113851,13 @@ aaa
 aaa
 aaa
 aaa
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
-lDG
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
+vIl
 abe
 wiZ
 aax
@@ -114097,19 +114088,19 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
-mXy
-gfa
+jCm
+svF
 aax
-rGF
-teM
-iPQ
-kqP
-kqP
+hFf
+vrj
+uxr
+eJB
+eJB
 aax
-uty
+qKV
 sdw
 aaa
 aaa
@@ -114354,7 +114345,7 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 aax
 aax
@@ -114366,7 +114357,7 @@ aax
 aax
 aax
 aax
-uty
+qKV
 sdw
 aaa
 aaa
@@ -114611,19 +114602,19 @@ aaa
 aaa
 aaa
 aaa
-oRr
+fyE
 lMJ
 lMJ
 lMJ
 lMJ
 lMJ
-jkw
+uvp
 lMJ
 lMJ
 lMJ
 lMJ
 lMJ
-uty
+qKV
 sdw
 aaa
 aaa
@@ -114868,19 +114859,19 @@ aaa
 aaa
 aaa
 aaa
-uty
-uty
-uty
-uty
-uty
-uty
-uty
-uty
+qKV
+qKV
+qKV
+qKV
+qKV
+qKV
+qKV
+qKV
 lMJ
-oRr
-oRr
-oRr
-oRr
+fyE
+fyE
+fyE
+fyE
 sdw
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35,6 +35,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aaZ" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "abf" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
@@ -2435,13 +2448,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ahS" = (
-/obj/structure/table/optable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahT" = (
@@ -2678,9 +2693,6 @@
 /area/maintenance/department/security/brig)
 "aiv" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -3766,6 +3778,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "akF" = (
@@ -14496,6 +14510,22 @@
 	},
 /turf/open/space,
 /area/solar/port)
+"aIz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Permabrig East Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aIC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -16712,12 +16742,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"aOq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/prison)
 "aOs" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
@@ -26278,6 +26302,19 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"bkI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
 "bkP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -29052,9 +29089,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bqP" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/security/prison)
 "bqS" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
@@ -38413,6 +38447,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"bJY" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "bJZ" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -47223,6 +47261,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cgD" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "cgG" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
@@ -47330,16 +47375,6 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"cha" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "chb" = (
 /obj/machinery/camera{
 	c_tag = "Monastery Kitchen";
@@ -47935,6 +47970,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"cjK" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood,
+/area/security/prison)
 "cjO" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -48910,6 +48949,11 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"cmT" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "cmU" = (
 /obj/machinery/light{
 	dir = 4
@@ -50121,6 +50165,15 @@
 /obj/item/reagent_containers/food/snacks/grown/poppy,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"crI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "crK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -52013,6 +52066,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"czz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "czB" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
@@ -52114,15 +52173,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cAb" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "cAg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -52136,13 +52186,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cAh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cAi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -52357,15 +52400,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cAZ" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cBk" = (
 /obj/machinery/vending/boozeomat/pubby_maint,
 /turf/closed/wall,
@@ -52518,24 +52552,27 @@
 "cBU" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
+"cBV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cCl" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "cCt" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"cCv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "cCB" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"cCC" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "cCF" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
@@ -52623,29 +52660,11 @@
 "cDa" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"cDr" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "cDB" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"cEZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "cFB" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -52658,15 +52677,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"cIn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "cJo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -52702,6 +52712,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cNl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -52743,31 +52762,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cRF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"cRH" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"cSy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cSJ" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -2;
@@ -52822,17 +52816,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"cSZ" = (
-/obj/machinery/light{
+"cWy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"cWh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"cWR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "cXW" = (
 /obj/structure/grille,
@@ -52852,13 +52847,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dat" = (
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"daM" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "daY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -52869,24 +52857,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"dbO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dci" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"dcF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dcL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"dfv" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dgg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -52947,31 +52949,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dih" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"djC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"djK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"djN" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dkR" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -52991,6 +52988,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"dkZ" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "dmP" = (
 /obj/structure/chair{
 	dir = 8
@@ -53149,13 +53149,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"dvB" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "dxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53168,20 +53161,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"dxg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+"dxr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"dxO" = (
-/obj/structure/punching_bag,
+"dxS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/button/door{
+	id = "soli1";
+	name = "Solitary Cell 1";
+	pixel_x = 26;
+	pixel_y = 10;
+	req_access_txt = "3"
+	},
+/obj/machinery/door_timer{
+	id = "soli1";
+	name = "Solitary 1 door timer";
+	pixel_x = 31;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -53198,6 +53204,18 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dyo" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Prisoner Arrivals";
+	dir = 8;
+	name = "aft camera"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dAF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -53212,20 +53230,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
-"dCE" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dEy" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -53233,24 +53237,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"dEU" = (
-/obj/machinery/door/airlock/glass{
-	name = "Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "dFJ" = (
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dHp" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"dGL" = (
+/obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dHr" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
@@ -53265,6 +53263,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dHT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dHZ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -53285,22 +53293,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"dIA" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dJk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -53326,12 +53318,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"dLt" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+"dLx" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53375,30 +53370,12 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dOw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dRg" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dRV" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/cryopod{
+"dRH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "dSp" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
@@ -53410,12 +53387,34 @@
 /obj/item/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"dSG" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dTx" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/instrument/accordion,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dTV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"dVh" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dVI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -53456,6 +53455,18 @@
 	name = "secure isolation floor"
 	},
 /area/security/prison)
+"dYv" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
+/area/security/prison)
+"dZe" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/peppermill,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dZj" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/airalarm/engine{
@@ -53466,16 +53477,35 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"eal" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/white,
+"eaq" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ear" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "eaw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"ebb" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "ebD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53484,6 +53514,14 @@
 	},
 /turf/open/floor/plating,
 /area/lawoffice)
+"ecP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "edl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53497,11 +53535,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"eeu" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/wood,
-/area/security/prison)
 "eex" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -53516,16 +53549,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"efs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+"efg" = (
+/obj/structure/table,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -53540,6 +53570,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"egr" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "egK" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -53554,6 +53591,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"eis" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "eit" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53561,16 +53616,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"eiL" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eiV" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -53584,17 +53629,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"elg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "elk" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -53647,6 +53681,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"etH" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "euQ" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -53656,25 +53702,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"evw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ewc" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"exJ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
 "eyj" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"eyW" = (
+/obj/item/caution,
+/obj/item/caution,
+/turf/open/floor/plating,
+/area/security/prison)
 "ezF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -53736,16 +53772,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"eCH" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eCK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53753,18 +53779,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"eDw" = (
+/obj/machinery/newscaster,
+/turf/closed/wall,
+/area/security/prison)
 "eDC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"eEl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "eEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -53777,16 +53801,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"eFk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eFG" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -53799,19 +53813,52 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"eHA" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eHI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"eIa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"eIj" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eIL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"eLl" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
+"eIW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"eLe" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "eLt" = (
 /obj/structure/closet/firecloset,
@@ -53827,12 +53874,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"eLP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
 "eMC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -53851,6 +53892,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
+"eNm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eNq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53862,14 +53914,6 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/space/nearstation)
-"eOV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/judgerobe,
@@ -53877,11 +53921,36 @@
 /obj/item/gavelhammer,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"ePO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"ePy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ePT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig West Hallway 2";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ePU" = (
@@ -53911,27 +53980,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"eRe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"eRo" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/instrument/accordion,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "eRp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -53958,6 +54006,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"eTm" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -53983,6 +54042,23 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"eXO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"eXP" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eYr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -53995,6 +54071,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"eZd" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eZA" = (
 /obj/item/stack/cable_coil/cut/random,
 /turf/open/floor/plating,
@@ -54045,28 +54140,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"feI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"feP" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 10;
-	req_access_txt = "3"
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = -5
-	},
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ffJ" = (
@@ -54092,15 +54178,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"fiS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fjs" = (
 /obj/machinery/light{
 	dir = 8
@@ -54114,6 +54191,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"fjy" = (
+/obj/item/bedsheet/rd/royal_cape,
+/obj/structure/bed/pod,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison)
 "fjD" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -54132,16 +54214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"flK" = (
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
@@ -54167,6 +54239,15 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"fnm" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fon" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -54192,6 +54273,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"fra" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"frg" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "frj" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
@@ -54241,6 +54333,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"fwh" = (
+/turf/open/floor/plasteel/elevatorshaft,
+/area/security/prison)
 "fwl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54294,6 +54389,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"fzj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "fzu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54349,13 +54453,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"fDA" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"fCf" = (
+/obj/structure/filingcabinet,
+/obj/machinery/camera{
+	c_tag = "Permabrig Library";
+	network = list("ss13","prison")
 	},
-/obj/item/reagent_containers/dropper,
+/turf/open/floor/wood,
+/area/security/prison)
+"fCY" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "fFv" = (
@@ -54366,6 +54478,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fGe" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fHs" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54385,24 +54519,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"fJn" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space North";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"fJY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "fKj" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Mineral Room"
@@ -54413,17 +54529,14 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"fLT" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"fMS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fNv" = (
@@ -54432,6 +54545,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fPH" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Prisoner-side";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fQf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54444,25 +54566,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fQk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/button/flasher{
-	id = "visitflash";
-	pixel_x = 24;
-	pixel_y = 5;
-	req_access_txt = "3"
-	},
-/obj/machinery/button/door{
-	id = "visit";
-	name = "Visitation Shutters";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fRs" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
@@ -54484,29 +54587,10 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"fUY" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "fWv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"fXd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fZK" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -54531,6 +54615,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"gbv" = (
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "gcj" = (
 /obj/machinery/vending/kink,
 /obj/effect/turf_decal/tile/blue{
@@ -54540,6 +54629,12 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
+"gdy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gdJ" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -54721,16 +54816,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gpd" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pressing Room"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "gpC" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -54752,28 +54837,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"gqv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gsF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gue" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -54789,10 +54852,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"guD" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
+"gur" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"guG" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -54825,12 +54895,6 @@
 	},
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
-"gxg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "gxq" = (
 /obj/structure/chair{
 	dir = 4
@@ -54857,15 +54921,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gAi" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"gyk" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"gzV" = (
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gAG" = (
@@ -54873,6 +54944,13 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"gAQ" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gBb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -54881,6 +54959,24 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"gCE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gCO" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Showers";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "gDR" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway Escape";
@@ -54968,21 +55064,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gIz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gIC" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -55005,18 +55086,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"gJF" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space,
-/area/space/nearstation)
-"gKv" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gKz" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/required/kirbyplants{
@@ -55035,6 +55104,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gKV" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gLF" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -55049,16 +55123,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"gLW" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "gMm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -55090,15 +55154,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gOH" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"gNM" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "gPV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55112,6 +55177,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"gQL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
+"gRQ" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/security/prison)
 "gSH" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -55142,20 +55222,6 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
-"gVK" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/security/prison)
 "gXg" = (
 /obj/item/extinguisher,
 /obj/structure/closet/crate{
@@ -55188,10 +55254,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"haP" = (
-/obj/item/caution,
-/obj/item/caution,
-/turf/open/floor/plating,
+"hds" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -55204,12 +55269,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"heX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hfZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
@@ -55231,16 +55290,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hiB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hiY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55282,14 +55331,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"hme" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "hnu" = (
 /obj/machinery/button/door{
 	id = "lawyer_shutters";
@@ -55310,19 +55351,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"hoq" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hoB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation - Prisoners"
+"hox" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "visitexit"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hoS" = (
@@ -55353,48 +55389,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hqu" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"hqv" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hqU" = (
-/obj/machinery/holopad,
+"hto" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"hrr" = (
+"hts" = (
+/obj/structure/chair/stool,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/jukebox{
-	req_one_access = null
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hrP" = (
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/wood,
-/area/security/prison)
-"hrT" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/security/prison)
-"hue" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
+"hul" = (
+/obj/structure/bed,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -55430,17 +55452,18 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"hwK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hxn" = (
 /obj/structure/chair,
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hxI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "hyh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -55477,17 +55500,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"hBx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+"hBl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hBO" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"hBT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -55499,18 +55531,22 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/entry)
-"hDs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"hDa" = (
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hDE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
@@ -55543,17 +55579,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hGv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "hGB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -55563,14 +55588,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"hGU" = (
+"hGY" = (
+/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hHr" = (
@@ -55601,9 +55627,10 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"hKq" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
+"hKz" = (
+/obj/machinery/plate_press,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "hOx" = (
 /obj/structure/cable{
@@ -55632,25 +55659,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"hPQ" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hPU" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -55679,6 +55687,16 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"hQB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hQC" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -55730,6 +55748,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hTZ" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -55742,18 +55766,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"hUC" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
-	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
-	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hUJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55763,37 +55775,42 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"hVl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "hVx" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"hVy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hVF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"hVZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hXt" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hXy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hXK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -55827,21 +55844,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"hZG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -55857,13 +55859,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"iaf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ick" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55878,26 +55873,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ieP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ifm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ifS" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -55932,6 +55907,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ihx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ijr" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -55959,6 +55956,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"ile" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ill" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
@@ -56002,12 +56016,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ior" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"iox" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitations Visitor-side";
+	dir = 8;
+	network = list("s13","prison");
+	start_active = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/button/door{
+	id = "sexroom";
+	name = "Conjugal Visits";
+	pixel_x = 27;
+	pixel_y = 1;
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ioF" = (
@@ -56018,9 +56040,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ipj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iqc" = (
 /turf/open/floor/plasteel/stairs/right,
 /area/maintenance/department/crew_quarters/dorms)
+"iqr" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "irM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -56028,6 +56070,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"isR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"itg" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "itl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56043,6 +56099,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"itv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "iuM" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -56078,14 +56140,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ixK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"ixh" = (
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "iyg" = (
 /obj/structure/cable{
@@ -56165,6 +56221,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"iCw" = (
+/obj/structure/table,
+/obj/item/paicard,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iCV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -56172,6 +56237,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"iEy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iEQ" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -56188,12 +56264,37 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"iFL" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iGJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
+"iHP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iJi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -56203,10 +56304,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"iJz" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/security/prison)
 "iKb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56225,17 +56322,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"iNH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"iNL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 0
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "iPj" = (
 /obj/machinery/igniter{
@@ -56299,23 +56394,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iSe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "iSz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -56332,32 +56410,88 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"iTM" = (
+/obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "iVJ" = (
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"iWI" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Garden";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iWV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"iXh" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iXx" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
+"iXA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"jcc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jdk" = (
-/turf/open/floor/plasteel/showroomfloor,
+"jee" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jeq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56373,26 +56507,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"jeH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jeJ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -56404,6 +56518,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"jgF" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space West";
+	dir = 8;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jhk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56426,6 +56549,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"jje" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -56438,37 +56574,45 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"jlV" = (
-/obj/machinery/shower{
-	dir = 4
+"jlE" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"jnr" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"jnP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"joT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/cryopod{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"joC" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"joF" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"jrE" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -56511,6 +56655,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"jsJ" = (
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/obj/item/tank/internals/plasmaman/belt,
+/turf/open/floor/plating,
+/area/security/prison)
 "jtf" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56540,6 +56695,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"jvW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jwe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -56551,9 +56716,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"jxi" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
+"jwJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "jxl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -56568,6 +56735,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jyM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jzz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -56626,15 +56799,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"jDL" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"jDB" = (
+/turf/open/floor/wood,
+/area/security/prison)
+"jEy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jEX" = (
 /obj/structure/disposalpipe/segment{
@@ -56668,23 +56844,40 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jLT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+"jIA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jJf" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jLW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"jNW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jOB" = (
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -56703,6 +56896,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/science)
+"jQW" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "jRG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -56713,40 +56910,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"jRV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jSa" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"jSx" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jTc" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56778,6 +56959,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jUQ" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/item/toy/cards/deck,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jUV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56787,13 +56980,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jWn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+"jVf" = (
+/obj/structure/chair/stool,
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"jVi" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jXh" = (
@@ -56839,13 +57033,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"jZP" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "kaR" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -56855,46 +57042,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kev" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"kfz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"kfk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"kfv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/security/prison)
 "kfM" = (
 /obj/structure/closet,
@@ -56916,6 +57080,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"khB" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -56929,6 +57100,15 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"kjM" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kkk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -56936,22 +57116,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
-"kkO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kkQ" = (
 /obj/machinery/vending/cola/pwr_game,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"kla" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "klb" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -56970,6 +57147,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"klT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "klV" = (
 /obj/item/clothing/under/rank/civilian/clown/sexy,
 /turf/open/floor/plasteel/dark,
@@ -56984,11 +57174,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"knW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/peppermill,
-/turf/open/floor/plasteel/white,
+"knZ" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "koz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -57006,6 +57200,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"kqr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "krU" = (
 /obj/structure/chair{
 	dir = 4
@@ -57019,10 +57230,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ksn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
+"ktt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -57039,17 +57254,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kvm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kwm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -57093,17 +57297,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kzB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -57120,14 +57313,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"kCP" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"kAu" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/flasher{
+	id = "visitflash";
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -57150,9 +57346,11 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"kEx" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
+"kEo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "kEM" = (
 /obj/structure/sign/directions/evac{
@@ -57227,13 +57425,34 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"kHc" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	network = list("ss13","prison")
+"kHH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "kIc" = (
 /obj/machinery/door/airlock/public/glass{
@@ -57260,6 +57479,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kJn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "kJo" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -57275,35 +57501,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"kKe" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
+"kKj" = (
+/obj/machinery/cryopod{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"kKr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kKt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "kKI" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57326,6 +57528,23 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kOj" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/snacks/hotdog,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"kPd" = (
+/obj/machinery/door/airlock/glass{
+	name = "Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "kPi" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -57340,19 +57559,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"kPs" = (
-/obj/machinery/shower{
-	dir = 4
+"kQc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/soap,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"kQl" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/wood,
 /area/security/prison)
 "kQy" = (
 /obj/structure/disposalpipe/segment{
@@ -57390,19 +57601,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"kRM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kSb" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -57436,11 +57634,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kTN" = (
-/obj/machinery/plate_press,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "kTR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -57454,18 +57647,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"kVK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"kWr" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+"kVQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -57499,14 +57683,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"kYK" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+"kYn" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kYM" = (
@@ -57519,17 +57702,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"lbB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "lcU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"lcY" = (
-/obj/item/bedsheet/rd/royal_cape,
-/obj/structure/bed/pod,
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
 "lcZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -57551,13 +57735,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"leW" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "lfx" = (
 /obj/structure/table,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
@@ -57595,49 +57772,24 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"lji" = (
+/obj/structure/bed,
+/obj/effect/landmark/start/prisoner,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/item/bedsheet/orange,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ljG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lkz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"llp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -57662,11 +57814,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"loc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"loy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Pressing Room"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "loz" = (
 /obj/structure/closet/radiation,
@@ -57679,12 +57835,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"lpz" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+"loE" = (
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"loT" = (
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "lqc" = (
 /obj/item/toy/gun,
@@ -57700,12 +57869,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"lrf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "lrM" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -57713,64 +57876,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ltA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"lvP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lvR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"lxp" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "lxI" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/chapel/monastery)
-"lyl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"lzt" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -57804,22 +57915,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lDf" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"lDG" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "lEn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -57882,6 +57977,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lIZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lJr" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -57904,12 +58009,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"lLV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "lMU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -57917,14 +58016,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"lNU" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/security/prison)
 "lNW" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -57964,6 +58055,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lRC" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "lRX" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -57971,20 +58069,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"lTB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/storage/bag/tray,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -57999,20 +58083,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"lVV" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"lWq" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lWy" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -58049,6 +58119,16 @@
 /obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"lXo" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lXJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -58056,6 +58136,28 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"lYo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"mai" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58070,12 +58172,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"mam" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "mau" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -58102,14 +58198,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mbU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+"mbW" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mci" = (
@@ -58191,12 +58288,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"mkZ" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -58204,17 +58295,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"mlX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mmv" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -58227,13 +58307,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mmR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "mnG" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
@@ -58251,11 +58324,16 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"mpt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"mpo" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/camera{
+	c_tag = "Permabrig Pressing Room";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "mpy" = (
 /obj/structure/table/wood,
@@ -58263,6 +58341,14 @@
 /obj/item/pen/blue,
 /turf/open/floor/wood,
 /area/lawoffice)
+"mqa" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mql" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -58288,32 +58374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"mrk" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"mrq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"mrz" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -58352,14 +58412,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"muL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/security/prison)
-"mwe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "mwg" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -58370,6 +58422,20 @@
 /obj/item/gun/ballistic/shotgun/toy,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"mwy" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mwG" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -58378,6 +58444,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mxp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 2";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mxy" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -58416,14 +58495,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mzd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
+"myP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
 /area/security/prison)
 "mzl" = (
 /obj/structure/chair,
@@ -58434,11 +58508,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/engine)
-"mAx" = (
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
+"mzV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/checker,
+/area/security/prison)
+"mBc" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "mCe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58448,11 +58533,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
-"mCq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"mCp" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "mDW" = (
 /obj/machinery/power/smes{
@@ -58477,16 +58564,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mFl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/vending/kink,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -58500,14 +58577,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"mJu" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -58538,15 +58607,26 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"mPT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"mNx" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"mOR" = (
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "mQm" = (
 /obj/structure/chair/office/light{
@@ -58554,21 +58634,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"mQn" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"mRP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "mSc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -58590,6 +58655,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"mTZ" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "mVD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -58599,32 +58672,29 @@
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"mWg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"mWK" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "mXq" = (
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/lawoffice)
+"mYL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"mYN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "mZE" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -58641,12 +58711,6 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nbm" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "ncm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -58663,6 +58727,20 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"ndV" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -58694,20 +58772,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nga" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"nfI" = (
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/wood,
+/area/security/prison)
+"nfV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "nge" = (
 /obj/structure/grille/broken,
@@ -58718,20 +58803,21 @@
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
-"nhn" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "nho" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"nhq" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northeast";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nih" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/costume,
@@ -58755,31 +58841,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"niG" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"njr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nku" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
@@ -58788,14 +58849,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"nmK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"nmx" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -58816,17 +58887,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"npo" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "npE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nqo" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nqu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -58844,25 +58918,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"nqY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nrk" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nsy" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -58900,17 +58955,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"nsQ" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/plating,
+"nsS" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ntj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58924,12 +58978,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ntI" = (
-/obj/machinery/shower{
-	dir = 4
+"ntp" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/vaporwave,
 /area/security/prison)
 "nuv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58941,25 +58994,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"nxc" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nxQ" = (
+"nwi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"nyv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nyB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58979,15 +59036,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"nze" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "nzD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -59073,13 +59121,12 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"nGy" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge West";
-	dir = 4;
-	network = list("ss13","prison")
+"nHC" = (
+/obj/machinery/shower{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/item/soap,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "nIm" = (
 /obj/machinery/computer/security/telescreen{
@@ -59091,17 +59138,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"nIw" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+"nIG" = (
+/obj/machinery/computer/arcade,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -59128,11 +59171,31 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"nJO" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nKo" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nKK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nLl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59140,6 +59203,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nMk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nMG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -59182,6 +59251,12 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"nOm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "nOY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59231,15 +59306,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
-"nTc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nTr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -59254,28 +59320,6 @@
 /obj/item/twohanded/spear,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nWs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"nWL" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Visitor-side";
-	dir = 8;
-	network = list("s13","prison");
-	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "sexroom";
-	name = "Conjugal Visits";
-	pixel_x = 27;
-	pixel_y = 1;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "nWP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -59295,22 +59339,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"obe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"obf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "obj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59335,6 +59363,10 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"ocG" = (
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "odM" = (
 /obj/effect/landmark/barthpot,
 /turf/open/floor/carpet,
@@ -59351,12 +59383,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oew" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
@@ -59377,10 +59403,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ohd" = (
+/obj/machinery/deepfryer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oiR" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/security/prison)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom";
@@ -59391,6 +59428,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"one" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/prison)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -59403,12 +59444,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ood" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "ooh" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -59420,6 +59455,13 @@
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
 /area/medical/chemistry)
+"ooi" = (
+/obj/structure/punching_bag,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "opz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -59443,6 +59485,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"osn" = (
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -59452,13 +59498,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"osF" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
 "ous" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
@@ -59481,6 +59520,21 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ova" = (
+/obj/structure/table,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"ove" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ovM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -59495,6 +59549,16 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"owb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "owS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59505,10 +59569,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"oxr" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oxw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59524,6 +59584,16 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ozY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oAw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59565,6 +59635,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"oDc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oDO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oDP" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -59572,12 +59658,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"oEp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"oEo" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "oEA" = (
 /turf/closed/wall,
@@ -59638,19 +59726,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
-"oGO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oHa" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
@@ -59661,9 +59736,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"oIx" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
+"oHY" = (
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "oKa" = (
 /obj/structure/rack,
@@ -59692,13 +59770,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"oLN" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "oLR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -59719,21 +59790,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oOa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oPx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -59755,13 +59811,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"oPL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oRX" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -59842,13 +59891,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oUC" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59899,6 +59941,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oYG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -59924,21 +59970,31 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"pbQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "pbR" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"pci" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pdq" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"pdN" = (
-/obj/structure/chair/stool,
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "pdW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -59951,19 +60007,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/explab)
-"pek" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/shovel/spade,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "peE" = (
 /obj/machinery/door/poddoor{
 	id = "soli2"
@@ -59999,18 +60042,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"phc" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
-/area/security/prison)
 "phJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"phR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "phS" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -60028,33 +60076,31 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
-"pjE" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "pjH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"pjS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
+"plj" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleeper Hallway";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "plA" = (
 /obj/structure/piano,
 /turf/open/floor/plasteel/dark,
@@ -60066,6 +60112,16 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pmT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/vending/kink,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -60118,6 +60174,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"ptK" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "puw" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -60140,15 +60201,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"pwi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pwj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60165,12 +60217,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pxC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/prison)
 "pxD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60182,30 +60228,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"pxJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"pyw" = (
-/turf/open/space/basic,
-/area/hallway/secondary/entry)
-"pze" = (
+"pyd" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/fortunecookie,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"pzx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+"pyw" = (
+/turf/open/space/basic,
+/area/hallway/secondary/entry)
 "pBD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60223,14 +60253,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pCe" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pCo" = (
 /obj/structure/reflector/single/anchored{
 	dir = 6
@@ -60240,6 +60262,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"pDc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "pDP" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/neutral{
@@ -60254,27 +60283,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"pDS" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pEG" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -60317,17 +60325,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"pIn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"pJz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"pHC" = (
+/obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
+/area/security/prison)
+"pHQ" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/wood,
 /area/security/prison)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60337,14 +60347,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"pKD" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pMG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -60395,9 +60397,20 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"pPr" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
+"pOZ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"pQm" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "pQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60405,30 +60418,8 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"pQP" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleeper Hallway";
-	dir = 1;
-	name = "security camera";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"pRz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"pRj" = (
+/turf/open/floor/plasteel/vaporwave,
 /area/security/prison)
 "pVD" = (
 /obj/machinery/light/small{
@@ -60438,17 +60429,9 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
-"pVH" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
+"pWa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "pWm" = (
 /obj/machinery/door/window/southleft{
@@ -60536,17 +60519,20 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
-"pZq" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "qar" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qaC" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -60578,16 +60564,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qcR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qdi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60617,20 +60593,6 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qdw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/flasher{
-	id = "visitflash";
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qeY" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -60661,40 +60623,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qmK" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "qni" = (
 /obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
 /area/medical/surgery)
+"qnA" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall,
+/area/security/prison)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qpc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "qpd" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
@@ -60714,22 +60654,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qqB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
-"qsd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"qqM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qsJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qtA" = (
@@ -60760,6 +60694,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qua" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"qwU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Out"
@@ -60776,21 +60725,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qzc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qAM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"qBc" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"qBt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "qBv" = (
 /obj/item/clothing/head/ushanka,
 /turf/open/floor/plating,
@@ -60814,14 +60765,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"qEG" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/window/reinforced{
@@ -60890,23 +60833,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qIY" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"qKY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qLI" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -60922,6 +60848,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qLQ" = (
+/obj/structure/lattice,
+/obj/machinery/camera,
+/turf/open/space,
+/area/space/nearstation)
 "qMi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -60940,9 +60871,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"qNy" = (
+"qMl" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
+/area/security/prison)
+"qOt" = (
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "qOE" = (
 /turf/open/floor/plasteel/dark,
@@ -60978,6 +60912,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"qPK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "qRl" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -60988,11 +60928,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qSW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+"qSk" = (
+/obj/structure/weightmachine/weightlifter,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"qSF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "qTV" = (
 /obj/item/radio/intercom{
@@ -61018,6 +60969,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"qUW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/security/prison)
+"qVH" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "qVP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61029,33 +60991,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qVV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qVX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "visitexit";
-	name = "Visitation Prisoner Lockdown";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qWf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Sleepers"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qWo" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -61127,13 +61062,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"rai" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/storage/bag/trash,
-/obj/item/radio/off,
-/turf/open/floor/plating,
-/area/security/prison)
 "rar" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -61144,9 +61072,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"rcK" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -61190,14 +61115,14 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
-"riu" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+"rhu" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "riF" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/tile/neutral{
@@ -61221,56 +61146,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"rke" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+"rka" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"rkl" = (
-/obj/structure/bed,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"rlL" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"rlR" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
+"rlf" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rmC" = (
 /turf/open/space/basic,
 /area/space/station_ruins)
-"rmT" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rnr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -61297,13 +61191,20 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
-"rox" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+"rqr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "rrb" = (
 /obj/structure/cable{
@@ -61352,6 +61253,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rvD" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "rvH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -61366,15 +61277,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"rwZ" = (
-/obj/structure/table,
+"rvN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"rwh" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "rxa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -61400,21 +61314,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"ryW" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -61424,6 +61323,23 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"rAB" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Northwest";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"rAR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rBh" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -61432,12 +61348,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rDA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cell Hallway 1";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rEh" = (
 /obj/structure/table/glass,
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rEs" = (
+/obj/structure/bookcase/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "rFq" = (
 /obj/structure/chair,
 /obj/item/reagent_containers/food/snacks/donkpocket,
@@ -61445,28 +61377,9 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"rGP" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "rHA" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"rIt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rJg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light/small{
@@ -61479,6 +61392,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"rJA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rJZ" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -61520,6 +61441,18 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"rLO" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Sleepers";
+	dir = 1;
+	name = "security camera";
+	network = list("ss13","prison")
+	},
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rMV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61527,15 +61460,22 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
-"rNl" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+"rNc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rNB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rNW" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rPg" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -61557,39 +61497,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"rUC" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"rUW" = (
+"rUj" = (
+/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rVa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rWE" = (
@@ -61608,6 +61520,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"rYd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "rYC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -61617,18 +61537,17 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"rZc" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"sbr" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera{
-	c_tag = "Permabrig Library";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "sbY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -61659,6 +61578,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"scV" = (
+/obj/structure/holohoop,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "sdk" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -61689,6 +61618,13 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"sik" = (
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/storage/bag/trash,
+/obj/item/radio/off,
+/turf/open/floor/plating,
+/area/security/prison)
 "sjC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -61715,14 +61651,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"smj" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
+"smh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Permabrig Laundry";
+	dir = 4;
+	network = list("ss13","prison")
 	},
-/turf/open/floor/plating,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "smv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -61735,6 +61679,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"spk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -61754,16 +61704,6 @@
 "sqQ" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"srY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "srZ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -61774,6 +61714,14 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ssS" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Lounge West";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "stQ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -61790,15 +61738,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"suV" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
-	name = "aft camera"
+"suF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "svA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -61817,13 +61769,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"sws" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sww" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
@@ -61862,16 +61807,6 @@
 /obj/item/clothing/mask/gas/plaguedoctor,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"sAS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61887,19 +61822,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sDt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sEe" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -61911,16 +61833,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"sEW" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall/r_wall,
-/area/security/prison)
 "sGr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"sIp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "sJp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -61942,6 +61866,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sKD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sNz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61955,6 +61885,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"sPY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -61965,18 +61901,32 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"sQJ" = (
-/obj/structure/chair/stool,
+"sRl" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Space Southeast"
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/security/prison)
+"sRI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"sRV" = (
+/obj/structure/table,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"sTU" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
-	},
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/storage/photo_album,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "sUP" = (
@@ -62152,6 +62102,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"tdP" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tfw" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -62159,6 +62119,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"tfF" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tfP" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -62167,10 +62141,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
+"tgv" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "thA" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"thP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Sleepers"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"thQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "thW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -62197,20 +62190,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"tiS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+"tjo" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
 /area/security/prison)
-"tjC" = (
-/obj/structure/toilet{
+"tjI" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "tkL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -62247,30 +62242,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"tmA" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tmE" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -62285,15 +62256,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"toK" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
+"toc" = (
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tpb" = (
@@ -62302,19 +62266,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
-"tpX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tqO" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -62335,11 +62286,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"tsn" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "ttS" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green,
@@ -62349,6 +62295,16 @@
 /mob/living/simple_animal/pet/bumbles,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ttV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tue" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -62366,16 +62322,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tuO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -62391,6 +62337,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"tws" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/security/prison)
 "twv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -62416,16 +62366,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"tyU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
 "tzH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
@@ -62434,6 +62374,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
+"tAC" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Showers"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "tAK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -62443,18 +62390,10 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"tCn" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/security/prison)
 "tCP" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"tCX" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
-/area/security/prison)
 "tDn" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -62466,6 +62405,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tEQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Kitchen";
+	network = list("ss13","prison")
+	},
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"tFH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tGR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tHk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -62475,11 +62446,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tIi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+"tHs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "tIS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -62496,26 +62465,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"tLv" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"tKj" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plating,
 /area/security/prison)
 "tLP" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"tMI" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+"tNn" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tNB" = (
 /turf/open/floor/plating,
 /area/security/prison)
 "tOD" = (
@@ -62525,6 +62499,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"tQK" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space East";
+	dir = 4;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "tQT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62568,12 +62551,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tXB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -62586,6 +62563,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"uaF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "uaO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -62602,6 +62588,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"ubk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/security/prison)
+"ubD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -62614,16 +62617,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"udI" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -62667,15 +62660,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ufu" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "ugC" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -62688,13 +62672,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"uht" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -62708,6 +62685,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ujL" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "ukn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62724,12 +62706,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ukW" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
-"ula" = (
-/turf/open/floor/wood,
-/area/security/prison)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -62762,6 +62738,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"umf" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/shovel/spade,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uoj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -62799,6 +62788,14 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"upP" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62867,13 +62864,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"uwE" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -62957,24 +62947,25 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uEq" = (
-/obj/structure/holohoop,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"uGM" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"uGA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
+/area/security/prison)
+"uGC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/security/prison)
 "uHG" = (
 /obj/structure/cable{
@@ -62994,28 +62985,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"uJe" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/food/condiment/saltshaker,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"uKX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -63039,13 +63008,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uMi" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Laundry"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow,
@@ -63059,24 +63021,25 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uMQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+"uNL" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole,
+/turf/open/floor/wood,
 /area/security/prison)
-"uPo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+"uOD" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"uPK" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"uQl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63094,20 +63057,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"uSx" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"uST" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"uUc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "permalock2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "uUQ" = (
@@ -63158,6 +63112,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"uYz" = (
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uZb" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -63166,6 +63129,35 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
+"uZh" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Permabrig Space North";
+	dir = 1;
+	name = "aft camera"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"uZA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"uZH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vay" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -63176,18 +63168,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"vaD" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+"vbp" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/button/door{
+	id = "visitexit";
+	name = "Visitation Prisoner Lockdown";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vbG" = (
-/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "vco" = (
@@ -63219,6 +63211,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"vfs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"vfF" = (
+/obj/structure/chair/stool,
+/obj/machinery/camera{
+	c_tag = "Permabrig Cafeteria";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "vgp" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -63240,17 +63246,6 @@
 /obj/structure/chair,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"vhL" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vjd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63295,6 +63290,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"vmp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vmG" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -63319,6 +63328,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vnA" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "voh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -63344,20 +63364,6 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
-"vqV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -63379,9 +63385,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vsy" = (
-/turf/open/floor/plating,
-/area/security/prison)
 "vsG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63417,6 +63420,19 @@
 "vtT" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"vuz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vuP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -63428,16 +63444,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"vvM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "vxp" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -63468,6 +63474,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"vyt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -63517,16 +63532,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vAN" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vBf" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
+"vBp" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "vBE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -63551,20 +63562,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vDn" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"vDu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vFn" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
+"vGc" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "vGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -63581,19 +63588,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vIZ" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
-/area/security/prison)
-"vJU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "vKq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/poster/official/random{
@@ -63604,6 +63598,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"vLw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vLN" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vMh" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/security/prison)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -63627,12 +63654,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"vPA" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
+"vQv" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "vRi" = (
 /obj/structure/disposalpipe/segment,
@@ -63672,13 +63703,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vSJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/security/prison)
 "vTL" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/tile/neutral{
@@ -63708,12 +63732,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"vUr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "vVO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -63724,14 +63742,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vXW" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
+"vWj" = (
+/obj/machinery/shower{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -63742,16 +63758,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"vZE" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "wbB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "External Gas to Loop"
@@ -63770,6 +63776,12 @@
 "wcs" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wdo" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/security/prison)
 "wdx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -63785,16 +63797,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"wfd" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "wfs" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -63844,24 +63846,6 @@
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wjj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wjm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63932,6 +63916,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"wrM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm{
@@ -63940,13 +63930,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"wsB" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wtE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -63954,16 +63937,6 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"wub" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wun" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63976,6 +63949,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wup" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/security/prison)
+"wvp" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -64002,6 +63988,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"wxD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wxJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -64010,15 +64002,36 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"wyJ" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1;
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "wzb" = (
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"wzj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"wAG" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/button/flasher{
+	id = "visitflash";
+	pixel_x = 24;
+	pixel_y = 5;
+	req_access_txt = "3"
+	},
+/obj/machinery/button/door{
+	id = "visit";
+	name = "Visitation Shutters";
+	pixel_y = -26;
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wAI" = (
@@ -64045,36 +64058,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wBk" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wBS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wCp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
 "wDe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
@@ -64113,20 +64096,12 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"wEp" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+"wET" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -64136,6 +64111,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wHy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Laundry"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wHB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wHI" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -64147,12 +64135,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wHX" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+"wHR" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "wIo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -64171,17 +64159,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wIY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"wIK" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"wJp" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "wJP" = (
 /obj/structure/lattice,
@@ -64194,6 +64187,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"wKc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "wLo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -64242,12 +64241,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wNU" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/security/prison)
 "wOa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -64266,6 +64259,31 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"wQv" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wQH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Visitation - Prisoners"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "visitexit"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -64352,13 +64370,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wXf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -64370,6 +64381,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"wXZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "wYu" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "shootshut"
@@ -64387,19 +64404,6 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"wZa" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wZs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -64408,16 +64412,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/entry)
-"xab" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xah" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64456,27 +64450,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"xbA" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/security/prison)
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"xdt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"xdJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xdK" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Arrivals";
-	dir = 8;
-	name = "aft camera"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xee" = (
@@ -64500,10 +64494,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"xfT" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+"xfV" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "xgh" = (
@@ -64567,6 +64564,11 @@
 /mob/living/simple_animal/hostile/retaliate/goose,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
+"xjt" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xjK" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -64591,10 +64593,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xkf" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "xlA" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xlG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "xmp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -64638,6 +64661,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xsj" = (
+/obj/machinery/plate_chute/inputchute{
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "xsO" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating{
@@ -64649,17 +64678,6 @@
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"xvj" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/nitrogen/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/turf/open/floor/plating,
-/area/security/prison)
 "xvO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -64670,18 +64688,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xwo" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"xwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel/dark,
@@ -64741,13 +64747,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xAd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -64771,16 +64770,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xEc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"xDR" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "sexroom"
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
-	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -64799,10 +64793,12 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
 /area/space/station_ruins)
-"xIb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+"xIf" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall,
 /area/security/prison)
 "xIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -64828,6 +64824,10 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"xKh" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -64859,13 +64859,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xNX" = (
-/obj/machinery/deepfryer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -64880,6 +64873,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"xPH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xQc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -64910,26 +64912,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"xTV" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xUV" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "xVt" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -64951,66 +64933,57 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"xWN" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+"xWR" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "xYV" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
+"ybO" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ybX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ycc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ycr" = (
 /obj/structure/target_stake,
 /obj/item/target/syndicate,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ycu" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ycx" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/department/engine)
-"ycE" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ydf" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"yeh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "yfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -65027,6 +65000,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"ylc" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
+"ylL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison)
 "ymb" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
@@ -81283,17 +81275,17 @@ aaa
 rmC
 rmC
 aaa
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
 aaa
 aaa
 aaa
@@ -81540,7 +81532,7 @@ aaa
 rmC
 rmC
 aaa
-rNl
+ptK
 aht
 aht
 aht
@@ -81548,9 +81540,9 @@ aht
 aht
 aht
 aht
-hue
 aht
-rNl
+aht
+ptK
 aaa
 aaa
 aaa
@@ -81783,21 +81775,21 @@ rmC
 rmC
 rmC
 rmC
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
 aht
 aem
 aem
@@ -81807,7 +81799,7 @@ aem
 aem
 aem
 aht
-rNl
+ptK
 aaa
 aaa
 aaa
@@ -82040,7 +82032,7 @@ rmC
 rmC
 rmC
 rmC
-rNl
+ptK
 aht
 aht
 aht
@@ -82051,20 +82043,20 @@ aht
 aht
 aht
 aht
-ufu
+jgF
 aht
 aht
 aht
 aht
 aem
-tmA
-kWr
-wjj
-wub
-ycE
+jJf
+dVh
+iWI
+ill
+mai
 aem
 aht
-rNl
+ptK
 aaa
 aaa
 aaa
@@ -82297,8 +82289,8 @@ rmC
 rmC
 rmC
 rmC
-rNl
-rlL
+ptK
+rAB
 aem
 aem
 aem
@@ -82314,14 +82306,14 @@ aem
 aem
 aem
 aem
-pEG
+lXo
 aig
-hoq
+dSG
 aig
-sEe
+pQm
 aem
 aht
-rNl
+ptK
 aaa
 aaa
 aaa
@@ -82554,31 +82546,31 @@ rmC
 rmC
 rmC
 rmC
-rNl
+ptK
 aht
 aem
-kTN
-hGv
-mAx
+hKz
+mpo
+xsj
 aem
-jlV
-ntI
-qIY
-jlV
-kPs
+qBc
+vWj
+gCO
+qBc
+nHC
 agy
-kev
-wEp
-elg
+kqr
+smh
+mbW
 agy
-rmT
-qSW
-hqv
-qsd
-sEe
+nqo
+sKD
+gKV
+sPY
+pQm
 aem
 aht
-rNl
+ptK
 aaa
 aaa
 aaa
@@ -82811,31 +82803,31 @@ rmC
 rmC
 rmC
 rmC
-rNl
+ptK
 aht
 aem
-kTN
-oLN
-cDr
+hKz
+ove
+etH
 aem
-jDL
-jdk
-jdk
-pxJ
-rGP
+wIK
+cCC
+cCC
+uZA
+mOR
 agy
-wZa
-kYK
-fLT
+suF
+guG
+mNx
 agy
-pek
+umf
 ahB
 aig
-jNW
-wBk
+cWy
+dfv
 aem
 aht
-rNl
+ptK
 aaa
 aaa
 afU
@@ -83066,30 +83058,30 @@ aaa
 aaa
 rmC
 rmC
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
 aht
 aem
-kTN
-tyU
-nWs
+hKz
+ubD
+mzV
 aem
-cAb
-nbm
-jdk
-gLW
-nbm
+wvp
+tgv
+cCC
+ebb
+tgv
 agy
-wZa
-jWn
-iSe
+suF
+vLw
+jIA
 agy
-ryW
-mrk
-lpz
-vaD
-nIw
+feP
+ndV
+egr
+tdP
+wQv
 aem
 aht
 aht
@@ -83323,29 +83315,29 @@ aaa
 aaa
 rmC
 rmC
-rNl
+ptK
 aht
 aht
 aht
 aem
 aem
-cWh
-gpd
+wKc
+loy
 aem
-aOq
+spk
 agy
-wXf
-pxC
-agy
-agy
-aOq
-uMi
-pxC
+tAC
+kfv
 agy
 agy
-aOq
-pPr
-hiB
+spk
+wHy
+kfv
+agy
+agy
+spk
+qnA
+sRI
 aem
 aem
 aht
@@ -83578,31 +83570,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
 aht
-eLl
-jLT
-sEW
-mWK
-jeH
-pRz
-gAi
-oGO
-niG
-obe
-rUW
-uST
-oOa
-oGO
-obe
-wIY
-nga
-obe
-hBx
-obe
-srY
+hBO
+kJn
+ocG
+mwy
+nyv
+hVy
+nsS
+tjI
+hGY
+oDc
+ePT
+ihx
+nKK
+tjI
+oDc
+qqM
+ePy
+oDc
+fGe
+oDc
+jEy
 aem
 aem
 aht
@@ -83835,31 +83827,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aht
 aht
 aen
-mFl
+pmT
 aig
-hwK
-tiS
-uGM
-xWN
-eFk
-gqv
-eRe
-gqv
-eFk
-gqv
-eFk
-gqv
-eRe
-gqv
-gqv
-fXd
-wsB
-vvM
+dxr
+kVQ
+wET
+kYn
+dHT
+tNn
+eIj
+tNn
+dHT
+tNn
+dHT
+tNn
+eIj
+tNn
+tNn
+ktt
+rUj
+hVZ
 aem
 aht
 aht
@@ -84090,19 +84082,19 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
 aht
 aem
-jLT
+kJn
 aem
-vBf
+hDa
 aig
-wzj
-vbG
-vhL
-qNy
+nwi
+gur
+vQv
+qMl
 agy
 agy
 agy
@@ -84115,8 +84107,8 @@ agy
 agy
 agy
 agy
-rlR
-vAN
+vLN
+toc
 aem
 aht
 aht
@@ -84347,32 +84339,32 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aht
 aht
 aen
-eCH
-nGy
+gzV
+ssS
 aic
-wBS
-xIb
-djN
-nrk
+hds
+jVi
+ybO
+jUQ
 agy
-rkl
-kKe
+hul
+dGL
 agy
-pVH
-kKe
+lji
+dGL
 agy
-rkl
-kKe
+hul
+dGL
 agy
-pVH
-kKe
+lji
+dGL
 agy
-ixK
+xPH
 aig
 aem
 aem
@@ -84604,32 +84596,32 @@ aaa
 aaa
 aaa
 aaa
-rNl
-fJn
-eLl
-jLT
-sEW
-pDS
+ptK
+uZh
+hBO
+kJn
+ocG
+eXP
 aig
 aic
 aig
-wzj
-mQn
-tmE
+nwi
+nJO
+mBc
 agy
-djC
-evw
+jee
+nMk
 agy
-djC
-evw
+jee
+nMk
 agy
-djC
-evw
+jee
+nMk
 agy
-djC
-evw
+jee
+nMk
 agy
-ixK
+xPH
 aig
 agy
 aeo
@@ -84640,10 +84632,10 @@ aeT
 aeC
 agn
 agy
-rVa
-gsF
-dCE
-vqV
+vmp
+iFL
+tfF
+uZH
 ahZ
 aiB
 ajc
@@ -84861,45 +84853,45 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
-jLT
-gKv
+kJn
+ooi
 aig
 aic
 aig
 aic
 aig
-wzj
-vbG
-vhL
+nwi
+gur
+vQv
 agy
-aOq
-djK
+spk
+yeh
 agy
-aOq
-djK
+spk
+yeh
 agy
-aOq
-djK
+spk
+yeh
 agy
-aOq
-djK
-qNy
-lVV
-lWq
-phc
+spk
+yeh
+qMl
+eaq
+xKh
+xIf
 aep
 aeD
 aeU
 agy
 afC
-mbU
-eiL
+hox
+knZ
 agy
 aae
 agW
-pKD
+ecP
 ahC
 aia
 aiC
@@ -85118,46 +85110,46 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
-tuO
-xUV
+hDE
+qSk
 aig
-cRF
-oew
-mzd
-oew
-fJY
-hVl
-kzB
-sDt
-oxr
-iaf
-ksn
-oxr
-iaf
+jcc
+eXO
+fzj
+eXO
+cNl
+uGC
+gQL
+rNc
+ear
+cWR
+dRH
+ear
+cWR
 aiH
-fiS
-iaf
-pwi
-oxr
-iaf
-sDt
-hGU
+kjM
+cWR
+rDA
+ear
+cWR
+rNc
+jvW
 aiH
-eOV
+rka
 aeq
 aiH
 aiH
 afo
 aiH
-tiS
+kVQ
 aga
 agz
 aie
-dLt
+ipj
 ahm
-dbO
+fHs
 aib
 aiD
 ajc
@@ -85375,46 +85367,46 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
-tuO
-hrr
+hDE
+vyt
 aig
-uEq
-ula
-tXB
-ula
-loc
-hrP
-oEp
-lWq
+scV
+jDB
+kQc
+jDB
+jwJ
+pHQ
+ubk
+xKh
 ahB
-jNW
-aig
-ahB
-jNW
-kEx
-ahB
-jNW
+cWy
 aig
 ahB
-jNW
-lWq
-ixK
+cWy
+eHA
+ahB
+cWy
 aig
-xAd
+ahB
+cWy
+xKh
+xPH
+aig
+uUc
 aig
 aig
-vXW
+uYz
 agy
 afE
-kEx
+eHA
 aig
 agy
 agK
 agY
-nqY
-pzx
+gAQ
+owb
 ahI
 aiE
 agy
@@ -85632,46 +85624,46 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
-tpX
-dxO
-heX
-kfz
-vJU
-hZG
-vJU
-iNH
-qpc
-wCp
-qsJ
-ieP
-cAh
-kRM
-ieP
-cAh
-xwG
-ieP
-cAh
-nmK
-ieP
-cAh
-qsJ
-hDs
-ePO
-feI
-ePO
+klT
+loE
+oDO
+eis
+uaF
+rqr
+uaF
+phR
+nfV
+bkI
+rAR
+fMS
+qwU
+mxp
+fMS
+qwU
+rJA
+fMS
+qwU
+iEy
+fMS
+qwU
+rAR
+jje
+gCE
+dxS
+gCE
 aeG
-ePO
+gCE
 afq
-ePO
+gCE
 agb
-ePO
+gCE
 agA
-efs
-tLv
+uGA
+eTm
 ahn
-pzx
+owb
 ahI
 aiF
 ajd
@@ -85889,40 +85881,40 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
-uht
-xUV
+rwh
+qSk
 aig
 aic
 aig
 aic
 aig
-wzj
-flK
-sQJ
-qNy
-aOq
-djK
+nwi
+hts
+ycu
+qMl
+spk
+yeh
 agy
-aOq
-djK
+spk
+yeh
 agy
-aOq
-djK
+spk
+yeh
 agy
-aOq
-djK
+spk
+yeh
 agy
-lVV
-lWq
+eaq
+xKh
 agy
 aet
 agy
 peE
 agy
 afG
-nTc
+dcF
 eSB
 agy
 ahD
@@ -86146,32 +86138,32 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
-eLl
-uht
-sEW
-pDS
+hBO
+rwh
+ocG
+eXP
 aig
 aic
 aig
-wzj
-rwZ
-toK
+nwi
+efg
+sRV
 agy
-gxg
-tIi
+isR
+vfs
 agy
-gxg
-tIi
+isR
+vfs
 agy
-gxg
-tIi
+isR
+vfs
 agy
-gxg
-tIi
+isR
+vfs
 agy
-ixK
+xPH
 aig
 agy
 aeu
@@ -86180,13 +86172,13 @@ dYe
 agy
 afH
 aeH
-lkz
+kHH
 agy
 agM
 aha
 ahp
 ahH
-qzc
+uQl
 aiH
 ajf
 ajL
@@ -86403,33 +86395,33 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aht
 aht
 aen
-udI
+nIG
 aig
 aic
 aig
-xdt
-nxc
-eRo
+eIa
+iCw
+dTx
 agy
-pVH
-tjC
+lji
+fnm
 agy
-rkl
-tjC
+hul
+fnm
 agy
-pVH
-tjC
+lji
+fnm
 agy
-rkl
-tjC
+hul
+fnm
 agy
-ixK
-sws
+xPH
+ile
 aem
 aem
 aem
@@ -86440,8 +86432,8 @@ aem
 aem
 agy
 agN
-dLt
-pzx
+ipj
+owb
 ahI
 aif
 aiB
@@ -86660,18 +86652,18 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
 aht
 aem
-uht
-vFn
+rwh
+wHR
 aic
 aig
-wzj
-flK
-sQJ
+nwi
+hts
+ycu
 agy
 agy
 agy
@@ -86684,21 +86676,21 @@ agy
 agy
 agy
 agy
-qNy
-ixK
-vAN
+qMl
+xPH
+toc
 aem
-ixK
+xPH
 aig
-vbG
+gur
 afr
-vbG
+gur
 aig
 ago
 agy
-uMQ
-ifm
-cWh
+crI
+cBV
+wKc
 ahJ
 aig
 aiJ
@@ -86919,43 +86911,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aht
 aht
 aen
-kkO
-cAZ
-qVV
-sAS
-lzt
-kvm
-lvP
-gIz
-ycc
-qcR
-qcR
-lvP
-qcR
-lvP
-njr
-qcR
-lvP
-qcR
-ior
-pJz
-hoB
-hGU
-dOw
-vbG
+tFH
+jrE
+gdy
+lIZ
+qaC
+iHP
+xdJ
+hBl
+vuz
+lYo
+lYo
+xdJ
+lYo
+xdJ
+jRV
+lYo
+xdJ
+lYo
+iXh
+kla
+wQH
+jvW
+wHB
+gur
 iPH
-vbG
+gur
 agd
 agp
 agC
-ieP
+fMS
 aag
-cWh
+wKc
 ahK
 aih
 aiK
@@ -87176,43 +87168,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
-rNl
-rNl
+ptK
+ptK
+ptK
 aht
-eLl
-uht
-sEW
-hPQ
-uPo
-llp
-cSy
-mlX
-llp
-cha
-uKX
-dRg
-mlX
-cha
-rIt
-cSy
-hXy
-mlX
-llp
-cha
-kKr
-mrq
-qdw
-qKY
+hBO
+rwh
+ocG
+eZd
+dLx
+mqa
+eLe
+tGR
+mqa
+ozY
+aIz
+ijr
+tGR
+ozY
+gNM
+eLe
+dih
+tGR
+mqa
+ozY
+hQB
+tHs
+kAu
+wxD
 aig
 agy
-wBS
-ewc
-qVX
-muL
-npo
+hds
+xjt
+vbp
+one
+rNW
 aiH
-mWg
+kfk
 ahL
 ahL
 ahL
@@ -87435,41 +87427,41 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aht
 aht
 aem
-cWh
-jNW
+wKc
+cWy
 aem
 agy
-aOq
-vSJ
-pxC
-pxC
+spk
+qUW
+kfv
+kfv
 agy
-aOq
-xab
+spk
+rvD
 agy
 agy
 agy
-aOq
-vPA
-pxC
+spk
+pDc
+kfv
 agy
 aem
-ixK
+xPH
 aig
-vbG
+gur
 iPH
-vbG
+gur
 aig
 aiB
 agy
-jTc
+nmx
 aig
-xwo
+uPK
 ahL
 aii
 aiL
@@ -87690,43 +87682,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aem
 aem
 aem
 aem
 aem
-cWh
-pCe
+wKc
+rlf
 aem
-vIZ
-dHp
-ula
-hqu
-hqu
+oiR
+nfI
+jDB
+rEs
+rEs
 agy
-mrz
-lrf
-eal
+mCp
+wrM
+gbv
 agy
-rUC
-jZP
-uSx
-lDG
-pdN
+bJY
+rZc
+dkZ
+xkf
+jVf
 aem
-xTV
-jSx
-vbG
+aaZ
+fPH
+gur
 afr
-vbG
-nWL
-fQk
+gur
+iox
+wAG
 agy
-dIA
+joC
 aig
-xwo
+uPK
 ahL
 aij
 aiM
@@ -87947,43 +87939,43 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aem
-hKq
-dat
-kQl
-hKq
-qVV
-mPT
+osn
+qOt
+wJp
+osn
+gdy
+pci
 aem
-leW
-kVK
-ula
-eEl
-vUr
+cgD
+czz
+jDB
+kEo
+wXZ
 agy
-xNX
-lrf
-oUC
+ohd
+wrM
+lRC
 agy
-pjE
-mJu
-uSx
-fUY
-riu
+joF
+kOj
+dkZ
+gyk
+ova
 aem
 aem
 aem
-sTU
+xDR
 aem
-sTU
-aem
-aem
+xDR
 aem
 aem
-xwo
-xwo
+aem
+aem
+uPK
+uPK
 ahL
 aik
 aiM
@@ -88204,37 +88196,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aem
-dat
-bqP
-bqP
-dat
+qOt
+fwh
+fwh
+qOt
 ahB
-kCP
+vnA
 aem
-vIZ
-vIZ
-tCn
-vIZ
-hqu
+oiR
+oiR
+gRQ
+oiR
+rEs
 agy
-fDA
-lrf
-oPL
+iTM
+wrM
+hto
 agy
-pZq
-nhn
-uSx
-hme
-pze
+ujL
+itg
+dkZ
+qua
+pyd
 aem
 aaa
 aem
-ukW
-eLP
-ukW
+pRj
+ntp
+pRj
 aem
 aaa
 aaa
@@ -88461,37 +88453,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aem
-dat
-bqP
-bqP
-dat
+qOt
+fwh
+fwh
+qOt
 ahB
-kKt
+ttV
 aem
-sbr
-ula
-ula
-ula
-gOH
+fCf
+jDB
+jDB
+jDB
+pHC
 agy
-dvB
-obf
-jnr
+vBp
+rvN
+wyJ
 agy
-kHc
-jZP
-uSx
-lDG
-rUC
+vfF
+rZc
+dkZ
+xkf
+bJY
 aem
 aaa
 aem
-ukW
-lcY
-ukW
+pRj
+fjy
+pRj
 aem
 aaa
 aaa
@@ -88718,37 +88710,37 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aem
-hKq
-dat
-cSZ
-hKq
-xdK
-cRH
+osn
+qOt
+qPK
+osn
+dyo
+oYG
 aem
-eeu
-iJz
-oIx
-qEG
-vUr
+uNL
+tjo
+cjK
+upP
+wXZ
 agy
-xEc
-hqU
-rcK
-pPr
-uSx
-nxQ
-ifS
-mCq
-rke
+tEQ
+frg
+ixh
+qnA
+dkZ
+sIp
+qVH
+lbB
+pOZ
 aem
 aaa
 aem
-ukW
-ukW
-ukW
+pRj
+pRj
+pRj
 aem
 abI
 agP
@@ -88975,31 +88967,31 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aem
 aem
 aem
 aem
 aem
-cWh
-pCe
+wKc
+rlf
 aem
 agy
-tCX
+eDw
 agy
 agy
-dEU
+kPd
 agy
-jnP
-rcK
-rcK
-uJe
-uSx
-lLV
-uSx
-cCv
-uSx
+eNm
+ixh
+ixh
+jyM
+dkZ
+qBt
+dkZ
+iXA
+dkZ
 aem
 aaa
 aem
@@ -89232,33 +89224,33 @@ aaa
 aaa
 aaa
 aaa
-rNl
+ptK
 aht
 aaa
 aaa
 aht
 aht
 aem
-mpt
-pjS
+nOm
+iNL
 aem
-rai
-haP
-xfT
-tMI
-qqB
+sik
+eyW
+dYv
+loT
+myP
 agy
-lTB
-rcK
-rcK
-pIn
-uSx
-uSx
-uSx
-uSx
-uSx
+xlG
+ixh
+ixh
+pbQ
+dkZ
+dkZ
+dkZ
+dkZ
+dkZ
 aem
-gJF
+qLQ
 abI
 aby
 aht
@@ -89494,26 +89486,26 @@ aaa
 aaa
 aaa
 gYo
-nze
+nhq
 aem
-mmR
-ltA
+hxI
+pWa
 aem
-xvj
-vsy
-vsy
-smj
-lNU
+jsJ
+tNB
+tNB
+oEo
+xbA
 agy
-lvR
-rcK
-rcK
-knW
-uSx
-uSx
-uSx
-uSx
-mkZ
+rYd
+ixh
+ixh
+dZe
+dkZ
+dkZ
+dkZ
+dkZ
+hTZ
 aem
 abI
 abI
@@ -89753,24 +89745,24 @@ aaa
 gYo
 aht
 aem
-cIn
-cEZ
+ylL
+thQ
 aem
-nsQ
-uwE
-hrT
-lxp
-mRP
+tKj
+fra
+tws
+xfV
+qSF
 agy
-lDf
-daM
-qmK
+fCY
+uOD
+vGc
 agy
-rox
-jxi
-tsn
-vDn
-vDn
+mTZ
+jQW
+cmT
+xWR
+xWR
 aem
 abI
 abI
@@ -90010,8 +90002,8 @@ aaa
 gYo
 aht
 aem
-mam
-cEZ
+mYL
+thQ
 aem
 aem
 aem
@@ -90267,16 +90259,16 @@ aaa
 gYo
 aht
 aem
-mam
-cEZ
+mYL
+thQ
 aem
-wNU
-gVK
+wdo
+vMh
 aig
-wNU
-wNU
+wdo
+wdo
 aem
-exJ
+wup
 aht
 aht
 aht
@@ -90524,24 +90516,24 @@ aaa
 gYo
 aht
 aem
-wHX
-pQP
-mwe
+khB
+plj
+hVF
 aiH
 aiH
-dOw
+wHB
 aig
 aig
 aem
-exJ
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
-rNl
+wup
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
+ptK
 aby
 aaa
 aaa
@@ -90781,16 +90773,16 @@ aaa
 gYo
 aht
 aem
-mam
-cEZ
-qWf
+mYL
+thQ
+thP
 aig
-dxg
-dxg
-dxg
-hUC
+eIW
+eIW
+eIW
+rLO
 aem
-osF
+sRl
 aaa
 aaa
 aaa
@@ -91038,16 +91030,16 @@ aaa
 gYo
 aht
 aem
-cIn
-vZE
-mrq
-vDu
-vDu
-qKY
+ylL
+ylc
+tHs
+hBT
+hBT
+wxD
 aig
 aig
 aem
-exJ
+wup
 fon
 mZE
 aaa
@@ -91295,16 +91287,16 @@ aaa
 gYo
 aht
 aem
-lyl
-joT
+mYN
+itv
 aem
-dRV
-wfd
-guD
-ood
-ood
+jlE
+iqr
+oHY
+kKj
+kKj
 aem
-exJ
+wup
 fon
 mZE
 aaa
@@ -91561,7 +91553,7 @@ aem
 aem
 aem
 aem
-exJ
+wup
 fon
 mZE
 aaa
@@ -91812,7 +91804,7 @@ aht
 aht
 aht
 aht
-suV
+tQK
 aht
 aht
 aht
@@ -94006,8 +93998,8 @@ mjK
 mjK
 mjK
 wHI
-jeJ
-jeJ
+rhu
+rhu
 bXk
 shH
 shH
@@ -95034,7 +95026,7 @@ cgu
 cgU
 izm
 chw
-jeJ
+rhu
 jzE
 bXk
 bXk
@@ -95281,7 +95273,7 @@ bZA
 can
 cbi
 ccc
-jeJ
+rhu
 cdR
 tQT
 bXk
@@ -95537,12 +95529,12 @@ bYR
 bZA
 can
 cbj
-jeJ
+rhu
 cbX
 wcs
 iyJ
 cfa
-jeJ
+rhu
 twv
 hoS
 sWj
@@ -96051,12 +96043,12 @@ bYT
 bZB
 caq
 cbk
-jeJ
+rhu
 ccY
 cdT
 ccY
 cbX
-jeJ
+rhu
 vlC
 iej
 qeY
@@ -96308,7 +96300,7 @@ bYU
 bZE
 car
 mgz
-jeJ
+rhu
 cbX
 wcs
 wcs
@@ -97336,7 +97328,7 @@ bYQ
 bZA
 cam
 mgz
-jeJ
+rhu
 cbX
 wcs
 wcs
@@ -97593,12 +97585,12 @@ wjm
 bZF
 cbm
 mgz
-jeJ
+rhu
 oHa
 oHa
 eWi
 cbX
-jeJ
+rhu
 vlC
 cgx
 qeY
@@ -98107,12 +98099,12 @@ bYY
 bZA
 cam
 cbn
-jeJ
+rhu
 cbX
 wcs
 cfP
 cff
-jeJ
+rhu
 cfX
 vVO
 iop
@@ -98365,7 +98357,7 @@ bZG
 cax
 cbo
 ccc
-jeJ
+rhu
 cdR
 tQT
 bXq


### PR DESCRIPTION


## About The Pull Request

Removes all operating tables from all security on maps.
Adds some fluff to the transfer for some maps so AIs can assume maybe there is a shuttle.
Removes some cameras from outside perma that could cause issues for Transfer center.

## Why It's Good For The Game

Makes medical used more by security... Sorry Brig Physicians.
More imagination for 'transferring' prisoners. 
AIs shouldnt look into transfer and see a prisoner dying due to re-education.

## Changelog
:cl:
add: Added a 'shuttle docking' to transfer. (No actual shuttle docking)
del: Removed surgery tables and surgery computers from security
del: Removed some cameras from some maps near perma
/:cl:
