### PR TITLE
strange seeds have their own crate now, other seed crate prices lowered

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -329,7 +329,7 @@
 /datum/supply_pack/organic/seeds
 	name = "Seeds Crate"
 	desc = "Big things have small beginnings. Contains fourteen different seeds."
-	cost = 1000
+	cost = 1000 //skyrate change
 	contains = list(/obj/item/seeds/chili,
 					/obj/item/seeds/berry,
 					/obj/item/seeds/corn,
@@ -350,7 +350,7 @@
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds!"
-	cost = 1200
+	cost = 1200 //skyrat change
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/replicapod,
 					/obj/item/seeds/replicapod,
@@ -360,14 +360,14 @@
 					/obj/item/seeds/amanita,
 					/obj/item/seeds/reishi,
 					/obj/item/seeds/banana,
-					/obj/item/seeds/eggplant/eggy)
+					/obj/item/seeds/eggplant/eggy) //skyrat change
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 	
 	/datum/supply_pack/organic/strangeseeds //skyrat addition
 	name = "Seeds Crate (Strange)"
 	desc = "A crate of strange seeds, contains 6 seeds found on alien planets"
-	cost = 1500
+	cost = 3500
 	contains = list(/obj/item/seeds/random,
 					/obj/item/seeds/random,
 					/obj/item/seeds/random,

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -329,7 +329,7 @@
 /datum/supply_pack/organic/seeds
 	name = "Seeds Crate"
 	desc = "Big things have small beginnings. Contains fourteen different seeds."
-	cost = 1250
+	cost = 1000
 	contains = list(/obj/item/seeds/chili,
 					/obj/item/seeds/berry,
 					/obj/item/seeds/corn,
@@ -350,7 +350,7 @@
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds!"
-	cost = 1500
+	cost = 1200
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/replicapod,
 					/obj/item/seeds/replicapod,
@@ -360,11 +360,23 @@
 					/obj/item/seeds/amanita,
 					/obj/item/seeds/reishi,
 					/obj/item/seeds/banana,
-					/obj/item/seeds/eggplant/eggy,
-					/obj/item/seeds/random,
-					/obj/item/seeds/random)
+					/obj/item/seeds/eggplant/eggy)
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
+	
+	/datum/supply_pack/organic/strangeseeds //skyrat addition
+	name = "Seeds Crate (Strange)"
+	desc = "A crate of strange seeds, contains 6 seeds found on alien planets"
+	cost = 1500
+	contains = list(/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random,
+					/obj/item/seeds/random)
+	crate_name = "strange seeds crate"
+	crate_type = /obj/structure/closet/crate/hydroponics
+	
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////// Misc /////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
To get strange seeds you need to get a pack with a lot of seeds you probably don't need
This helps stop clutter on the shuttle and at cargo

Oh yeah i lowered the other crate costs because some of those seeds are round start free in public areas and it's hard to run out of them

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now order dedicated strange seed crates
add: Regular and exotic crate costs lowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
