### PR TITLE
Strange Reagent revives based on dosage instead of flat value.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1209,7 +1209,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	reagent_state = LIQUID
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	color = "#91D865"
-	overdose_threshold = 20  //SKYRAT CHANGE
+	overdose_threshold = 30
 	taste_description = "jelly"
 	pH = 11.8
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -861,8 +861,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	//SKYRAT EDIT: Outdated description.
-	//description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
+	//description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living." SKYRAT EDIT: Outdated description.
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -861,7 +861,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug that can bring people back from the dead based on the dosage. For every 10 units of brute or burn damage, 1u of this reagent is required. Deals a small amount of damage on metabolism."
+	description = "A miracle drug that can bring people back from the dead based on the dosage. For every 20 units of brute or burn damage, 1u of this reagent is required. Deals a small amount of damage on metabolism."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -861,13 +861,15 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
+	//SKYRAT EDIT: Outdated description.
+	//description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "magnets"
 	pH = 0
 
+/* SKYRAT EDIT: op pls nerf, see modular file of medicine_reagents
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
 		if(M.suiciding || M.hellbound) //they are never coming back
@@ -902,7 +904,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 					M.emote("gasp")
 					log_combat(M, M, "revived", src)
 	..()
-
+*/
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(0.5*REM, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -874,10 +874,10 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 		if(M.suiciding || M.hellbound) //they are never coming back
 			M.visible_message("<span class='warning'>[M]'s body does not react... it seems they are not meant for this world.</span>")
 			return
-		if(M.getFireLoss() + M.getBruteLoss() >= true_reaction_volume*10) //body is too damaged to be revived
-			//10u is required to heal 100 total damage.
-			//20u is required to heal 200 total damage.
-			//40u is required to heal 400 total damage.
+		if(M.getFireLoss() + M.getBruteLoss() >= true_reaction_volume*20) //body is too damaged to be revived
+			//10u is required to heal 200 total damage.
+			//20u is required to heal 400 total damage.
+			//40u is required to heal 800 total damage.
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			M.do_jitter_animation(10)
 			return

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -867,7 +867,6 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "magnets"
 	pH = 0
-
 /* SKYRAT EDIT: op pls nerf, see modular file of medicine_reagents
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -861,7 +861,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
+	description = "A miracle drug that can bring people back from the dead based on the dosage. For every 10 units of brute or burn damage, 1u of this reagent is required. Deals a small amount of damage on metabolism."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -870,10 +870,14 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
+		var/true_reaction_volume = reac_volume + M.reagents.get_reagent_amount(/datum/reagent/medicine/strange_reagent)
 		if(M.suiciding || M.hellbound) //they are never coming back
-			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
+			M.visible_message("<span class='warning'>[M]'s body does not react... it seems they are not meant for this world.</span>")
 			return
-		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || HAS_TRAIT(M, TRAIT_HUSK)) //body is too damaged to be revived
+		if(M.getFireLoss() + M.getBruteLoss() >= true_reaction_volume*10) //body is too damaged to be revived
+			//10u is required to heal 100 total damage.
+			//20u is required to heal 200 total damage.
+			//40u is required to heal 400 total damage.
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			M.do_jitter_animation(10)
 			return
@@ -883,7 +887,6 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 			M.do_jitter_animation(10)
 			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 40) //jitter immediately, then again after 4 and 8 seconds
 			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 80)
-
 			spawn(100) //so the ghost has time to re-enter
 				if(iscarbon(M))
 					var/mob/living/carbon/C = M
@@ -902,7 +905,6 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 					M.emote("gasp")
 					log_combat(M, M, "revived", src)
 	..()
-
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(0.5*REM, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -861,7 +861,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
-	description = "A miracle drug that can bring people back from the dead based on the dosage. For every 20 units of brute or burn damage, 1u of this reagent is required. Deals a small amount of damage on metabolism."
+	description = "A miracle drug capable of bringing the dead back to life. Only functions when applied by patch or spray, if the target has less than 100 brute and burn damage (independent of one another) and hasn't been husked. Causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -870,14 +870,10 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
-		var/true_reaction_volume = reac_volume + M.reagents.get_reagent_amount(/datum/reagent/medicine/strange_reagent)
 		if(M.suiciding || M.hellbound) //they are never coming back
-			M.visible_message("<span class='warning'>[M]'s body does not react... it seems they are not meant for this world.</span>")
+			M.visible_message("<span class='warning'>[M]'s body does not react...</span>")
 			return
-		if(M.getFireLoss() + M.getBruteLoss() >= true_reaction_volume*20) //body is too damaged to be revived
-			//10u is required to heal 200 total damage.
-			//20u is required to heal 400 total damage.
-			//40u is required to heal 800 total damage.
+		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100 || HAS_TRAIT(M, TRAIT_HUSK)) //body is too damaged to be revived
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			M.do_jitter_animation(10)
 			return
@@ -887,6 +883,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 			M.do_jitter_animation(10)
 			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 40) //jitter immediately, then again after 4 and 8 seconds
 			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 80)
+
 			spawn(100) //so the ghost has time to re-enter
 				if(iscarbon(M))
 					var/mob/living/carbon/C = M
@@ -905,6 +902,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 					M.emote("gasp")
 					log_combat(M, M, "revived", src)
 	..()
+
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(0.5*REM, 0)
@@ -1211,7 +1209,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	reagent_state = LIQUID
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	color = "#91D865"
-	overdose_threshold = 30
+	overdose_threshold = 20  //SKYRAT CHANGE
 	taste_description = "jelly"
 	pH = 11.8
 

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,11 +1,5 @@
 /datum/reagent/medicine/strange_reagent
-	name = "Strange Reagent"
 	description = "A miracle drug that can bring people back from the dead based on the dosage. For every 20 units of brute or burn damage, 1u of this reagent is required. Deals a small amount of damage on metabolism."
-	reagent_state = LIQUID
-	color = "#A0E85E"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	taste_description = "magnets"
-	pH = 0
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1,0 +1,52 @@
+/datum/reagent/medicine/strange_reagent
+	name = "Strange Reagent"
+	description = "A miracle drug that can bring people back from the dead based on the dosage. For every 20 units of brute or burn damage, 1u of this reagent is required. Deals a small amount of damage on metabolism."
+	reagent_state = LIQUID
+	color = "#A0E85E"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	taste_description = "magnets"
+	pH = 0
+
+/datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(M.stat == DEAD)
+		var/true_reaction_volume = reac_volume + M.reagents.get_reagent_amount(/datum/reagent/medicine/strange_reagent)
+		if(M.suiciding || M.hellbound) //they are never coming back
+			M.visible_message("<span class='warning'>[M]'s body does not react... it seems they are not meant for this world.</span>")
+			return
+		if(M.getFireLoss() + M.getBruteLoss() >= true_reaction_volume*20) //body is too damaged to be revived
+			//10u is required to heal 200 total damage.
+			//20u is required to heal 400 total damage.
+			//40u is required to heal 800 total damage.
+			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
+			M.do_jitter_animation(10)
+			return
+		else
+			M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
+			M.notify_ghost_cloning(source = M)
+			M.do_jitter_animation(10)
+			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 40) //jitter immediately, then again after 4 and 8 seconds
+			addtimer(CALLBACK(M, /mob/living/carbon.proc/do_jitter_animation, 10), 80)
+			spawn(100) //so the ghost has time to re-enter
+				if(iscarbon(M))
+					var/mob/living/carbon/C = M
+					if(!(C.dna && C.dna.species && (NOBLOOD in C.dna.species.species_traits)))
+						C.blood_volume = max(C.blood_volume, BLOOD_VOLUME_NORMAL*C.blood_ratio) //so you don't instantly re-die from a lack of blood
+					for(var/organ in C.internal_organs)
+						var/obj/item/organ/O = organ
+						if(O.damage > O.maxHealth/2)
+							O.setOrganDamage(O.maxHealth/2) //so you don't instantly die from organ damage when being revived
+
+				M.adjustOxyLoss(-20, 0)
+				M.adjustToxLoss(-20, 0)
+				M.updatehealth()
+				if(M.revive())
+					M.grab_ghost()
+					M.emote("gasp")
+					log_combat(M, M, "revived", src)
+	..()
+
+/datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(0.5*REM, 0)
+	M.adjustFireLoss(0.5*REM, 0)
+	..()
+	. = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3618,6 +3618,7 @@
 #include "modular_skyrat\code\modules\projectiles\guns\energy\nuclear.dm"
 #include "modular_skyrat\code\modules\projectiles\projectile\pistol.dm"
 #include "modular_skyrat\code\modules\projectiles\projectile\stun.dm"
+#include "modular_skyrat\code\modules\reagents\chemistry\reagents\medicine_reagents.dm"
 #include "modular_skyrat\code\modules\reagents\chemistry\reagents\other_reagents.dm"
 #include "modular_skyrat\code\modules\reagents\reagents_containers\borghydro.dm"
 #include "modular_skyrat\code\modules\reagents\reagents_containers\reagent_containers\bottle.dm"


### PR DESCRIPTION

## About The Pull Request

Strange reagent now requires 1u for every 20 damage healed in order to revive, meaning that if you have a corpse with 200 damage, you need 10u of strange reagent in order to revive them.

Strange reagent can now also revive husks.



## Why It's Good For The Game

Strange reagent was a bit of a meme chem as you only needed 1u of the stuff to revive someone with less than 100 brute and 100 burn damage. Now you need to actually set the dosage correctly if you want to revive someone.

You can still revive with just 1 unit, they just have to have less than 20 brute or burn damage to them.

Also if you're a legend, you can use 100u of Strange Reagent to revive someone with 2000 damage. Not sure why you'd want to do this since they'll die one frame later.

## Changelog
:cl: BurgerBB
balance: Strange Reagent now works based on dosage. You need 1u of strange reagent for every 20 brute+burn damage to revive someone. Strange Reagent can now also revive husks.
/:cl:

