### PR TITLE
Global projectile speed config modifier

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -287,6 +287,7 @@
 /////////////////////////////////////////////////
 
 /datum/config_entry/number/projectile_speed_modifier
+	config_entry_value = 1
 
 /datum/config_entry/flag/roundstart_away	//Will random away mission be loaded.
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -286,6 +286,8 @@
 	movedelay_type = /mob/living/simple_animal
 /////////////////////////////////////////////////
 
+/datum/config_entry/number/projectile_speed_modifier
+
 /datum/config_entry/flag/roundstart_away	//Will random away mission be loaded.
 
 /datum/config_entry/number/gateway_delay	//How long the gateway takes before it activates. Default is half an hour. Only matters if roundstart_away is enabled.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -118,6 +118,7 @@
 	. = ..()
 	permutated = list()
 	decayedRange = range
+	speed /= CONFIG_GET(number/projectile_speed_modifier)
 
 /obj/item/projectile/proc/Range()
 	range--

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -48,7 +48,7 @@ MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 
 ## PROJECTILES 
 
-## 1 is the default projectile speeds, so 1.5 would be 50% faster.
+## 1 is the default projectile speed, so 1.5 would be 50% faster.
 PROJECTILE_SPEED_MODIFIER 1
 
 ## NAMES ###

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -46,6 +46,10 @@ MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 1
 ##MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal/slime 0
 MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 
+## PROJECTILES 
+
+## 1 is the default projectile speeds, so 1.5 would be 50% faster.
+PROJECTILE_SPEED_MODIFIER 1
 
 ## NAMES ###
 ## If uncommented this adds a random surname to a player's name if they only specify one name.


### PR DESCRIPTION
Adds a modifier in game_options to adjust global projectile speeds.