### PR TITLE
Eye modules disable when unconscious

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -251,6 +251,10 @@
 	else
 		activate()
 
+/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+    RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
+    . = ..()
+
 /obj/item/organ/eyes/robotic/glow/proc/prompt_for_controls(mob/user)
 	var/C = input(owner, "Select Color", "Select color", "#ffffff") as color|null
 	if(!C || QDELETED(src) || QDELETED(user) || QDELETED(owner) || owner != user)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -251,10 +251,6 @@
 	else
 		activate()
 
-/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
-    RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
-    . = ..()
-
 /obj/item/organ/eyes/robotic/glow/proc/prompt_for_controls(mob/user)
 	var/C = input(owner, "Select Color", "Select color", "#ffffff") as color|null
 	if(!C || QDELETED(src) || QDELETED(user) || QDELETED(owner) || owner != user)

--- a/modular_skyrat/code/modules/surgery/organs/eyes.dm
+++ b/modular_skyrat/code/modules/surgery/organs/eyes.dm
@@ -1,4 +1,4 @@
 /obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
     RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
     . = ..()
-    // Makes High Lum Eyes depower if you lose conciousness.
+	// makes High lum eyes depower upon conciousness loss

--- a/modular_skyrat/code/modules/surgery/organs/eyes.dm
+++ b/modular_skyrat/code/modules/surgery/organs/eyes.dm
@@ -1,3 +1,4 @@
 /obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
     RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
     . = ..()
+    // Makes High Lum Eyes depower if you lose conciousness.

--- a/modular_skyrat/code/modules/surgery/organs/eyes.dm
+++ b/modular_skyrat/code/modules/surgery/organs/eyes.dm
@@ -1,0 +1,3 @@
+/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
+    RegisterSignal(M,COMSIG_LIVING_STATUS_UNCONSCIOUS,.proc/deactivate)
+    . = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3685,6 +3685,7 @@
 #include "modular_skyrat\code\modules\ruins\spaceruin_code\oldstation.dm"
 #include "modular_skyrat\code\modules\surgery\organ_manipulation.dm"
 #include "modular_skyrat\code\modules\surgery\surgery_step.dm"
+#include "modular_skyrat\code\modules\surgery\organs\eyes.dm"
 #include "modular_skyrat\code\modules\surgery\organs\tongue.dm"
 #include "modular_skyrat\code\modules\surgery\organs\vox_lungs.dm"
 #include "modular_skyrat\code\modules\telescience\telepad.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![highlumshutdown](https://user-images.githubusercontent.com/6706750/80494184-62603b80-8934-11ea-9ba0-f790f9e82753.gif)

your toggleable eye modules disable upon loss of consciousness!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
for synthlizards like myself use the high lum eyes to make their eyes seem more displayish. by disabling them makes their screen go black. 

for everyone else and synths if you lose consciousness your light-emitting eyes turn off. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added loss of consciousness feature to high lum eyes and flashlight eyes.
code: Added some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
