### PR TITLE
[DNM] Adds unconcious deactivation of High-Lum-Eyes

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -251,6 +251,10 @@
 	else
 		activate()
 
+/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+    RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
+    . = ..()
+
 /obj/item/organ/eyes/robotic/glow/proc/prompt_for_controls(mob/user)
 	var/C = input(owner, "Select Color", "Select color", "#ffffff") as color|null
 	if(!C || QDELETED(src) || QDELETED(user) || QDELETED(owner) || owner != user)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -251,10 +251,6 @@
 	else
 		activate()
 
-/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
-    RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
-    . = ..()
-
 /obj/item/organ/eyes/robotic/glow/proc/prompt_for_controls(mob/user)
 	var/C = input(owner, "Select Color", "Select color", "#ffffff") as color|null
 	if(!C || QDELETED(src) || QDELETED(user) || QDELETED(owner) || owner != user)

--- a/modular_skyrat/code/modules/surgery/organs/eyes.dm
+++ b/modular_skyrat/code/modules/surgery/organs/eyes.dm
@@ -1,3 +1,4 @@
 /obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
     RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
     . = ..()
+    // Makes High Lum Eyes depower if you lose conciousness.

--- a/modular_skyrat/code/modules/surgery/organs/eyes.dm
+++ b/modular_skyrat/code/modules/surgery/organs/eyes.dm
@@ -1,0 +1,3 @@
+/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+    RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
+    . = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you go unconscious your High Luminosity Eyes will turn off

**THANKS PUTNAM**

![highlumshutdown](https://user-images.githubusercontent.com/6706750/80226927-fc657280-861a-11ea-85c7-05f2a68af170.gif)

never again will your partner wake up seeing you asleep with your eyes glowing through your eyelids if you have forgotten to turn them off. 

This tweak only makes them deactivate upon when unconscious, it does not prevent you from reactivating (of course you will have to be conscious to do so)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

going unconscious should turn off the eye lightbulbs, it willl make it look as if you actually fell unconscious. in addition if you play as a synth lizard with the screen. your screen goes blank if you go unconscious with High Luminosity Eyes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked High Luminosity Eyes
code: Added unconcious modifier to High Luminosity Eyes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
