### PR TITLE
Allows prisoners to send wood planks, fabrics and other sellables via the plate shoot

### DIFF
--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -9,6 +9,23 @@
 	desc = "For your delivery needs. Just insert and watch as it goes! It reads you can place wood planks, pressed plates, cardboard, and fabrics."
 	icon_state = "inputchute"
 	var/obj/machinery/plate_chute/outputchute/OC
+	var/list/delivery_types = list(
+								/obj/item/stack/license_plates/filled,
+								/obj/item/stack/sheet/mineral/wood,
+								/obj/item/stack/sheet/leather,
+								/obj/item/stack/sheet/cloth,
+								/obj/item/stack/sheet/silk,
+								/obj/item/stack/sheet/durathread,
+								/obj/item/stack/sheet/cardboard,
+								/obj/item/glasswork/glass_base/lens,
+								/obj/item/laser_pointer/blue/handmade,
+								/obj/item/tea_plate,
+								/obj/item/tea_cup,
+								/obj/item/reagent_containers/glass/beaker/glass_dish,
+								/obj/item/reagent_containers/glass/beaker/flask/spouty,
+								/obj/item/reagent_containers/glass/beaker/flask,
+								/obj/item/reagent_containers/glass/beaker/flask/large
+								)	
 
 /obj/machinery/plate_chute/outputchute
 	name = "export delivery output chute"
@@ -20,37 +37,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/stack/license_plates/filled) && OC)
-		I.forceMove(OC.loc)
-		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
-		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
-		return
-	if(istype(I, /obj/item/stack/sheet/mineral/wood) && OC)
-		I.forceMove(OC.loc)
-		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
-		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
-		return
-	if(istype(I, /obj/item/stack/sheet/leather) && OC)
-		I.forceMove(OC.loc)
-		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
-		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
-		return
-	if(istype(I, /obj/item/stack/sheet/cloth) && OC)
-		I.forceMove(OC.loc)
-		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
-		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
-		return
-	if(istype(I, /obj/item/stack/sheet/silk) && OC)
-		I.forceMove(OC.loc)
-		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
-		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
-		return
-	if(istype(I, /obj/item/stack/sheet/durathread) && OC)
-		I.forceMove(OC.loc)
-		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
-		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
-		return
-	if(istype(I, /obj/item/stack/sheet/cardboard) && OC)
+	if(istype(I.type in export_types) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -17,11 +17,15 @@
 								/obj/item/stack/sheet/silk,
 								/obj/item/stack/sheet/durathread,
 								/obj/item/stack/sheet/cardboard,
-								/obj/item/lens,
+								/obj/item/glasswork/glass_base/lens,
 								/obj/item/reagent_containers/glass/beaker/glass_dish,
 								/obj/item/reagent_containers/glass/beaker/flask/spouty,
 								/obj/item/reagent_containers/glass/beaker/flask,
-								/obj/item/reagent_containers/glass/beaker/flask/large
+								/obj/item/reagent_containers/glass/beaker/flask/large,
+								/obj/item/laser_pointer/blue/handmade, //If they somehow make this let them send it.
+								/obj/item/glasswork/glasses, //This is admin only atm but just in case
+								/obj/item/tea_plate,
+								/obj/item/tea_cup
 								)	
 
 /obj/machinery/plate_chute/outputchute

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -6,7 +6,7 @@
 
 /obj/machinery/plate_chute/inputchute
 	name = "export delivery input chute"
-	desc = "For your delivery needs. Just insert and watch as it goes! It reads you can place wood planks, pressed plates, cardboard, and fabrics."
+	desc = "For your license plate delivery needs. Just insert and watch as it goes!. A sign at the bottom reads: Now accepts other materials like cloth, silk, some glassware, etc."
 	icon_state = "inputchute"
 	var/obj/machinery/plate_chute/outputchute/OC
 	var/list/delivery = list(

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -34,7 +34,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I in delivery) && OC)
+	if(istype(I, delivery) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -17,10 +17,7 @@
 								/obj/item/stack/sheet/silk,
 								/obj/item/stack/sheet/durathread,
 								/obj/item/stack/sheet/cardboard,
-								/obj/item/glasswork/glass_base/lens,
-								/obj/item/laser_pointer/blue/handmade,
-								/obj/item/tea_plate,
-								/obj/item/tea_cup,
+								/obj/item/glasswork/lens,
 								/obj/item/reagent_containers/glass/beaker/glass_dish,
 								/obj/item/reagent_containers/glass/beaker/flask/spouty,
 								/obj/item/reagent_containers/glass/beaker/flask,
@@ -37,7 +34,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I.type in delivery_types) && OC)
+	if(istype(I in delivery_types) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -9,7 +9,7 @@
 	desc = "For your delivery needs. Just insert and watch as it goes! It reads you can place wood planks, pressed plates, cardboard, and fabrics."
 	icon_state = "inputchute"
 	var/obj/machinery/plate_chute/outputchute/OC
-	var/list/delivery_types = list(
+	var/list/delivery = list(
 								/obj/item/stack/license_plates/filled,
 								/obj/item/stack/sheet/mineral/wood,
 								/obj/item/stack/sheet/leather,
@@ -17,7 +17,7 @@
 								/obj/item/stack/sheet/silk,
 								/obj/item/stack/sheet/durathread,
 								/obj/item/stack/sheet/cardboard,
-								/obj/item/glasswork/lens,
+								/obj/item/lens,
 								/obj/item/reagent_containers/glass/beaker/glass_dish,
 								/obj/item/reagent_containers/glass/beaker/flask/spouty,
 								/obj/item/reagent_containers/glass/beaker/flask,
@@ -34,7 +34,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I in delivery_types) && OC)
+	if(istype(I, in delivery) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -37,7 +37,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I.type in export_types) && OC)
+	if(istype(I.type in delivery_types) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -34,7 +34,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, delivery) && OC)
+	if(istype(delivery) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -34,7 +34,7 @@
 	OC = locate()
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, in delivery) && OC)
+	if(istype(I in delivery) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)

--- a/modular_skyrat/code/game/machinery/lpchutes.dm
+++ b/modular_skyrat/code/game/machinery/lpchutes.dm
@@ -5,14 +5,14 @@
 	use_power = NO_POWER_USE
 
 /obj/machinery/plate_chute/inputchute
-	name = "plate delivery input chute"
-	desc = "For your license plate delivery needs. Just insert and watch as it goes!"
+	name = "export delivery input chute"
+	desc = "For your delivery needs. Just insert and watch as it goes! It reads you can place wood planks, pressed plates, cardboard, and fabrics."
 	icon_state = "inputchute"
 	var/obj/machinery/plate_chute/outputchute/OC
 
 /obj/machinery/plate_chute/outputchute
-	name = "plate delivery output chute"
-	desc = "For your license plate delivery needs. Just wait for the credit cows to go!"
+	name = "export delivery output chute"
+	desc = "For your delivery needs. Just wait for the credit cows to go!"
 	icon_state = "outputchute"
 
 /obj/machinery/plate_chute/inputchute/Initialize()
@@ -21,6 +21,36 @@
 
 /obj/machinery/plate_chute/inputchute/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/stack/license_plates/filled) && OC)
+		I.forceMove(OC.loc)
+		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
+		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
+		return
+	if(istype(I, /obj/item/stack/sheet/mineral/wood) && OC)
+		I.forceMove(OC.loc)
+		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
+		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
+		return
+	if(istype(I, /obj/item/stack/sheet/leather) && OC)
+		I.forceMove(OC.loc)
+		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
+		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
+		return
+	if(istype(I, /obj/item/stack/sheet/cloth) && OC)
+		I.forceMove(OC.loc)
+		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
+		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
+		return
+	if(istype(I, /obj/item/stack/sheet/silk) && OC)
+		I.forceMove(OC.loc)
+		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
+		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
+		return
+	if(istype(I, /obj/item/stack/sheet/durathread) && OC)
+		I.forceMove(OC.loc)
+		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
+		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)
+		return
+	if(istype(I, /obj/item/stack/sheet/cardboard) && OC)
 		I.forceMove(OC.loc)
 		playsound(loc, 'sound/effects/bin_close.ogg', 15, 1, -3)
 		playsound(OC.loc, 'sound/effects/bin_open.ogg', 15, 1, -3)


### PR DESCRIPTION
## About The Pull Request

Horrably copy pasts codes to allow the plate shoot to send - Wood planks, cardboard, silk, cloth and duracloth as well as glasswork stuff

## Why It's Good For The Game

Lets prisoners send more money items to cargo if they wish to other then the one and only plates

## Changelog
:cl:
add: You can now using the now named "export" delivery input chute as a prisoner, to send cargo Wood planks, Cardboard, Silk/Cloth/Duracloth. As well as glasswork end crafting.
/:cl:
