### PR TITLE
Fixes Plasma/Uranium Objects Made Via Exosuit Fabricator

### DIFF
--- a/modular_skyrat/code/game/mecha/mech_fabricator.dm
+++ b/modular_skyrat/code/game/mecha/mech_fabricator.dm
@@ -104,6 +104,7 @@
 
 	var/location = get_step(src,(dir))
 	var/obj/item/I = new D.build_path(location)
+	I.material_flags |= MATERIAL_NO_EFFECTS
 	I.set_custom_materials(res_coef)
 	say("\The [I] is complete.")
 	being_built = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This puts an end to exploding power armor and radioactive mech/borg parts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR will fix issue #1595.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes Uranium and Plasma issues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
