### PR TITLE
Restores Seva Suit to original armor values.

### DIFF
--- a/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
@@ -48,14 +48,6 @@
 	"Improved" = "seva"
 	)
 
-/obj/item/clothing/suit/hooded/explorer/seva/Initialize()
-	. = ..()
-	AddComponent(/datum/component/armor_plate)
-
-/obj/item/clothing/head/hooded/explorer/seva/Initialize()
-	. = ..()
-	AddComponent(/datum/component/armor_plate)
-
 /obj/item/clothing/mask/gas/seva
 	icon = 'modular_skyrat/icons/obj/clothing/masks.dmi'
 	icon_state = "seva"


### PR DESCRIPTION
Removes the ability to add Goliath plates to the armor set.

## About The Pull Request

<!-- The Seva Suit was never meant to gain armor, it was made to be the weakest as it allows players to have roundstart ash storm immunity in exchange for low mob damage protection. Seva suit was intended for players who wanted to mine and focus on mining without having to hunt for a fauna or tentacle to get one of the ash immune items. -->

## Why It's Good For The Game

<!-- Reduces the powercreep in mining by taking away the ability to reinforce an already ash immune armor set, if you want to use armor, then use the exo or normal mining suit.  -->

## Changelog
:cl:
del: Removed the ability to add goliath plates to Seva armor set.
balance: toned down the unneeded powercreep with regards to every suit needing to be armored.
/:cl:

