### PR TITLE
[READY] Changes Formatting of Alkali Code to fix NTOS Crashes

### DIFF
--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -113,9 +113,11 @@ Bonus
 	symptom_delay_max = 90
 	var/chems = FALSE
 	var/explosion_power = 1
-	threshold_desc = "<b>Resistance 9:</b> Doubles the intensity of the effect, but reduces its frequency.<br>\
-					  <b>Stage Speed 8:</b> Increases explosion radius when the host is wet.<br>\
-					  <b>Transmission 8:</b> Additionally synthesizes chlorine trifluoride and napalm inside the host."
+	threshold_desc = list(
+	"Resistance 9" = "Doubles the intensity of the effect, but reduces its frequency.",
+	"Stage Speed 8" = "Increases explosion radius when the host is wet.",
+	"Transmission 8" = "Additionally synthesizes chlorine trifluoride and napalm inside the host.",
+	)
 
 /datum/symptom/alkali/Start(datum/disease/advance/A)
 	if(!..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What is says in the title, changes how the code of alkali is formatted so that the Pandemic machine stops bluescreening, literally.
Useroth told me to do this non-modular
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: https://github.com/Skyrat-SS13/Skyrat13/issues/1257
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
