### PR TITLE
[HOTFIX] [SPEEDMERGE] Fixes distribution and scrubbers being the same pipenet.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -26253,8 +26253,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bhs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall,
 /area/security/checkpoint/medical)
 "bht" = (
 /obj/machinery/door/firedoor,
@@ -27804,7 +27806,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -27835,6 +27836,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bkS" = (
@@ -28774,7 +28776,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
 	req_access_txt = "63"
@@ -28792,11 +28793,11 @@
 	req_access_txt = "6;5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -29307,7 +29308,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -29407,12 +29407,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bon" = (
@@ -56266,9 +56264,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -62000,6 +61995,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sEy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/medical/morgue)
 "sEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -62835,7 +62836,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -103066,7 +103066,7 @@ cBm
 bfK
 bhj
 biw
-bhs
+biw
 uJi
 bkP
 bmV
@@ -103326,7 +103326,7 @@ biy
 cCZ
 wsu
 bkR
-bfK
+bhs
 boo
 bhh
 bhg
@@ -103583,7 +103583,7 @@ bfL
 bfL
 bfL
 bkQ
-bfL
+sEy
 bom
 biu
 bri


### PR DESCRIPTION
## Do you ever hear of the tradegy of Darth Scrubbernet the Connected?
The scrubber loop and distro were connected. They are no longer connected.

## I thought not. It's not a story the Maintainers would tell you. It's a mapper legend. Darth Scrubbernet was a dark lord of the distro pipenet.
Distro should not be scrubbers, scrubbers should not be distro.

## So powerful, so wise, he could use the gas to influence the admin MIDI chlorine to create simplemobs. He had such a knowledge of atmos, he could even keep the pipes he cared about from being unwrenched.
:cl:
fix: Distro and Srubbers pipenet are no longer the same pipenet roundstart.
del: Removes Darth Scrubbernet the Connected from the game.
/:cl:

## Ironic. He could save others from plasma fires, but not himself.
![image](https://user-images.githubusercontent.com/53862927/79672259-39b7a380-81c8-11ea-8278-81c245945ade.png)
![image](https://user-images.githubusercontent.com/53862927/79672263-3d4b2a80-81c8-11ea-9cf7-6b1f11c07032.png)
