### PR TITLE
[READY] Welding helmet to be stored in the Utility belt.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -66,6 +66,7 @@
 		/obj/item/holosign_creator,
 		/obj/item/forcefield_projector,
 		/obj/item/assembly/signaler
+		/obj/item/clothing/head/welding
 		))
 	STR.can_hold = can_hold
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows Welding helmet to be stored in the Utility belt.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows Welding helmet to be stored in the Utility belt. its a toolbelt, if you have a free slot or make one you can hook your Welding helmet to the Utility belt. instead of taking precious space in your bag.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked the Utility belt to also carry Welding helmets.
code: Welding helmet to be stored in the Utility belts now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


### Did I say welding helmet can now be stored in the Utility belt?
because they can, rejoice!