### PR TITLE
[Box]Replaces blast doors in lawyer/blueshield office with auctall shutters

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -8438,14 +8438,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ard" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "blueshield_blast";
-	name = "privacy door"
-	},
-/turf/open/floor/plating,
-/area/blueshield)
 "are" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -54631,9 +54623,9 @@
 /area/construction)
 "cCi" = (
 /obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "lawyer_blast";
-	name = "privacy door"
+	name = "Lawyer's office privacy shutters"
 	},
 /turf/open/floor/plating,
 /area/lawoffice)
@@ -62548,11 +62540,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ssP" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "blueshield_blast";
-	name = "privacy door"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "blueshield_blast";
+	name = "Blueshield office privacy shutters"
+	},
 /turf/open/floor/plating,
 /area/blueshield)
 "ssX" = (
@@ -93729,8 +93721,8 @@ anz
 aov
 jGc
 jGc
-ard
-ard
+ssP
+ssP
 ssP
 jGc
 jGc


### PR DESCRIPTION
It isnt a high security area its just a office

## Changelog
:cl: Improvedname
tweak: Removes the blast doors from lawyer/blueshield office and gives them privacy shutters
/:cl:
