### PR TITLE
Throw the baby out with the bathwater: Removes reskinning from explorer suits

### DIFF
--- a/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
@@ -14,6 +14,7 @@
 	icon_state = "seva_helmet"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
+	flags_inv = HIDEHAIR
 
 /obj/item/clothing/suit/hooded/explorer/seva/Initialize()
 	. = ..()

--- a/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
@@ -8,44 +8,12 @@
 	icon_state = "seva_suit"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_digi = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/suits.dmi',
-	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
-	)
-	unique_reskin_worn = list(
-	"Old" = 'icons/mob/suit.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
-	)
-	unique_reskin_worn_digi = list(
-	"Old" = 'icons/mob/suit_digi.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	)
-	unique_reskin = list(
-	"Old" = "seva",
-	"Improved" = "seva_suit"
-	)
 
 /obj/item/clothing/head/hooded/explorer/seva
 	icon = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
 	icon_state = "seva_helmet"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/hats.dmi',
-	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
-	)
-	unique_reskin_worn = list(
-	"Old" = 'icons/mob/head.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
-	)
-	unique_reskin_worn_muzzled = list(
-	"Old" = 'icons/mob/head_muzzled.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	)
-	unique_reskin = list(
-	"Old" = "seva",
-	"Improved" = "seva_helmet"
-	)
 
 /obj/item/clothing/suit/hooded/explorer/seva/Initialize()
 	. = ..()
@@ -60,22 +28,6 @@
 	icon_state = "seva_mask"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/masks.dmi',
-	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
-	)
-	unique_reskin_worn = list(
-	"Old" = 'icons/mob/mask.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
-	)
-	unique_reskin_worn_muzzled = list(
-	"Old" = 'icons/mob/mask_muzzled.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	)
-	unique_reskin = list(
-	"Old" = "seva",
-	"Improved" = "seva_mask"
-	)
 
 //exosuit shit
 /obj/item/clothing/suit/hooded/explorer/exo
@@ -83,63 +35,15 @@
 	icon_state = "exo_suit"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_digi = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/suits.dmi',
-	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
-	)
-	unique_reskin_worn = list(
-	"Old" = 'icons/mob/suit.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
-	)
-	unique_reskin_worn_digi = list(
-	"Old" = 'icons/mob/suit_digi.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	)
-	unique_reskin = list(
-	"Old" = "exo",
-	"Improved" = "exo_suit"
-	)
 
 /obj/item/clothing/head/hooded/explorer/exo
 	icon = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
 	icon_state = "exo_helmet"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/hats.dmi',
-	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
-	)
-	unique_reskin_worn = list(
-	"Old" = 'icons/mob/head.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
-	)
-	unique_reskin_worn_muzzled = list(
-	"Old" = 'icons/mob/head_muzzled.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	)
-	unique_reskin = list(
-	"Old" = "exo",
-	"Improved" = "exo_helmet"
-	)
 
 /obj/item/clothing/mask/gas/exo
 	icon = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
 	icon_state = "exo_mask"
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/masks.dmi',
-	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
-	)
-	unique_reskin_worn = list(
-	"Old" = 'icons/mob/mask.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
-	)
-	unique_reskin_worn_muzzled = list(
-	"Old" = 'icons/mob/mask_muzzled.dmi',
-	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
-	)
-	unique_reskin = list(
-	"Old" = "exo",
-	"Improved" = "exo_mask"
-	)

--- a/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
@@ -61,15 +61,15 @@
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
 	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/hats.dmi',
+	"Old" = 'icons/obj/clothing/masks.dmi',
 	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
 	)
 	unique_reskin_worn = list(
-	"Old" = 'icons/mob/head.dmi',
+	"Old" = 'icons/mob/mask.dmi',
 	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	)
 	unique_reskin_worn_muzzled = list(
-	"Old" = 'icons/mob/head_muzzled.dmi',
+	"Old" = 'icons/mob/mask_muzzled.dmi',
 	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
 	)
 	unique_reskin = list(
@@ -128,15 +128,15 @@
 	alternate_worn_icon = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	alternate_worn_icon_muzzled = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
 	unique_reskin_icons = list(
-	"Old" = 'icons/obj/clothing/hats.dmi',
+	"Old" = 'icons/obj/clothing/masks.dmi',
 	"Improved" = 'modular_skyrat/icons/obj/clothing/epic_mining.dmi'
 	)
 	unique_reskin_worn = list(
-	"Old" = 'icons/mob/head.dmi',
+	"Old" = 'icons/mob/mask.dmi',
 	"Improved" = 'modular_skyrat/icons/mob/epic_mining.dmi'
 	)
 	unique_reskin_worn_muzzled = list(
-	"Old" = 'icons/mob/head_muzzled.dmi',
+	"Old" = 'icons/mob/mask_muzzled.dmi',
 	"Improved" = 'modular_skyrat/icons/mob/epic_mining_digi.dmi'
 	)
 	unique_reskin = list(


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

reskinning is causing problems and making shit invisible because of the parent proc
instead of doing any hard work trying to fix it i'm just going to fucking throw the baby out with the bathwater
bye bye old icons

## Changelog
:cl:
del: Goodbye, old stinky sprites for the seva and exo.
fix: SEVA hood now hides hair. Because honestly it looks less fucking weird.
/:cl:
