### PR TITLE
Changes travis builds to run on 512, to ensure compatibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tgstation/byond:513.1508 as base
+FROM tgstation/byond:512.1488 as base
 
 FROM base as build_base
 


### PR DESCRIPTION
Those are slightly slower, as far as the compilation itself goes. But most of Travis time is taken by installing the entire build environment, so we should be looking at like... maybe 20 seconds more per build.