### PR TITLE
[READY] Added 2 Extra Paramedic Spawns on Box to fix Spawning Issue

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -33950,6 +33950,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxT" = (
@@ -61342,6 +61343,10 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"rJT" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -101284,7 +101289,7 @@ bAv
 bvj
 bCO
 bDR
-bDR
+rJT
 bDR
 bIn
 bJC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes an issue that caused Paramedics to spawn in a randomnized location around the map due to a missing second Paramedic Spawner when 2 Paramedics were ready at Roundstart
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed https://github.com/Skyrat-SS13/Skyrat13/issues/1112 by adding 2 extra Paramedic Spawners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
