### PR TITLE
[READY] Brig phys changes

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -12,13 +12,16 @@ GLOBAL_LIST_INIT(engineering_positions, list(
 	"Station Engineer",
 	"Atmospheric Technician"))
 
-
+// Added Brig Phys SKYRAT CHANGE
+// People were AFKing as Brig Phys in order to get blueshield
+// Well fuck you. It's in medical now.
 GLOBAL_LIST_INIT(medical_positions, list(
 	"Chief Medical Officer",
 	"Medical Doctor",
 	"Geneticist",
 	"Virologist",
 	"Paramedic",
+	"Brig Physician",
 	"Chemist"))
 
 
@@ -45,13 +48,12 @@ GLOBAL_LIST_INIT(civilian_positions, list(
 	"Mime",
 	"Prisoner",
 	"Assistant"))
-// Added Brig Physician and Blueshield SKYRAT EDIT
+// Added Blueshield SKYRAT EDIT
 GLOBAL_LIST_INIT(security_positions, list(
 	"Head of Security",
 	"Warden",
 	"Detective",
 	"Security Officer",
-	"Brig Physician",
 	"Blueshield"))
 
 GLOBAL_LIST_INIT(nonhuman_positions, list(

--- a/modular_skyrat/code/modules/jobs/job_types/brig_physician.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/brig_physician.dm
@@ -9,7 +9,7 @@
 	supervisors = "the head of security and chief medical officer"
 	selection_color = "#c02f2f"
 	minimal_player_age = 7
-	exp_requirements = 120 //SKYRAT CHANGE - lowers security exp requirement
+	exp_requirements = 120 //SKYRAT CHANGE - lowers medical exp requirement
 	exp_type = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/brig_phys

--- a/modular_skyrat/code/modules/jobs/job_types/brig_physician.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/brig_physician.dm
@@ -10,7 +10,7 @@
 	selection_color = "#c02f2f"
 	minimal_player_age = 7
 	exp_requirements = 120 //SKYRAT CHANGE - lowers security exp requirement
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/brig_phys
 


### PR DESCRIPTION
## About The Pull Request

Changes Brig phys so you can't just AFK as it to unlock blueshield.

## Why It's Good For The Game

People are AFKing as brig phys in order to unlock blueshield, which is bad. They should know medical first.

## Changelog
:cl:
tweak: Brig Phys no longer counts towards security hours, it counts towards medical hours.
tweak: You need medical hours in order to unlock Brig Phys now.
/:cl:
