### PR TITLE
Nerfs/Reworks the Scrubber Event

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -62,6 +62,7 @@
 /datum/round_event/vent_clog/announce()
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
 
+/* MODULAR SKYRAT CHANGE
 /datum/round_event/vent_clog/setup()
 	endWhen = rand(120, 180)
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
@@ -101,6 +102,7 @@
 	C.set_up(R,16,1,T)
 	C.start()
 	playsound(T, 'sound/effects/smoke.ogg', 50, 1, -3)
+*/
 
 /datum/round_event_control/vent_clog/threatening
 	name = "Clogged Vents: Threatening"

--- a/modular_skyrat/code/modules/events/vent_clog.dm
+++ b/modular_skyrat/code/modules/events/vent_clog.dm
@@ -1,0 +1,49 @@
+/datum/round_event/vent_clog/setup()
+	endWhen = rand(120, 180)
+	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
+		var/turf/T = get_turf(temp_vent)
+		var/area/A = T.loc
+		if(T && is_station_level(T.z) && !A.safe)
+			vents += temp_vent
+
+	if(!vents.len)
+		return kill()
+
+/datum/round_event/vent_clog/tick()
+
+	if(!vents.len)
+		return kill()
+
+	CHECK_TICK
+
+	var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent = pick(vents)
+	vents -= vent
+
+	if(!vent || vent.welded || !vent.on)
+		return
+
+	var/turf/T = get_turf(vent)
+	if(!T)
+		return
+
+	var/scrubber_radius = 3
+
+	var/datum/gas_mixture/int_air = vent.return_air()
+	if(!int_air)
+		return
+
+	var/pressure = int_air.return_pressure()
+	if(pressure)
+		scrubber_radius += (pressure/100)
+
+	var/datum/reagents/R = new/datum/reagents(reagentsAmount)
+	R.my_atom = vent
+	if (prob(randomProbability))
+		R.add_reagent(get_random_reagent_id(), reagentsAmount)
+	else
+		R.add_reagent(pick(saferChems), reagentsAmount)
+
+	var/datum/effect_system/smoke_spread/chem/smoke_machine/C = new
+	C.set_up(R,6,1,T)
+	C.start()
+	playsound(T, 'sound/effects/smoke.ogg', 50, 1, -3)

--- a/modular_skyrat/code/modules/events/vent_clog.dm
+++ b/modular_skyrat/code/modules/events/vent_clog.dm
@@ -26,7 +26,7 @@
 	if(!T)
 		return
 
-	var/scrubber_radius = 3
+	var/scrubber_radius = 4
 
 	var/datum/gas_mixture/int_air = vent.return_air()
 	if(!int_air)
@@ -35,6 +35,7 @@
 	var/pressure = int_air.return_pressure()
 	if(pressure)
 		scrubber_radius += (pressure/100)
+		scrubber_radius = min(scrubber_radius,32)
 
 	var/datum/reagents/R = new/datum/reagents(reagentsAmount)
 	R.my_atom = vent

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3532,6 +3532,7 @@
 #include "modular_skyrat\code\modules\events\pirates.dm"
 #include "modular_skyrat\code\modules\events\radiation_storm.dm"
 #include "modular_skyrat\code\modules\events\spontaneous_appendicitis.dm"
+#include "modular_skyrat\code\modules\events\vent_clog.dm"
 #include "modular_skyrat\code\modules\food_and_drinks\food\snacks\meat.dm"
 #include "modular_skyrat\code\modules\food_and_drinks\food\snacks\snacks_soup.dm"
 #include "modular_skyrat\code\modules\food_and_drinks\recipes\tablecraft\recipes_soup.dm"


### PR DESCRIPTION

## About The Pull Request

Changed the scrubber base spread range from 16 to 4.
Scrubber backpressure gains +1 range for every 100 kPA of pressure inside the pipes, up to 32.
Scrubber backpressure can no longer occur on an individual scrubber if it is off.

## Why It's Good For The Game

Right. A long long time ago in 2019, I made it so that the scrubber event instead wasn't a round pausing event that spewed foam but instead smoke in a reasonable radius (Like 6?) where you can only get fucked if you were in a room with a scrubber. It was a reasonable change and made the event more reasonable.

Then some idiot came along and buffed the shit out of it, making the smoke spray in a 16 til radius (that means smoke is sprayed in a 33x33 tile circle instead of the previous 13x13 tile circle) because there was a legitimately unironic and almost elitist attitude where every event should kill at least x amount of people and anyone who says otherwise is a baby who doesn't like being killed.

Given that this is an HRP server and things are supposed to make sense, I made it so that the scrubber event does just that: Actually make sense.

Full disclaimer, I've been killed once by this event but this was back in foam scrubber days of 2018.

## Changelog
:cl: BurgerBB
balance: Changed the scrubber base spread range from 16 to 4. Scrubber backpressure gains +1 range for every 100 kPA of pressure inside the pipes, up to 32. Scrubber backpressure can no longer occur on an individual scrubber if it is off.
/:cl:
