### PR TITLE
plasmafolk genital selection enabling

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -4,7 +4,7 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/stack/sheet/mineral/plasma
-	species_traits = list(NOBLOOD,NOTRANSSTING)
+	species_traits = list(NOBLOOD,NOTRANSSTING) //Skyrat change
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_NOHUNGER,TRAIT_CALCIUM_HEALER)
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	mutantlungs = /obj/item/organ/lungs/plasmaman

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -4,7 +4,7 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/stack/sheet/mineral/plasma
-	species_traits = list(NOBLOOD,NOTRANSSTING,NOGENITALS)
+	species_traits = list(NOBLOOD,NOTRANSSTING)
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_NOHUNGER,TRAIT_CALCIUM_HEALER)
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	mutantlungs = /obj/item/organ/lungs/plasmaman


### PR DESCRIPTION
## About The Pull Request
Removes plasmaman genitals restriction in character setup.

## Why It's Good For The Game
It enables more opportunity for players - with little, to zero harm done in any way.
Plus, plasmafolk can already use autosurgeons and penis/breast enlargement pills to achieve this result regardless - this just streamlines it for the people who **want it**.
Also: since penis pills don't naturally generate testicles, autosurgeons are required for nutting. Which are **pretty hard to track down**, sometimes!

_As it's a choice to enable genetalia by default,_ the people who don't want to play plasmafolk with genitals are really _not obliged_ to choose them, either. 

**Screenshots:**
![image](https://user-images.githubusercontent.com/13970003/80312696-a1678300-87b4-11ea-8897-b6ca77c94aa5.png)
![image](https://user-images.githubusercontent.com/13970003/80312717-be03bb00-87b4-11ea-8daf-b8f2927682a3.png)

## Changelog
:cl:
tweak: plasmafolk can now enable genitalia in the player setup screen
/:cl: