### PR TITLE
[FEEDBACK WANTED!!!] Changes ahelp language to be more forgiving and kind + Extra transparency

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -395,7 +395,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /datum/admin_help/proc/HandleIssue(key_name = key_name_admin(usr))
 	if(state != AHELP_ACTIVE)
 		return
-	var/msg = "<span class ='adminhelp'>Your ticket is now being handled by an admin. Please wait while they type their response and/or gather relevant information.</span>" // Skyrat Change
+	var/msg = "<span class ='adminhelp'>Your ticket is now being handled by [usr?.client?.holder?.fakekey? usr.client.holder.fakekey : "an administrator"]!. Please wait while they type their response and/or gather relevant information.</span>" // Skyrat Change
 
 	if(initiator)
 		to_chat(initiator, msg)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -395,8 +395,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /datum/admin_help/proc/HandleIssue(key_name = key_name_admin(usr))
 	if(state != AHELP_ACTIVE)
 		return
-
-var/msg = "<span class ='adminhelp'>Your ticket is now being handled by an admin. Please wait while they type their response and/or gather relevant information.</span>" // Skyrat Change
+	var/msg = "<span class ='adminhelp'>Your ticket is now being handled by an admin. Please wait while they type their response and/or gather relevant information.</span>" // Skyrat Change
 
 	if(initiator)
 		to_chat(initiator, msg)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -154,7 +154,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/initiator_key_name
 	var/heard_by_no_admins = FALSE
 
-	var/handler = "" //SKYRAT EDIT - string of admin who takes care of the ticket to display at stat() 
+	var/handler = "" //SKYRAT EDIT - string of admin who takes care of the ticket to display at stat()
 
 	var/list/_interactions	//use AddInteraction() or, preferably, admin_ticket_log()
 
@@ -172,7 +172,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		qdel(src)
 		return
 
-	//SKYRAT CHANGE 
+	//SKYRAT CHANGE
 	if(admin_C && is_bwoink)
 		handler = "H-[admin_C.ckey] "
 	//END OF SKYRAT CHANGES
@@ -362,8 +362,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		SEND_SOUND(initiator, sound('sound/effects/adminhelp.ogg'))
 
 		to_chat(initiator, "<font color='red' size='4'><b>- AdminHelp Rejected by [usr?.client?.holder?.fakekey? usr.client.holder.fakekey : "an administrator"]! -</b></font>")
-		to_chat(initiator, "<font color='red'><b>Your admin help was rejected.</b> The adminhelp verb has been returned to you so that you may try again.</font>")
-		to_chat(initiator, "Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting.")
+		to_chat(initiator, "<font color='red'><b>Your adminhelp was rejected.</b> The adminhelp verb has been returned to you so that you may submit another ticket.</font>") // Skyrat Change
+		to_chat(initiator, "Please try to be calm, clear, and descriptive in adminhelps. Assume that the admin has not seen any related events, and clearly state the character names or byond keys of anybody you are reporting.")
 
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "rejected")
 	var/msg = "Ticket [TicketHref("#[id]")] rejected by [key_name]"
@@ -378,8 +378,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		return
 
 	var/msg = "<font color='red' size='4'><b>- AdminHelp marked as IC issue by [usr?.client?.holder?.fakekey? usr.client.holder.fakekey : "an administrator"]! -</b></font><br>"
-	msg += "<font color='red'><b>Losing is part of the game!</b></font><br>"
-	msg += "<font color='red'>It is also possible that your ahelp is unable to be answered properly, due to events occurring in the round.</font>"
+	msg += "<font color='red'><b>An admin has looked at the submitted issue and has determined that the reported incident is valid.</b></font><br>" // Skyrat Change "uwu its valid uwu uwu uwu"
+	msg += "<font color='red'>Some actions by users, while appearing malicious, can be legitimate due to their status or given situation.</font>"
+	msg += "<font color='red'>Please do not be discouraged from reporting similar instances in the future.</font>"
 	if(initiator)
 		to_chat(initiator, msg)
 
@@ -395,7 +396,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(state != AHELP_ACTIVE)
 		return
 
-	var/msg = "<span class ='adminhelp'>Your ticket is now being handled by an admin. Please be patient.</span>"
+var/msg = "<span class ='adminhelp'>Your ticket is now being handled by an admin. Please wait while they type their response and/or gather relevant information.</span>" // Skyrat Change
 
 	if(initiator)
 		to_chat(initiator, msg)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Modified Version of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/8946
Big thanks for @BurgerLUA for setting the blueprint for me to work off of

Recently that PR has made their way into our dev channel and i was apalled at how badly Burger was ridiculed for making some very valid changes. This PR is about porting that over and possibly elaborates or modifies it a bit more to fit our environment
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**Changes are to the following situations:**

When an admin starts to handle your ticket:
`Your ticket is now being handled by (X ADMIN). Please wait while they type their response and/or gather relevant information.`

When an Admin rejects your Ticket:
`Your adminhelp was rejected.
The adminhelp verb has been returned to you so that you may submit another ticket.
Please try to be calm, clear, and descriptive in adminhelps. Assume that the admin has not seen any related events, and clearly state the character names or byond keys of anybody you are reporting.`

When a ticket is marked as IC issue:
`An admin has looked at the submitted issue and has determined that the reported incident is valid.
Some actions by users, while appearing malicious, can be legitimate due to their status or given situation.
Please do not be discouraged from reporting similar instances in the future.`
## Why It's Good For The Game
Burger summed it up best in the original PR:
> The current language is really weak and doesn't really give anything for the person to chew on when it comes to learning the game. For the IC issue response, it assumes too much about why you're ahelping by stating "Losing is a part of the game.", which can cause the undesired effect of the admin not really knowing about the situation as not everyone who ahelps does it because they die or get caught. It also doesn't really explain that much for a button that is so commonly used, so that is also fixed.
It also re-words some of the responses to seem less direct and more friendly. For example, It doesn't say "do not assume that the admin knows everything" but says "assume the admin knows nothing". Language has a huge impact on mood and mannerisms which is why you never have tech support companies say "Calm and be patient before you speak to our operators." but rather "Please speak in a calm, clear manner when describing the problem."

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Handle Ticket Verb now states WHO is handling the ticket
tweak: Tweaks ahelp preset responses to be more friendly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
