### PR TITLE
Makes disguised syndicate borgs not obvious

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,5 +1,13 @@
 /mob/living/silicon/robot/examine(mob/user)
-	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>, a [src.module.name] unit!")
+	//Skyrat changes - fixes chameleon borgs examine
+	var/module_name
+	var/obj/item/borg_chameleon/BC = locate() in src
+	if(BC && BC.active)
+		module_name = "Engineering" //The borg is a saboteur disguised as another borg, always engi unit
+	else
+		module_name = src.module.name
+	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>, [prefix_a_or_an(module_name)] [module_name] unit!")
+	//End of skyrat changes
 	if(desc)
 		. += "[desc]"
 

--- a/modular_skyrat/code/game/objects/items/devices/radio/radio.dm
+++ b/modular_skyrat/code/game/objects/items/devices/radio/radio.dm
@@ -1,3 +1,7 @@
 /obj/item/radio/talk_into(mob/living/M, message, channel, list/spans,datum/language/language, direct=TRUE)
 	if (!direct || !ismob(M) || M.mobility_flags & MOBILITY_USE) // if can't use items, you can't press the button
 		return ..()
+
+//Makes it so syndicate borgs dont transmit their radio so well. Due to how comms work there isn't really a better way unless you were to touch comms
+/obj/item/radio/borg/syndicate
+	canhear_range = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes their radio range to 0, making it only affect the tile they're on. Due to how comms work there isn't really a better easy way.

The examine for borgs now checks whether they're cloaked with chameleon disguise and sets their displayed module type approprietly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed issues regarding to syndicate borg disguises
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
