### PR TITLE
Neo Jelly OD Threshold.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1209,7 +1209,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	reagent_state = LIQUID
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	color = "#91D865"
-	overdose_threshold = 20
+	overdose_threshold = 20  //SKYRAT CHANGE
 	taste_description = "jelly"
 	pH = 11.8
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1209,7 +1209,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	reagent_state = LIQUID
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	color = "#91D865"
-	overdose_threshold = 30
+	overdose_threshold = 20
 	taste_description = "jelly"
 	pH = 11.8
 


### PR DESCRIPTION
Lowers the OD threshold from 30 to 20U, makes double penning back to back OD for certain. Should help prevent players from stacking an omni heal and keeping it in their system.

## About The Pull Request

In an attempt to make it so you cannot have a large amount of an omni heal present in your body, I have lowered the OD threshold significantly, preventing back to back penning. 

## Why It's Good For The Game

This will ideally stop miners from keeping a large amount of neo jelly in the body so they can fight for longer without having to get more heals. Hopes to cut back on powergaming the pen. 

## Changelog
:cl:
balance: lowered the OD level for neo jelly, punishing players who would double pen themselves.
/:cl:
