### PR TITLE
Buffs Syndicate Sleeper

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -250,7 +250,7 @@
 		data["occupant"]["fireLoss"] = mob_occupant.getFireLoss()
 		data["occupant"]["cloneLoss"] = mob_occupant.getCloneLoss()
 		data["occupant"]["brainLoss"] = mob_occupant.getOrganLoss(ORGAN_SLOT_BRAIN)
-		
+
 		if(mob_occupant.reagents.reagent_list.len)
 			for(var/datum/reagent/R in mob_occupant.reagents.reagent_list)
 				chemical_list += list(list("name" = R.name, "volume" = R.volume))
@@ -375,10 +375,11 @@
 	for(var/chem in av_chem)
 		chem_buttons[chem] = pick_n_take(av_chem) //no dupes, allow for random buttons to still be correct
 
-
+/* SEE MODULAR SKYRAT FILE
 /obj/machinery/sleeper/syndie
 	icon_state = "sleeper_s"
 	controls_inside = TRUE
+*/
 
 /obj/machinery/sleeper/syndie/Initialize()
 	. = ..()

--- a/modular_skyrat/code/game/machinery/Sleeper.dm
+++ b/modular_skyrat/code/game/machinery/Sleeper.dm
@@ -24,7 +24,6 @@
 			/datum/reagent/medicine/spaceacillin
 		),
 		list( //T4
-			/datum/reagent/medicine/rezadone,
-			/datum/reagent/medicine/regen_jelly
+			/datum/reagent/medicine/rezadone
 		)
 	)

--- a/modular_skyrat/code/game/machinery/Sleeper.dm
+++ b/modular_skyrat/code/game/machinery/Sleeper.dm
@@ -1,0 +1,30 @@
+/obj/machinery/sleeper/syndie
+	icon_state = "sleeper_s"
+	desc = "An enclosed machine used to stabilize and heal patients. This one has inward facing controls that allows the patient to self-treat."
+	controls_inside = TRUE
+	possible_chems = list(
+		list( //T1
+			/datum/reagent/medicine/epinephrine,
+			/datum/reagent/medicine/morphine,
+			/datum/reagent/medicine/salbutamol,
+			/datum/reagent/medicine/bicaridine,
+			/datum/reagent/medicine/kelotane,
+			/datum/reagent/medicine/omnizine
+		),
+		list( //T2
+			/datum/reagent/medicine/oculine,
+			/datum/reagent/medicine/inacusiate,
+			/datum/reagent/medicine/salglu_solution
+		),
+		list( //T3
+			/datum/reagent/medicine/antitoxin,
+			/datum/reagent/medicine/mutadone,
+			/datum/reagent/medicine/mannitol,
+			/datum/reagent/medicine/pen_acid,
+			/datum/reagent/medicine/spaceacillin
+		),
+		list( //T4
+			/datum/reagent/medicine/rezadone,
+			/datum/reagent/medicine/regen_jelly
+		)
+	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3410,6 +3410,7 @@
 #include "modular_skyrat\code\game\gamemodes\traitor\traitor.dm"
 #include "modular_skyrat\code\game\machinery\lpchutes.dm"
 #include "modular_skyrat\code\game\machinery\prisonlabor.dm"
+#include "modular_skyrat\code\game\machinery\Sleeper.dm"
 #include "modular_skyrat\code\game\machinery\syndicatebeacon.dm"
 #include "modular_skyrat\code\game\machinery\syndicatebomb.dm"
 #include "modular_skyrat\code\game\machinery\computer\card.dm"


### PR DESCRIPTION


## About The Pull Request

Buffs the syndicate sleeper by giving it the following chemicals at the follow tiers:

T1: Omnizine (Moved from T4)
T2: Saline Glucose Solution.
T3: Spaceacillin
T4: Rezadone

## Why It's Good For The Game

While syndicate sleepers allow self-heal, I think some additional medicines should be added to it that allows traitors to effectively and possibly treat most illnesses that they could encounter. Some places with the syndicate sleeper don't have medicine to prevent viruses, reduce bloodloss, or treat genetic damage.

This PR isn't a straight up traitor buff as the crew can actually unlock the sleeper too through illegal research.

## Changelog
:cl: BurgerBB
add: Adds additional chemicals to the Syndicate Sleeper.
/:cl: