### PR TITLE
nerfs botanical chem dispenser

### DIFF
--- a/modular_skyrat/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -4,19 +4,18 @@
 	circuit = /obj/item/circuitboard/machine/chem_dispenser/upgradeablemutagen
 
 	dispensable_reagents = list(
-		/datum/reagent/toxin/mutagen,
-		/datum/reagent/saltpetre,
-		/datum/reagent/water)
-	upgrade_reagents = list(
 		/datum/reagent/plantnutriment/eznutriment,
 		/datum/reagent/plantnutriment/left4zednutriment,
 		/datum/reagent/plantnutriment/robustharvestnutriment)
+	upgrade_reagents = list(
+		/datum/reagent/ammonia,
+		/datum/reagent/saltpetre,
+		/datum/reagent/radium)
 	upgrade_reagents2 = list(
 		/datum/reagent/toxin/plantbgone,
 		/datum/reagent/toxin/plantbgone/weedkiller,
 		/datum/reagent/toxin/pestkiller)
 	upgrade_reagents3 = list(
-		/datum/reagent/medicine/cryoxadone,
-		/datum/reagent/ammonia,
-		/datum/reagent/ash,
+		/datum/reagent/toxin/mutagen,
+		/datum/reagent/consumable/sodawater,
 		/datum/reagent/diethylamine)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
nerfs the botanical chem dispenser, it was way too strong roundstart
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes the endless supply of mutagen botany was getting roundstart. Now they must suffer the grueling task of asking for upgrades, or talking to the chemist.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: swaps botanical chem dispenser chems around
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
