### PR TITLE
[READY] Made Biogens easily accessible by Cooks on Delta and Box

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -61214,9 +61214,7 @@
 	id = "kitchen";
 	name = "kitchen shutters"
 	},
-/obj/item/reagent_containers/food/snacks/cheesynachos{
-	pixel_y = 5
-	},
+/obj/item/reagent_containers/food/snacks/mint,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "quT" = (

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -17194,7 +17194,6 @@
 	pixel_x = 13;
 	pixel_y = 5
 	},
-/obj/item/watertank,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aLe" = (
@@ -19636,6 +19635,10 @@
 /area/crew_quarters/kitchen)
 "aRH" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRI" = (
@@ -20105,7 +20108,8 @@
 /area/crew_quarters/kitchen)
 "aSP" = (
 /obj/machinery/smartfridge,
-/turf/closed/wall,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aSQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -20127,7 +20131,15 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aST" = (
-/obj/machinery/biogenerator,
+/obj/structure/table,
+/obj/item/book/manual/hydroponics_pod_people{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/paper/guides/jobs/hydroponics{
+	pixel_x = -5;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aSU" = (
@@ -20476,7 +20488,7 @@
 /area/storage/tools)
 "aTM" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/snacks/mint,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aTN" = (
@@ -21332,12 +21344,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aVH" = (
-/obj/machinery/processor,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/biogenerator,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aVI" = (
 /obj/effect/turf_decal/tile/green{
@@ -21349,10 +21358,16 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aVJ" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aVK" = (
@@ -22110,13 +22125,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXn" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
 	pixel_x = 30
 	},
+/obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXo" = (
@@ -22799,7 +22813,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYP" = (
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/structure/sign/poster/contraband/lizard{
 	pixel_x = -32
 	},
@@ -22809,7 +22822,8 @@
 /obj/structure/sign/poster/contraband/lizard{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aYQ" = (
 /obj/machinery/hydroponics/constructable,
@@ -23325,15 +23339,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bal" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bam" = (
@@ -62022,14 +62032,7 @@
 /area/crew_quarters/dorms)
 "sHx" = (
 /obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/paper/guides/jobs/hydroponics{
-	pixel_x = -5;
-	pixel_y = 3
-	},
+/obj/item/watertank,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "sJx" = (
@@ -64081,6 +64084,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"xmk" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "xmo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -103857,7 +103867,7 @@ aJI
 aRH
 aVz
 aVz
-aVH
+aVz
 aXn
 aYN
 aJI
@@ -104114,7 +104124,7 @@ aJI
 aJI
 aSP
 aUh
-aJI
+aVH
 aJI
 aJI
 aJI
@@ -104372,7 +104382,7 @@ aOX
 aSR
 aUi
 aVJ
-aOX
+xmk
 aYP
 bal
 bam

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -17194,6 +17194,14 @@
 	pixel_x = 13;
 	pixel_y = 5
 	},
+/obj/item/book/manual/hydroponics_pod_people{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/paper/guides/jobs/hydroponics{
+	pixel_x = -5;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aLe" = (
@@ -20131,15 +20139,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aST" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/paper/guides/jobs/hydroponics{
-	pixel_x = -5;
-	pixel_y = 3
-	},
+/obj/machinery/chem_dispenser/upgradeablemutagen,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aSU" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -33807,19 +33807,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bll" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
-	},
-/obj/item/storage/bag/plants/portaseeder,
-/obj/machinery/door/window/eastright,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "blm" = (
@@ -35716,17 +35708,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"boz" = (
-/obj/machinery/biogenerator,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"boA" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "boB" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -36998,14 +36979,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqA" = (
-/obj/machinery/seed_extractor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqB" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqC" = (
@@ -38212,6 +38189,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/biogenerator,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsz" = (
@@ -40912,6 +40891,7 @@
 /obj/structure/sign/poster/official/ian{
 	pixel_y = -32
 	},
+/obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bwR" = (
@@ -124926,6 +124906,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"epx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "eqc" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
@@ -162513,7 +162508,7 @@ bhB
 bjs
 blg
 bni
-boz
+bqA
 bqA
 bsy
 buk
@@ -162770,9 +162765,9 @@ bhC
 bjt
 blh
 bnj
-boA
 bqB
-bnj
+bqB
+epx
 bul
 bvB
 bwP

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -33812,6 +33812,11 @@
 	dir = 4
 	},
 /obj/machinery/biogenerator,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "blm" = (
@@ -38190,7 +38195,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/biogenerator,
+/obj/machinery/chem_dispenser/upgradeablemutagen,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsz" = (

--- a/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
@@ -50217,10 +50217,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/chem_dispenser/upgradeablemutagen,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bAv" = (

--- a/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
@@ -54033,6 +54033,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/item/clothing/suit/apron,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bYn" = (
@@ -54666,6 +54667,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
+/obj/item/clothing/suit/apron,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bZx" = (
@@ -82412,6 +82414,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/cultivator,
 /obj/item/wirecutters,
+/obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "dix" = (
@@ -84486,11 +84489,8 @@
 /turf/closed/wall,
 /area/science/circuit)
 "kwI" = (
-/obj/item/wrench,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/accessory/armband/hydro,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/chem_dispenser/upgradeablemutagen,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kxk" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -19399,6 +19399,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUW" = (
@@ -20810,12 +20814,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXW" = (
-/obj/machinery/plantgenes{
-	pixel_y = 6
-	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -57034,10 +57035,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kEW" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
-/obj/structure/table,
+/obj/machinery/chem_dispenser/upgradeablemutagen,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kFm" = (
@@ -91487,7 +91485,7 @@ aQJ
 aRL
 aSD
 aTT
-aXS
+aXW
 aRL
 aWR
 aXT
@@ -92261,7 +92259,7 @@ aTW
 aUW
 aRL
 kEW
-aXW
+aYO
 aXS
 aZX
 bbd

--- a/modular_skyrat/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/modular_skyrat/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -22,3 +22,8 @@
 	. = ..()
 	vending_names_paths += list(/obj/machinery/vending/dinnerware/prisoner = "\improper Plasteel Chef's Prisoner Dinnerware Vendor",
 								/obj/machinery/vending/hydronutrients/prisoner = "\improper Prisoner NutriMax")
+
+/obj/item/circuitboard/machine/chem_dispenser/upgradeablemutagen
+	name = "botanical chemical dispenser"
+	desc = "Creates and dispenses chemicals useful for botany."
+	build_path = /obj/machinery/chem_dispenser/upgradeablemutagen

--- a/modular_skyrat/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -1,0 +1,22 @@
+/obj/machinery/chem_dispenser/upgradeablemutagen
+	name = "botanical chemical dispenser"
+	desc = "Creates and dispenses chemicals useful for botany."
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/upgradeablemutagen
+
+	dispensable_reagents = list(
+		/datum/reagent/toxin/mutagen,
+		/datum/reagent/saltpetre,
+		/datum/reagent/water)
+	upgrade_reagents = list(
+		/datum/reagent/plantnutriment/eznutriment,
+		/datum/reagent/plantnutriment/left4zednutriment,
+		/datum/reagent/plantnutriment/robustharvestnutriment)
+	upgrade_reagents2 = list(
+		/datum/reagent/toxin/plantbgone,
+		/datum/reagent/toxin/plantbgone/weedkiller,
+		/datum/reagent/toxin/pestkiller)
+	upgrade_reagents3 = list(
+		/datum/reagent/medicine/cryoxadone,
+		/datum/reagent/ammonia,
+		/datum/reagent/ash,
+		/datum/reagent/diethylamine)

--- a/modular_skyrat/code/modules/research/designs/machine_designs.dm
+++ b/modular_skyrat/code/modules/research/designs/machine_designs.dm
@@ -23,3 +23,4 @@
 	build_path = /obj/item/circuitboard/computer/telesci_console
 	category = list("Teleportation Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+

--- a/modular_skyrat/code/modules/research/designs/machine_desings/machine_designs_service.dm
+++ b/modular_skyrat/code/modules/research/designs/machine_desings/machine_designs_service.dm
@@ -5,3 +5,11 @@
 	build_path = /obj/item/circuitboard/machine/biogenerator/prisoner
 	category = list ("Hydroponics Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
+/datum/design/board/chem_dispenser_upgrademutagen
+	name = "Machine Design (Botanical Chemical Dispenser)"
+	desc = "Creates and dispenses chemicals useful for botany."
+	id = "bot_chem_dis"
+	build_path = /obj/item/circuitboard/machine/chem_dispenser/upgradeablemutagen
+	category = list("Hydroponics Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE

--- a/modular_skyrat/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/code/modules/research/techweb/all_nodes.dm
@@ -46,6 +46,7 @@
 
 /datum/techweb_node/botany/New()
 	design_ids += "prisonerbiogenerator"
+	design_ids += "bot_chem_dis"
 	. = ..()
 
 /datum/techweb_node/syndicate_basic/New()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3650,6 +3650,7 @@
 #include "modular_skyrat\code\modules\projectiles\guns\energy\nuclear.dm"
 #include "modular_skyrat\code\modules\projectiles\projectile\pistol.dm"
 #include "modular_skyrat\code\modules\projectiles\projectile\stun.dm"
+#include "modular_skyrat\code\modules\reagents\chemistry\machinery\chem_dispenser.dm"
 #include "modular_skyrat\code\modules\reagents\chemistry\reagents\medicine_reagents.dm"
 #include "modular_skyrat\code\modules\reagents\chemistry\reagents\other_reagents.dm"
 #include "modular_skyrat\code\modules\reagents\reagents_containers\borghydro.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it so that the Cook has access to the Biogen. This is done by putting the Biogenerator into a wall between Botany and the Kitchen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kilo, Pubby and Meta have it this way. So why shouldn't Box and Delta?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Moves spare delta bio-gene to puplic access
tweak: Moves Box bio-gene to cook-wall for easy access
tweak: Tweaked Botany and Kitchen on both Box and Delta to accomodate the Biogen changes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
