### PR TITLE
Removes Pistols from Shoes

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -47,7 +47,7 @@
 	attack_hand_interact = FALSE
 	quickdraw = TRUE
 	silent = TRUE
-
+// SKYRAT EDIT: Removing "/obj/item/gun/ballistic/automatic/pistol, /obj/item/gun/ballistic/automatic/magrifle/pistol" from the holding.
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
 	cant_hold = typecacheof(list(/obj/item/screwdriver/power))
@@ -56,7 +56,7 @@
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin, /obj/item/gun/ballistic/automatic/pistol, /obj/item/gun/ballistic/automatic/magrifle/pistol
+		/obj/item/firing_pin
 		))
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()


### PR DESCRIPTION

## About The Pull Request

Pistols cant be stored in shoes.

## Why It's Good For The Game

Less power is sometimes good!

## Changelog
:cl:
balance: removed pistols from shoes
/:cl:
