### PR TITLE
Removes botany dispensers, And adds unstable mutagen as a biogenerator thing

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -17784,11 +17784,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aMG" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/wirecutters,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMH" = (
@@ -17800,7 +17796,6 @@
 /area/security/prison)
 "aMI" = (
 /obj/machinery/light/small,
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMJ" = (
@@ -20155,7 +20150,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aST" = (
-/obj/machinery/chem_dispenser/upgradeablemutagen,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/wrench,
+/obj/item/wirecutters,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aSU" = (

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -29892,12 +29892,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "beM" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/wirecutters,
-/obj/item/shovel/spade,
 /obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beN" = (
@@ -38194,7 +38190,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/chem_dispenser/upgradeablemutagen,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsz" = (

--- a/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
@@ -50218,7 +50218,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/chem_dispenser/upgradeablemutagen,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bAv" = (

--- a/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
@@ -84441,11 +84441,6 @@
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
-"kwI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/chem_dispenser/upgradeablemutagen,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "kxk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -120826,7 +120821,7 @@ bOW
 bQH
 bRV
 bST
-kwI
+bUh
 bVx
 bWS
 bYi

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -57037,10 +57037,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kEW" = (
-/obj/machinery/chem_dispenser/upgradeablemutagen,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "kFm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -92255,7 +92251,7 @@ aSG
 aTW
 aUW
 aRL
-kEW
+aXS
 aYO
 aXS
 aZX

--- a/modular_skyrat/code/modules/research/designs/biogenerator_designs.dm
+++ b/modular_skyrat/code/modules/research/designs/biogenerator_designs.dm
@@ -1,0 +1,7 @@
+/datum/design/umutagen
+	name = "10u Unstable Mutagen"
+	id = "umutagen"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 100)
+	make_reagents = list(/datum/reagent/toxin/mutagen = 10)
+	category = list("initial","Botany Chemicals")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3684,6 +3684,7 @@
 #include "modular_skyrat\code\modules\reagents\reagents_containers\reagent_containers\bottle.dm"
 #include "modular_skyrat\code\modules\recycling\disposal\pipe.dm"
 #include "modular_skyrat\code\modules\research\designs\AI_module_designs.dm"
+#include "modular_skyrat\code\modules\research\designs\biogenerator_designs.dm"
 #include "modular_skyrat\code\modules\research\designs\biogenerator_designs_prisoner.dm"
 #include "modular_skyrat\code\modules\research\designs\machine_designs.dm"
 #include "modular_skyrat\code\modules\research\designs\mechfabricator_designs.dm"


### PR DESCRIPTION
Botany dispensers were over due and this is a good middleground.

## Changelog
:cl: Improvedname
balance: Removes botany dispensers.
Add: Biogenerators can now make unstable mutagen.
/:cl:
