### PR TITLE
Prisoners are spawn with tracker implants

### DIFF
--- a/modular_skyrat/code/modules/jobs/job_types/prisoner.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/prisoner.dm
@@ -27,6 +27,8 @@
 	ears = null
 	belt = null
 
+	implants = list(/obj/item/implant/tracking)
+
 /datum/job/prisoner/radio_help_message(mob/M)
 	to_chat(M, "<span class='userdanger'>As a prisoner, you are not an antagonist. You are to roleplay and add to the story. You must ahelp and receive permission from staff BEFORE you wish to riot and attempt to escape.</span>")
 	to_chat(M, "<span class='userdanger'>Even if you are allowed to riot or escape, this is not a pass to ruin other crew members days. Failing to follow this may result in punishments.</span>")


### PR DESCRIPTION

## About The Pull Request
Prisoners on spawn now have implants to track their movements

## Why It's Good For The Game

Why would these horrable criminals not have implants injected into them to track their movments?
Helps when ever theirs a prison brake, to track them down as well as can lead to more RP were they have to bribe/do getto surgery themselves to remove the implant well hiding

## Changelog
:cl:
add: CC has forced more regulations on prisoners fitting them now with an implant to track their movments
/:cl:
