### PR TITLE
Goat Simulator: Waste of Space

### DIFF
--- a/modular_skyrat/code/game/objects/items/plushes/plushes.dm
+++ b/modular_skyrat/code/game/objects/items/plushes/plushes.dm
@@ -43,6 +43,7 @@
 		return
 	cooldown_modifier = cooldown_modifier/2 * 0.75
 	throwforce = 12.5
+	force = 10
 	obj_flags |= EMAGGED
 	visible_message("<span class='danger'>[src] stares at [user] angrily before going docile.</span>")
 

--- a/modular_skyrat/code/game/objects/items/plushes/plushes.dm
+++ b/modular_skyrat/code/game/objects/items/plushes/plushes.dm
@@ -1,3 +1,4 @@
+//i hate these fucking goats but i can't murder them, for i know they will haunt me in my sleep if i do so. so i nerf them instead.
 /obj/item/toy/plush/goatplushie
 	name = "strange goat plushie"
 	icon = 'modular_skyrat/icons/obj/plushes.dmi'
@@ -7,7 +8,7 @@
 /obj/item/toy/plush/goatplushie/angry
 	icon = 'modular_skyrat/icons/obj/plushes.dmi'
 	var/mob/living/carbon/target
-	throwforce = 6
+	throwforce = 5
 	var/cooldown = 0
 	var/cooldown_modifier = 20
 
@@ -40,8 +41,8 @@
 	if (obj_flags&EMAGGED)
 		visible_message("<span class='notice'>[src] already looks angry enough, you shouldn't anger it more.</span>")
 		return
-	cooldown_modifier = 5
-	throwforce = 20
+	cooldown_modifier = cooldown_modifier/2 * 0.75
+	throwforce = 12.5
 	obj_flags |= EMAGGED
 	visible_message("<span class='danger'>[src] stares at [user] angrily before going docile.</span>")
 
@@ -69,8 +70,8 @@
 	desc = "A plushie depicting the king of all goats."
 	icon = 'modular_skyrat/icons/obj/plushes.dmi'
 	icon_state = "kinggoat"
-	throwforce = 25
-	force = 25
+	throwforce = 8
+	force = 8
 	attack_verb = list("chomped")
 	gender = MALE
 
@@ -79,8 +80,8 @@
 	desc = "A plushie depicting the god of all goats."
 	icon = 'modular_skyrat/icons/obj/plushes.dmi'
 	icon_state = "ascendedkinggoat"
-	throwforce = 30
-	force = 30
+	throwforce = 10
+	force = 10
 	var/divine = TRUE
 
 /obj/item/toy/plush/goatplushie/angry/kinggoat/ascendedkinggoat/attackby(obj/item/I,mob/living/user,params)
@@ -122,11 +123,11 @@
 	desc = "A plushie depicting one of the King Goat's guards, tasked to protect the king at all costs."
 	icon = 'modular_skyrat/icons/obj/plushes.dmi'
 	icon_state = "guardgoat"
-	throwforce = 10
+	throwforce = 6
 
 /obj/item/toy/plush/goatplushie/angry/guardgoat/masterguardgoat
 	name = "royal guard goat plushie"
 	desc = "A plushie depicting one of the royal King Goat's guards, tasked to protecting the king at all costs and training new goat guards."
 	icon = 'modular_skyrat/icons/obj/plushes.dmi'
 	icon_state = "royalguardgoat"
-	throwforce = 15
+	throwforce = 7


### PR DESCRIPTION
## About The Pull Request

Dramatically nerfs all goat plushies. Before, best you could get is a 30 throwforce and force plushie, now the best you can get is a 12.5 throwforce plushie with 10 force (if you emag it).

## Why It's Good For The Game

These goats have gone unpunished for far too long, and they can't keep getting away with it. People play fucking arcades the whole round just to get these fuckers and fuck everything up on EORG.
For more info on how evil goats are:
https://youtu.be/XcKtBqxcTK4
https://youtu.be/1Ug_KCkn-JI
https://youtu.be/e9NNG7BPejo
https://youtu.be/nlQF-xWVmms

## Changelog
:cl:
balance: King goat has lost his influence over the arcades. See PR #1072 for more detail.
/:cl:
