### PR TITLE
[Map Edit: Box, Pubby, Delta] GenPop for Security

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -1820,6 +1820,12 @@
 /area/security/prison)
 "aem" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/button/door{
+	id = "locklock";
+	name = "Perma Airlock Lockdown";
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aen" = (
@@ -2957,9 +2963,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/turnstile{
-	req_access_txt = "69"
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agj" = (
@@ -2979,10 +2982,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/machinery/turnstile{
-	dir = 1;
-	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6304,11 +6303,7 @@
 /area/security/prison)
 "amj" = (
 /obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6319,20 +6314,15 @@
 /turf/closed/wall,
 /area/security/prison)
 "amm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "amn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6409,15 +6399,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "amy" = (
 /obj/structure/chair/stool{
@@ -8540,14 +8523,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "arE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -15456,6 +15435,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/hatchet,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aHq" = (
@@ -17938,6 +17918,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aNu" = (
@@ -19800,10 +19784,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aSp" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -22188,6 +22168,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/flasher{
+	id = "permalock";
+	pixel_y = 25
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXB" = (
@@ -22234,11 +22218,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aXH" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -24158,12 +24140,20 @@
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "bcO" = (
-/obj/machinery/flasher{
-	id = "permalock";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = 26;
+	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "bcP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -28340,12 +28330,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "locklock";
-	name = "Perma Airlock Lockdown";
-	pixel_y = 26;
-	req_access_txt = "3"
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bmv" = (
@@ -28627,6 +28611,11 @@
 	dir = 4
 	},
 /obj/machinery/camera,
+/obj/machinery/computer/security/telescreen{
+	name = "Prisoner Telescreen";
+	network = list("prison");
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bne" = (
@@ -58737,16 +58726,10 @@
 /area/maintenance/starboard/fore)
 "jgf" = (
 /obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "jgm" = (
 /obj/structure/disposalpipe/segment{
@@ -58837,15 +58820,9 @@
 /area/crew_quarters/fitness)
 "jpM" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jsw" = (
@@ -60833,7 +60810,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "nXT" = (
 /obj/structure/spider/stickyweb/genetic,
@@ -61584,7 +61561,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "pEn" = (
 /obj/machinery/light_switch{
@@ -62009,7 +61989,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qGA" = (
 /obj/effect/turf_decal/tile/red{
@@ -62521,14 +62501,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sci" = (
 /obj/machinery/vr_sleeper{
@@ -63161,6 +63134,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tvi" = (
@@ -63233,6 +63209,16 @@
 /obj/item/instrument/violin,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"tCu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tDY" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Area";
@@ -63660,15 +63646,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uwq" = (
-/obj/structure/curtain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "uxY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63813,17 +63801,11 @@
 /area/ai_monitored/nuke_storage)
 "uPg" = (
 /obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uPT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -64779,6 +64761,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"wFq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -64869,10 +64857,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -65095,20 +65083,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"xgP" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xhn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65419,13 +65393,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/secure_closet/genpop,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xYb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -91049,12 +91017,12 @@ aat
 aTp
 aat
 aat
-aXH
-acd
-bcO
+aat
+amm
+aat
 abh
 aat
-acd
+aXH
 bmu
 acp
 uto
@@ -91583,7 +91551,7 @@ agL
 alZ
 uwq
 pDS
-als
+tCu
 amS
 aqC
 anz
@@ -91826,7 +91794,7 @@ bcT
 bfk
 biZ
 acd
-vZS
+bcO
 aeO
 afG
 agj
@@ -91838,9 +91806,9 @@ agj
 agM
 oiW
 agj
-als
-amL
-als
+ajc
+afM
+jpM
 amS
 anz
 anz
@@ -92095,8 +92063,8 @@ agj
 hkH
 hxc
 bkA
-amm
-wSh
+ajc
+afM
 jpM
 dys
 aqC
@@ -92609,8 +92577,8 @@ csK
 kPY
 hxc
 akT
-ajc
-afM
+wSh
+wFq
 tuZ
 amR
 aqC
@@ -92867,7 +92835,7 @@ ako
 hxc
 agj
 jgf
-afM
+amL
 amj
 amS
 anz
@@ -93382,7 +93350,7 @@ kdS
 akp
 xXJ
 nVk
-xgP
+xXJ
 seP
 aqC
 anz

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -2949,10 +2949,6 @@
 /area/security/execution/transfer)
 "agi" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2961,6 +2957,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/turnstile{
+	req_access_txt = "69"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agj" = (
@@ -2968,10 +2967,6 @@
 /area/security/brig)
 "agk" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -2984,6 +2979,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5199,6 +5198,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/machinery/camera{
+	c_tag = "Brig West Two";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajY" = (
@@ -5367,20 +5370,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akp" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = -32
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Brig West";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/brig)
 "akq" = (
 /obj/structure/cable{
@@ -5458,6 +5451,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5621,12 +5617,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "akM" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Brig West Three";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akN" = (
@@ -5697,11 +5695,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/turnstile{
+	req_access_txt = "69"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akU" = (
@@ -5936,16 +5932,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "als" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alt" = (
 /obj/machinery/door/airlock/security/glass{
@@ -6030,15 +6024,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/brig)
 "alz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6066,12 +6053,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alB" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "alC" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -6314,39 +6303,35 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "amj" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/genpop,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/brig)
 "aml" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/security/prison)
 "amm" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amn" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6421,14 +6406,18 @@
 /area/maintenance/solars/starboard/fore)
 "amx" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amy" = (
 /obj/structure/chair/stool{
@@ -6825,17 +6814,6 @@
 /obj/machinery/computer/libraryconsole,
 /turf/open/floor/wood,
 /area/security/prison)
-"any" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "anz" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -6847,28 +6825,12 @@
 /area/hallway/primary/fore)
 "anB" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "anC" = (
 /obj/effect/spawner/structure/window,
@@ -6932,32 +6894,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anM" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -27;
-	prison_radio = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -24;
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "anN" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -6979,22 +6930,17 @@
 /area/space)
 "anP" = (
 /obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
-"anQ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/curtain,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "anR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -7210,18 +7156,9 @@
 /area/security/brig)
 "aou" = (
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "aov" = (
 /obj/effect/turf_decal/tile/red{
@@ -7529,6 +7466,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "apl" = (
@@ -7834,6 +7774,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8592,24 +8535,15 @@
 /area/security/warden)
 "arD" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -21063,6 +20997,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aVi" = (
@@ -22868,17 +22805,15 @@
 /turf/open/floor/carpet,
 /area/library)
 "aYX" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "locklock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aYY" = (
@@ -23269,11 +23204,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bae" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -23282,7 +23212,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "locklock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile{
+	req_access_txt = "69"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "baf" = (
@@ -27539,18 +27471,12 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "bkB" = (
 /obj/machinery/button/door{
 	id = "Disposal Exit";
@@ -27604,18 +27530,13 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bkI" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	req_access_txt = "69"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -56282,28 +56203,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "dmX" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "doO" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
@@ -56345,13 +56249,16 @@
 /area/security/prison)
 "drO" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "dsC" = (
 /obj/structure/chair/stool{
@@ -57328,15 +57235,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "fEw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/fore)
 "fFA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57674,33 +57580,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
-"guS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -27;
-	prison_radio = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -24;
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gvp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58190,31 +58069,6 @@
 	name = "secure isolation floor"
 	},
 /area/security/prison)
-"hwJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hxc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58881,6 +58735,19 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jgf" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jgm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -58968,6 +58835,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"jpM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jsw" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/stool,
@@ -59450,6 +59330,9 @@
 /area/security/range)
 "kdS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "keg" = (
@@ -59833,8 +59716,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -59930,16 +59813,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lhh" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lip" = (
 /obj/structure/closet{
 	name = "Suit Closet"
@@ -60114,6 +59987,20 @@
 "lKL" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
+/area/security/brig)
+"lLh" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Brig West";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "lLR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60323,31 +60210,29 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "mym" = (
-/obj/machinery/light/small{
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"myo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -27;
-	prison_radio = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -24;
-	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "myX" = (
 /obj/effect/turf_decal/tile/red,
@@ -60942,25 +60827,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "nVk" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -61140,6 +61011,9 @@
 /obj/structure/sign/departments/security{
 	pixel_x = -32;
 	pixel_y = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -61496,6 +61370,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/main)
+"oYe" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oZc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -61699,6 +61580,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
 /area/crew_quarters/fitness)
+"pDS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pEn" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -61905,17 +61792,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"pWM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "pWX" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -62129,6 +62005,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
+"qFR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qGA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -62627,29 +62509,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"rZB" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "saK" = (
 /turf/open/floor/engine,
 /area/science/explab)
@@ -62657,6 +62516,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
+"saY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sci" = (
 /obj/machinery/vr_sleeper{
 	dir = 4
@@ -62691,15 +62564,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "sfa" = (
 /obj/effect/turf_decal/tile/blue{
@@ -63288,6 +63156,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tuZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63785,15 +63660,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uwq" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uxY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63936,6 +63811,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"uPg" = (
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uPT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -64975,6 +64864,18 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"wSh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wTf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -65194,6 +65095,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"xgP" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xhn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65496,6 +65411,22 @@
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xXJ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xYb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1;
@@ -90866,7 +90797,7 @@ aYX
 acG
 aeo
 biM
-bkA
+alB
 bml
 aeO
 amq
@@ -91137,9 +91068,9 @@ akg
 oWe
 aly
 anP
-sAr
+myo
 mym
-pWM
+aiX
 aqC
 anz
 aov
@@ -91392,9 +91323,9 @@ aiM
 ajz
 alz
 xCp
-alg
-rZB
-uto
+agj
+als
+amL
 drO
 aou
 aqC
@@ -91649,11 +91580,11 @@ aiO
 afn
 iaX
 agL
-akT
+alZ
 uwq
-fEw
-hwJ
-seP
+pDS
+als
+amS
 aqC
 anz
 aov
@@ -91906,10 +91837,10 @@ agj
 agj
 agM
 oiW
-akp
-akQ
-amB
-amn
+agj
+als
+amL
+als
 amS
 anz
 anz
@@ -92162,11 +92093,11 @@ aig
 agp
 agj
 hkH
-akl
-akM
+hxc
+bkA
 amm
-sAr
-anM
+wSh
+jpM
 dys
 aqC
 anz
@@ -92420,11 +92351,11 @@ afM
 kGl
 alA
 hxc
-alg
-dmX
-uto
-lhh
-seP
+oYe
+ajc
+afM
+lLh
+amR
 aqC
 anR
 aow
@@ -92676,11 +92607,11 @@ afM
 afM
 csK
 kPY
-alB
+hxc
 akT
-uwq
-fEw
-anB
+ajc
+afM
+tuZ
 amR
 aqC
 anz
@@ -92934,10 +92865,10 @@ ajY
 lKL
 ako
 hxc
+agj
+jgf
+afM
 amj
-akQ
-amB
-amn
 amS
 anz
 anz
@@ -93192,10 +93123,10 @@ all
 aku
 akl
 amk
-amm
-sAr
-guS
-dys
+uPg
+qFR
+amj
+anB
 aqC
 anz
 fPy
@@ -93448,10 +93379,10 @@ akF
 aiy
 akv
 kdS
-alg
+akp
+xXJ
 nVk
-uto
-anQ
+xgP
 seP
 aqC
 anz
@@ -93705,11 +93636,11 @@ aiX
 eCQ
 akx
 ybm
-akT
+alZ
 amx
-any
 arD
-amR
+saY
+anB
 aqC
 anz
 fPy
@@ -93962,7 +93893,7 @@ aiR
 ajc
 akz
 hxc
-als
+agj
 akQ
 amB
 amn
@@ -94219,19 +94150,19 @@ aiW
 ajc
 akz
 hxc
-alg
+akM
 alt
 amp
 aot
 apR
-aqE
-anz
+anM
+dmX
 old
 apk
-anw
-anw
-anw
-anw
+fEw
+fEw
+fEw
+fEw
 aVh
 avj
 awl

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -20291,25 +20291,17 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aPh" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "locklock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile{
+	req_access_txt = "69"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPj" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20318,7 +20310,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "locklock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aPn" = (
@@ -24753,31 +24748,22 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aWd" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	req_access_txt = "69"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aWf" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -25788,10 +25774,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aXL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -25803,9 +25785,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -25860,12 +25844,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26838,9 +26816,6 @@
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -26858,10 +26833,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZq" = (
@@ -26922,17 +26897,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZv" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/structure/curtain,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aZx" = (
 /obj/structure/cable/white{
@@ -27809,8 +27776,10 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48325,42 +48294,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"bHx" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "brig1";
-	name = "Cell 1 Locker"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bHy" = (
-/obj/machinery/flasher{
-	id = "brig1";
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bHz" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -48372,12 +48305,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bHA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bHB" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -49653,95 +49585,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bJs" = (
-/obj/structure/cable/white,
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigwindows";
-	name = "Brig Front Blast door"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
-"bJt" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bJu" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bJv" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/window/brigdoor/security/cell/westright{
-	id = "brig1";
-	name = "Cell 1"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bJw" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
+"bJw" = (
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bJx" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/curtain,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bJy" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
@@ -50856,46 +50716,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bLk" = (
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "brigwindows";
-	name = "Brig Front Blast door"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
-"bLl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bLm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/closet/secure_closet/genpop,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bLn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -52213,9 +52043,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bNi" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -52229,28 +52056,9 @@
 /turf/closed/wall,
 /area/security/brig)
 "bNk" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/door_timer{
-	id = "brig1";
-	name = "Cell 1";
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Security - Brig Center";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bNl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -53671,49 +53479,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"bPo" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "brig2";
-	name = "Cell 2 Locker"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bPp" = (
-/obj/machinery/flasher{
-	id = "brig2";
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bPq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -54880,38 +54656,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "bRo" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bRp" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/window/brigdoor/security/cell/westright{
-	id = "brig2";
-	name = "Cell 2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bRq" = (
 /obj/structure/table/reinforced,
@@ -55886,25 +55640,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bTb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bTc" = (
-/obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bTd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55913,6 +55658,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -57501,17 +57249,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bVk" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/door_timer{
-	id = "brig2";
-	name = "Cell 2";
-	pixel_x = -32
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bVl" = (
 /obj/structure/table/reinforced,
@@ -64222,31 +63963,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cfe" = (
-/obj/structure/chair,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cff" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cfg" = (
@@ -65302,35 +65019,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cgS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"cgT" = (
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cgU" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/window/brigdoor/security/holding/westright{
-	name = "Holding Cell"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -66455,29 +66144,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ciD" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ciE" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -124902,13 +124571,8 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "emd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "emo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -125493,6 +125157,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gtz" = (
+/obj/machinery/camera{
+	c_tag = "Security - Brig Center";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gut" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -125639,9 +125320,6 @@
 "gTf" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -126630,6 +126308,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kNq" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kOb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -128140,11 +127826,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "qCP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/computer/security/telescreen{
 	name = "Prisoner Telescreen";
 	network = list("prison");
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -128575,9 +128263,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "rZL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/button/flasher{
 	id = "permalock";
 	pixel_x = 6;
@@ -128805,6 +128490,19 @@
 /obj/item/soap/homemade,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
+"taY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tbd" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -128853,8 +128551,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tfH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -180000,13 +179700,13 @@ bAi
 bCa
 bDZ
 bnG
-bHw
-bJs
-bLk
 bgZ
-bHw
-bJs
-bLk
+bgZ
+bgZ
+bgZ
+bgZ
+bgZ
+bgZ
 bgZ
 bXB
 bZK
@@ -180257,21 +179957,21 @@ bAh
 bCb
 bEa
 bnG
-bHx
-bJt
-bLl
-bNj
-bPo
+bPp
 bRo
-bLl
+bTb
+gtz
+bPp
+bRo
+bTb
 bNj
 bXC
 bZL
 cbx
 bNj
-cfe
-cgS
-ciD
+cff
+cgU
+ciE
 bgZ
 cly
 cni
@@ -180514,12 +180214,12 @@ bAj
 bCc
 bEb
 bnG
-bHy
-bJu
-bLm
-bEe
 bPp
-bmj
+kNq
+bTb
+taY
+bPp
+kNq
 bTb
 bNj
 bXD
@@ -180527,7 +180227,7 @@ bZM
 cby
 bNj
 cff
-cgT
+cgU
 ciE
 bgZ
 clz
@@ -180771,11 +180471,11 @@ bAk
 bCd
 bnG
 bnG
-bHz
-bJv
-bmc
-bNj
-bHz
+bVk
+bRp
+emd
+taY
+emd
 bRp
 bTc
 bNj
@@ -180783,9 +180483,9 @@ bXE
 bZN
 cbz
 bNj
-biy
+cff
 cgU
-bTc
+ciE
 bgZ
 clA
 cnk
@@ -181028,14 +180728,14 @@ bAl
 bCe
 bEc
 bmh
-bHA
-bJw
+bAl
+bmh
 bLn
-bNk
+bmh
 bPq
-bJw
+bmh
 bTd
-bVk
+bmh
 bXF
 bmh
 cbA
@@ -181286,11 +180986,11 @@ bCf
 bEd
 bFJ
 bHB
-bJx
+bwd
 bLo
 bwd
 bPr
-bJx
+bwd
 bTe
 bwd
 bXG
@@ -183320,7 +183020,7 @@ aFm
 aFm
 aKV
 aXP
-aZv
+aZq
 bbf
 bcQ
 aFm
@@ -183833,7 +183533,7 @@ fxc
 shX
 mdU
 nAS
-mLc
+bJs
 aZx
 ozi
 bcR
@@ -184609,7 +184309,7 @@ aZA
 nOk
 aFm
 aFm
-aad
+aFm
 aad
 biP
 bkz
@@ -184864,9 +184564,9 @@ aFm
 aFm
 aZA
 nOk
+bLk
+bLk
 aFm
-aaa
-aad
 aaa
 biQ
 bkA
@@ -185116,14 +184816,14 @@ aNK
 aPt
 aNK
 aFm
-rqh
-rqh
 aFm
+aZv
+aZv
 aZC
-emd
+ozi
+bJw
+bNk
 aFm
-aaa
-aad
 aad
 biR
 bkB
@@ -185373,14 +185073,14 @@ aNK
 lEd
 aNK
 aFm
-rqh
-rqh
 aFm
+bHA
+bJw
 oyY
 htx
+bLk
+bLk
 aFm
-aaa
-aad
 aaa
 biS
 bkC
@@ -185630,14 +185330,14 @@ aNK
 aNK
 aNK
 aFm
-rqh
-rqh
 aFm
+aZv
+aZv
 aZA
 nOk
 aFm
-aaa
-aad
+aFm
+aFm
 aad
 biP
 bkD
@@ -185887,14 +185587,14 @@ aFm
 aFm
 aFm
 aFm
-rqh
-rqh
+aFm
+aFm
 aFm
 aZA
 nOk
+bLk
+bLk
 aFm
-aaa
-aaa
 aad
 biP
 biP
@@ -186144,14 +185844,14 @@ aac
 rqh
 rqh
 rqh
-rqh
-rqh
 aFm
+aZv
+bJx
 aZA
 nOk
+bJw
+bNk
 aFm
-aaa
-aaa
 aad
 aaa
 biP
@@ -186401,14 +186101,14 @@ nbW
 rqh
 rqh
 rqh
-rqh
-rqh
 aFm
+bHA
+bJw
 aZA
 nOk
+bLk
+bLk
 aFm
-aaa
-aaa
 aad
 aaa
 biP
@@ -186658,14 +186358,14 @@ rqh
 rqh
 rqh
 rqh
-rqh
-rqh
 aFm
+aZv
+aZv
 aZq
 bbl
 aFm
-aaa
-aad
+aFm
+aFm
 aad
 aad
 biP

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -19334,11 +19334,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aNA" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -21345,9 +21346,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/qm)
 "aRa" = (
-/obj/machinery/flasher{
-	id = "permalock";
-	pixel_y = 25
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -25804,12 +25805,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "locklock";
-	name = "Perma Airlock Lockdown";
-	pixel_y = 26;
-	req_access_txt = "3"
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXO" = (
@@ -26955,6 +26950,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZD" = (
@@ -124747,6 +124745,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"eRM" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eSc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -125245,6 +125256,19 @@
 	},
 /turf/open/floor/wood,
 /area/security/prison)
+"gHR" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gKo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -125466,6 +125490,7 @@
 	dir = 1;
 	pixel_x = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "huu" = (
@@ -125506,6 +125531,10 @@
 "hDf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/flasher{
+	id = "permalock";
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -125642,6 +125671,10 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -127234,6 +127267,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ozi" = (
@@ -128272,6 +128308,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/button/door{
+	id = "locklock";
+	name = "Perma Airlock Lockdown";
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "saw" = (
@@ -128609,6 +128651,16 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
+"tuk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "twt" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/neutral{
@@ -128861,6 +128913,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"upy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uqa" = (
 /turf/open/floor/circuit/green,
 /area/security/prison)
@@ -129238,6 +129298,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/hatchet,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wmt" = (
@@ -129310,10 +129371,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wBv" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -129663,6 +129720,12 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = 26;
+	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -181985,12 +182048,12 @@ gBd
 aJA
 gBd
 gBd
+gBd
 aNA
-aKV
-aRa
+gBd
 vqc
 gBd
-aKV
+aRa
 aXN
 hNi
 bbg
@@ -184563,7 +184626,7 @@ aFm
 aFm
 aFm
 aZA
-nOk
+tuk
 bLk
 bLk
 aFm
@@ -184820,7 +184883,7 @@ aFm
 aZv
 aZv
 aZC
-ozi
+upy
 bJw
 bNk
 aFm
@@ -185333,8 +185396,8 @@ aFm
 aFm
 aZv
 aZv
-aZA
-nOk
+eRM
+tuk
 aFm
 aFm
 aFm
@@ -185590,8 +185653,8 @@ aFm
 aFm
 aFm
 aFm
-aZA
-nOk
+eRM
+tuk
 bLk
 bLk
 aFm
@@ -185847,8 +185910,8 @@ rqh
 aFm
 aZv
 bJx
-aZA
-nOk
+eRM
+tuk
 bJw
 bNk
 aFm
@@ -186104,8 +186167,8 @@ rqh
 aFm
 bHA
 bJw
-aZA
-nOk
+eRM
+tuk
 bLk
 bLk
 aFm
@@ -186361,7 +186424,7 @@ rqh
 aFm
 aZv
 aZv
-aZq
+gHR
 bbl
 aFm
 aFm

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -26,9 +26,6 @@
 	},
 /area/maintenance/department/science)
 "aae" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/button/flasher{
 	id = "permalock";
 	pixel_x = 6;
@@ -1479,25 +1476,17 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afo" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "locklock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile{
+	req_access_txt = "69"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afq" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1506,7 +1495,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "locklock"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afr" = (
@@ -1870,31 +1862,22 @@
 /turf/closed/wall,
 /area/security/prison)
 "agz" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	req_access_txt = "69"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/turnstile{
+	dir = 1;
+	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1960,6 +1943,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2058,20 +2045,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2145,11 +2125,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahn" = (
@@ -2160,6 +2144,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aho" = (
@@ -2176,22 +2165,16 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2323,7 +2306,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahG" = (
@@ -2345,25 +2331,18 @@
 /area/security/prison)
 "ahH" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/closet/secure_closet/genpop,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2378,14 +2357,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ahJ" = (
-/obj/machinery/power/apc/highcap/five_k{
-	dir = 1;
-	name = "Prison Wing APC";
-	pixel_x = 1;
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2574,9 +2547,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aie" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2954,8 +2929,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ajc" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ajd" = (
 /obj/machinery/door/firedoor,
@@ -3712,68 +3692,25 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "akB" = (
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"akC" = (
-/obj/item/storage/firstaid/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/regular,
-/obj/structure/table/glass,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "akD" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 24
-	},
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "akE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "akF" = (
@@ -5542,6 +5479,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aow" = (
@@ -5810,6 +5750,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "apd" = (
@@ -6069,9 +6012,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "apJ" = (
@@ -6154,6 +6094,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "apQ" = (
@@ -6295,18 +6238,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -6437,6 +6377,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6772,6 +6715,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7306,15 +7252,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "asu" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7335,25 +7281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"asx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "asy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -7367,11 +7294,6 @@
 "asz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -7388,11 +7310,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7407,6 +7324,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "asD" = (
@@ -7415,6 +7335,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7426,6 +7349,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7769,102 +7695,63 @@
 /turf/open/floor/circuit/green,
 /area/maintenance/department/security/brig)
 "atv" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
-"atw" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atx" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/brig)
-"aty" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+"atz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/closed/wall,
-/area/security/brig)
-"atz" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
-"atA" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "atB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall,
-/area/security/brig)
-"atC" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"atC" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "atD" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "atE" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -7872,9 +7759,6 @@
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -7888,12 +7772,10 @@
 /area/security/brig)
 "atF" = (
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "atG" = (
@@ -8287,31 +8169,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/department/security/brig)
-"aux" = (
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = -2;
-	prison_radio = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"auz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "auA" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "auB" = (
 /obj/machinery/light{
@@ -8735,98 +8599,43 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"avs" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -28
-	},
-/obj/item/bedsheet/blue,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"avt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"avu" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "avv" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -28
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/item/bedsheet/green,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"avw" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avx" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avy" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -28
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
-/obj/item/bedsheet/orange,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avz" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = 3;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avA" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9380,43 +9189,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awI" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
-"awJ" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
-"awK" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awL" = (
 /obj/machinery/door/firedoor,
@@ -9428,9 +9205,6 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -9441,9 +9215,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "awM" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -52714,11 +52485,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "dbO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "dci" = (
@@ -53061,13 +52839,11 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "dEy" = (
@@ -53132,9 +52908,6 @@
 "dIA" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54605,17 +54378,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gsF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gue" = (
@@ -55761,6 +55528,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ifS" = (
@@ -55897,6 +55667,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ise" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "itl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56601,12 +56387,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58463,7 +58243,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "mWK" = (
 /obj/machinery/light{
@@ -58677,8 +58457,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "npo" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58705,10 +58487,18 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nqY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/curtain,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "nrk" = (
@@ -61438,17 +61228,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rVa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rWE" = (
@@ -62355,6 +62141,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"tKB" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "tLv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -62925,6 +62726,15 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/power/apc/highcap/five_k{
+	dir = 1;
+	name = "Prison Wing APC";
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "uPo" = (
@@ -63211,14 +63021,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "vsk" = (
@@ -63803,6 +63610,22 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"wrV" = (
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "wsB" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red{
@@ -64743,6 +64566,24 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"xPb" = (
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular,
+/obj/structure/table/glass,
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "xQc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -84509,8 +84350,8 @@ dCE
 vqV
 ahZ
 aiB
-ajc
 agy
+wrV
 akB
 alq
 alZ
@@ -84766,9 +84607,9 @@ pKD
 ahC
 aia
 aiC
-ajc
 agy
-akC
+xPb
+akD
 alr
 ama
 amM
@@ -85023,8 +84864,8 @@ ahm
 dbO
 aib
 aiD
-ajc
 agy
+tKB
 akD
 als
 amb
@@ -85276,12 +85117,12 @@ aig
 agy
 agK
 agY
-nqY
-pzx
+agy
+aOq
 ahI
 aiE
 agy
-agy
+ise
 akE
 alt
 amc
@@ -85534,7 +85375,7 @@ agA
 efs
 tLv
 ahn
-pzx
+nqY
 ahI
 aiF
 ajd
@@ -85550,10 +85391,10 @@ akF
 aom
 ark
 asu
-atv
-aux
-avs
-awI
+aqC
+avy
+avy
+akA
 axF
 ayL
 aAd
@@ -85788,7 +85629,7 @@ afG
 nTc
 eSB
 agy
-ahD
+ahB
 agZ
 aho
 ahG
@@ -85807,10 +85648,10 @@ apH
 aqm
 aon
 asv
-atw
-aon
-avt
-awJ
+atC
+auA
+avz
+akA
 axG
 ayG
 pFy
@@ -86062,12 +85903,12 @@ aoo
 aoo
 aoo
 aqn
-arl
-asw
-atx
-auz
-avu
-awJ
+aon
+asz
+aqC
+avA
+avA
+akA
 axG
 ayH
 aAe
@@ -86319,12 +86160,12 @@ ana
 aoQ
 apI
 aqo
-alv
-asx
-aty
-ajM
-ajM
+aon
+asz
 atB
+atB
+atB
+akA
 axH
 ayI
 aAf
@@ -86561,7 +86402,7 @@ ago
 agy
 uMQ
 ifm
-cWh
+ajc
 ahJ
 aig
 aiJ
@@ -86578,10 +86419,10 @@ apJ
 aqp
 aon
 asy
-atz
-aux
+auF
+atD
 avv
-awK
+akA
 axG
 ayL
 aAi
@@ -86816,9 +86657,9 @@ vbG
 agd
 agp
 agC
-ieP
+ahD
 aag
-cWh
+ahB
 ahK
 aih
 aiK
@@ -86835,10 +86676,10 @@ apJ
 aqq
 aon
 asv
-atA
+atC
 auA
-avw
-awJ
+avz
+akA
 axG
 ayL
 aAi
@@ -87092,10 +86933,10 @@ apK
 aqr
 arl
 asw
-atx
-auz
+atI
+awI
 avx
-awJ
+akA
 axG
 ayJ
 aAg
@@ -87332,7 +87173,7 @@ aiB
 agy
 jTc
 aig
-xwo
+aig
 ahL
 aii
 aiL
@@ -87350,9 +87191,9 @@ aqs
 aon
 asz
 atB
-ajM
-ajM
 atB
+atB
+akA
 axI
 ayL
 aAh
@@ -87589,7 +87430,7 @@ fQk
 agy
 dIA
 aig
-xwo
+aig
 ahL
 aij
 aiM
@@ -87605,11 +87446,11 @@ aoV
 apJ
 aqt
 arm
-asy
-atz
-aux
+atx
+aqC
 avy
-awK
+avy
+akA
 axG
 ayL
 aAi
@@ -87866,7 +87707,7 @@ asA
 atC
 auA
 avz
-awJ
+akA
 axG
 ayL
 aAi
@@ -88117,13 +87958,13 @@ anI
 aor
 aoX
 apJ
-aqt
-aro
-asw
-atD
-auz
+atv
+arp
+asz
+aqC
 avA
-awJ
+avA
+akA
 axG
 ayL
 aAi
@@ -88377,10 +88218,10 @@ apN
 sBA
 arp
 asB
-atB
 ajM
 ajM
-atB
+ajM
+akA
 axJ
 ayL
 aAi
@@ -89408,7 +89249,7 @@ asE
 ajM
 auD
 avC
-ajM
+akA
 axJ
 axG
 aAm
@@ -89661,7 +89502,7 @@ apc
 apP
 aqy
 arr
-asC
+atz
 ajM
 auE
 avD
@@ -90436,7 +90277,7 @@ asG
 ajM
 auH
 avG
-auH
+awR
 axM
 ayR
 aAo

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -35,7 +35,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/button/door{
+	id = "locklock";
+	name = "Perma Airlock Lockdown";
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aag" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -1583,12 +1589,19 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"afE" = (
 /obj/machinery/flasher{
 	id = "permalock";
 	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"afE" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "locklock"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -1930,13 +1943,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "locklock";
-	name = "Perma Airlock Lockdown";
-	pixel_y = 26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1949,7 +1956,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1962,6 +1969,11 @@
 	dir = 4
 	},
 /obj/machinery/camera,
+/obj/machinery/computer/security/telescreen{
+	name = "Prisoner Telescreen";
+	network = list("prison");
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "agP" = (
@@ -2012,21 +2024,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agZ" = (
 /obj/structure/cable{
@@ -2035,25 +2039,17 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aha" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/genpop,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahd" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -2125,31 +2121,23 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahm" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/curtain,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/curtain,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aho" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -2158,25 +2146,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/genpop,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahq" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -2299,11 +2279,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2323,11 +2299,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahH" = (
 /obj/structure/cable{
@@ -2336,15 +2308,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/genpop,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahI" = (
 /obj/structure/cable{
@@ -2500,6 +2468,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aia" = (
@@ -2513,6 +2484,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aib" = (
@@ -2522,6 +2496,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2544,6 +2521,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aie" = (
@@ -2553,7 +2533,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -52484,21 +52464,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"dbO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/curtain,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "dci" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
@@ -52839,12 +52804,8 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/genpop,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "dEy" = (
 /obj/machinery/airalarm{
@@ -53144,7 +53105,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "efu" = (
 /obj/structure/chair/stool,
@@ -53815,6 +53776,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"fsr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ftp" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -54375,14 +54349,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"gsF" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/genpop,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gue" = (
@@ -57411,6 +57377,18 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/prison)
+"lzn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "permalock2";
+	name = "Perma Secure Airlock";
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lzt" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red{
@@ -58490,16 +58468,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/curtain,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "nrk" = (
 /obj/structure/table,
@@ -58742,10 +58716,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "nIw" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -59612,6 +59582,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/hatchet,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "peE" = (
@@ -59988,11 +59959,10 @@
 /area/maintenance/department/cargo)
 "pKD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"pMk" = (
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "pMG" = (
 /obj/structure/sink{
@@ -60431,6 +60401,9 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61228,14 +61201,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rVa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/closet/secure_closet/genpop,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rWE" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -62161,11 +62128,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tLP" = (
 /obj/machinery/status_display/supply,
@@ -62737,6 +62700,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"uNZ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "uPo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -63021,12 +62990,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/closet/secure_closet/genpop,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -63395,11 +63360,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vXW" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -63647,6 +63610,10 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -64420,6 +64387,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xzr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xzR" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -84345,7 +84318,7 @@ aeC
 agn
 agy
 rVa
-gsF
+rVa
 dCE
 vqV
 ahZ
@@ -84859,9 +84832,9 @@ tiS
 aga
 agz
 aie
-dLt
+uNZ
 ahm
-dbO
+nqY
 aib
 aiD
 agy
@@ -85109,17 +85082,17 @@ aig
 xAd
 aig
 aig
-vXW
-agy
+aig
 afE
+aig
 kEx
 aig
-agy
+vXW
 agK
 agY
-agy
-aOq
-ahI
+pMk
+xzr
+fsr
 aiE
 agy
 ise
@@ -85376,7 +85349,7 @@ efs
 tLv
 ahn
 nqY
-ahI
+fsr
 aiF
 ajd
 ajJ
@@ -85629,7 +85602,7 @@ afG
 nTc
 eSB
 agy
-ahB
+lzn
 agZ
 aho
 ahG


### PR DESCRIPTION
## About The Pull Request

Adds the genpop lockers and turnstiles to perma and security.
Removes the holding cells.

## Why It's Good For The Game

Put the normal prisoners in with the perma prisoners. More interactions with possible better RP situations.

## Changelog
:cl:
add: Added turnstiles and genpop lockers to box, delta, and pubby.
del: Removes the holding cells.
/:cl:

