### PR TITLE
Gondola Meat Alternative PR 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2044,6 +2044,7 @@
 		to_chat(M, "You should sit down and take a rest...")
 	..()
 
+/* SEE MODULAR SKYRAT
 /datum/reagent/tranquility
 	name = "Tranquility"
 	description = "A highly mutative liquid of unknown origin."
@@ -2054,6 +2055,7 @@
 /datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
+*/
 
 /datum/reagent/moonsugar
 	name = "Moonsugar"

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -22,7 +22,7 @@
 		L.apply_status_effect(STATUS_EFFECT_PACIFY, 10 * reac_volume)
 		return
 
-	if(method == INJECT)
+	if(method == INJECT && reac_volume >= 5)
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
 
 	if(iscarbon(L) && prob(100 * (reac_volume/15)))

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -6,3 +6,25 @@
 	find. Lord knows what would happen if these got into a corpse..."
 	color = "#535452" // RGB (18, 53, 36) <--- Get a load of this guy.
 	taste_description = "copper"
+
+
+
+/datum/reagent/tranquility
+	name = "Gondala Essence"
+	description = "A highly mutative liquid of unknown origin."
+	color = "#9A6750" //RGB: 154, 103, 80
+	taste_description = "inner peace"
+	can_synth = FALSE
+
+/datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+
+	if(method == VAPOR)
+		L.apply_status_effect(STATUS_EFFECT_PACIFY, 10 * reac_volume)
+		return
+
+	if(method == INJECT)
+		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
+
+	if(iscarbon(L) && prob(100 * (reac_volume/15)))
+		var/mob/living/carbon/C = L
+		C.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -18,13 +18,20 @@
 
 /datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 
-	if(method == VAPOR)
+	if(method == VAPOR || method == TOUCH)
 		L.apply_status_effect(STATUS_EFFECT_PACIFY, 10 * reac_volume)
 		return
-
-	if(method == INJECT && volume >= 5)
-		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
 
 	if(iscarbon(L) && prob(100 * (volume/15)))
 		var/mob/living/carbon/C = L
 		C.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)
+
+/datum/reagent/gondolatoxin
+	name = "Gondola Mutation Toxin"
+	description = "An advanced corruptive toxin produced by slimes, but modifed by Gondola juice."
+	color = "#9A6750" // rgb: 19, 188, 94
+	taste_description = "outer peace"
+
+/datum/reagent/gondolatoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+	if(method != TOUCH)
+		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -22,9 +22,9 @@
 		L.apply_status_effect(STATUS_EFFECT_PACIFY, 10 * reac_volume)
 		return
 
-	if(method == INJECT && reac_volume >= 5)
+	if(method == INJECT && volume >= 5)
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
 
-	if(iscarbon(L) && prob(100 * (reac_volume/15)))
+	if(iscarbon(L) && prob(100 * (volume/15)))
 		var/mob/living/carbon/C = L
 		C.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -10,7 +10,7 @@
 
 
 /datum/reagent/tranquility
-	name = "Gondala Essence"
+	name = "Gondola Essence"
 	description = "A highly mutative liquid of unknown origin."
 	color = "#9A6750" //RGB: 154, 103, 80
 	taste_description = "inner peace"

--- a/modular_skyrat/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -4,4 +4,4 @@
 	results = list(/datum/reagent/gondolatoxin = 1)
 	required_reagents = list(/datum/reagent/tranquility = 1)
 	required_other = TRUE
-	required_container = /obj/item/slime_extract/green
+	required_container = /obj/item/slime_extract/black

--- a/modular_skyrat/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -1,0 +1,7 @@
+/datum/chemical_reaction/slime/slimegondola
+	name = "Gondola Mutation Toxin"
+	id = /datum/reagent/gondolatoxin
+	results = list(/datum/reagent/gondolatoxin = 1)
+	required_reagents = list(/datum/reagent/tranquility = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3662,6 +3662,7 @@
 #include "modular_skyrat\code\modules\projectiles\projectile\stun.dm"
 #include "modular_skyrat\code\modules\reagents\chemistry\reagents\medicine_reagents.dm"
 #include "modular_skyrat\code\modules\reagents\chemistry\reagents\other_reagents.dm"
+#include "modular_skyrat\code\modules\reagents\chemistry\recipes\slime_extracts.dm"
 #include "modular_skyrat\code\modules\reagents\reagent_containers\patch.dm"
 #include "modular_skyrat\code\modules\reagents\reagents_containers\borghydro.dm"
 #include "modular_skyrat\code\modules\reagents\reagents_containers\pill.dm"


### PR DESCRIPTION
## About The Pull Request

Renamed Tranquility to Gondola Essence. 

Gondola Essence no longer transforms you into a Gondola. 

Touch and vapor applications of Gondola Essence cause temporary pacifism. Inject and ingest application causes lobotomy-strength pacifism.

Added Gondola Mutation Toxin. Can be made by injecting Gondola Essence in a black slime core. It gives you the disease that transforms you into a Gondola.

## Why It's Good For The Game

Given what it currently does, it's exceptionally strong compared to other chemicals that transform you. Like all you need to do is put in 1u of this stuff in the chef's food and congrats, everyone who eats the chef's food is pretty much dead unless botany made some chili peppers.

This PR balances that out by giving it different effects based on the method of application. It's much harder to stealth with this chemical as you must actually inject them with the chemical as opposed o just poisoning their food.

## Changelog
:cl: BurgerBB
balance: Renamed Tranquility to Gondola Essence. It no longer transforms you into a Gondola. Touch and vapor applications cause temporary pacifism. Inject and ingest application causes lobotomy-strength pacifism.
add: Added Gondola Mutation Toxin. Can be made by injecting Gondola Essence in a black slime core. It gives you the disease that transforms you into a Gondola.
/:cl: