### PR TITLE
Fixed the auto-announcer.

### DIFF
--- a/modular_skyrat/code/game/objects/items/devices/radio/radio.dm
+++ b/modular_skyrat/code/game/objects/items/devices/radio/radio.dm
@@ -1,3 +1,3 @@
 /obj/item/radio/talk_into(mob/living/M, message, channel, list/spans,datum/language/language, direct=TRUE)
-	if (!direct || M?.mobility_flags & MOBILITY_USE) // if can't use items, you can't press the button
+	if (!direct || !ismob(M) || M.mobility_flags & MOBILITY_USE) // if can't use items, you can't press the button
 		return ..()


### PR DESCRIPTION
## Changelog
:cl:
fix: Non-mobs no longer have their mobility flags checked upon speaking into a radio. _Is your refrigerator running?_
/:cl:
