### PR TITLE
[Not Modular] Muddled Maint Radio

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -249,7 +249,7 @@
 	//SKYRAT EDIT
 	var/turf/areaposition = get_area(src)
 	if(istype(areaposition, /area/maintenance))
-		message = Gibberish(message,100)
+		message = Gibberish(message,50)
 
 	// Determine the identity information which will be attached to the signal.
 	var/atom/movable/virtualspeaker/speaker = new(null, M, src)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -246,6 +246,11 @@
 			message = Gibberish(message,100)
 			break
 
+	//SKYRAT EDIT
+	var/turf/areaposition = get_area(src)
+	if(istype(areaposition, /area/maintenance))
+		message = Gibberish(message,100)
+
 	// Determine the identity information which will be attached to the signal.
 	var/atom/movable/virtualspeaker/speaker = new(null, M, src)
 


### PR DESCRIPTION

## About The Pull Request

You go into maint, you are not getting your messages out clearly.

## Why It's Good For The Game

Perhaps this kind of change can help prevent certain situations. Makes sense that maint is a bit of a cage that makes it hard to hear you.

## Changelog
:cl:
add: Added muddling to speaking in maint into communications.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
