### PR TITLE
Removes being able to add plates to seva explorer suits.

### DIFF
--- a/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
@@ -19,14 +19,6 @@
 	"Improved" = "seva_hood"
 	)
 
-/obj/item/clothing/suit/hooded/explorer/seva/Initialize()
-	. = ..()
-	AddComponent(/datum/component/armor_plate)
-
-/obj/item/clothing/head/hooded/explorer/seva/Initialize()
-	. = ..()
-	AddComponent(/datum/component/armor_plate)
-
 /obj/item/clothing/mask/gas/seva
 	icon = 'modular_skyrat/icons/obj/clothing/masks.dmi'
 	icon_state = "seva_mask"


### PR DESCRIPTION
They were meant for mining only, and not supposed to be better then the standard explorer suit
Which is intended in https://github.com/Citadel-Station-13/Citadel-Station-13/pull/7611

By the adding plate removes the risk of the SEVA suit and turns it into a dominating suit instead.

## Changelog
:cl: Improvedname
balance: You can no longer add plates to seva explorer suits.
/:cl: