### PR TITLE
Allows hiding items and yourself in the trash piles

### DIFF
--- a/modular_skyrat/code/game/objects/structures/trash_pile.dm
+++ b/modular_skyrat/code/game/objects/structures/trash_pile.dm
@@ -10,6 +10,9 @@
 	obj_flags = CAN_BE_HIT
 	pass_flags = LETPASSTHROW
 
+	var/hide_person_time = 30
+	var/hide_item_time = 15
+
 	var/list/searchedby	= list()// Characters that have searched this trashpile, with values of searched time.
 
 	var/chance_alpha	= 99 // Alpha list is the normal maint loot table.
@@ -42,6 +45,31 @@
 		"brokecomp",
 	)
 
+/obj/structure/trash_pile/proc/do_search(mob/user)
+	if(contents.len) //There's something hidden
+		var/atom/A = contents[contents.len] //Get the most recent hidden thing
+		if(istype(A, /mob/living))
+			var/mob/living/M = A
+			to_chat(user,"<span class='notice'>You found someone in the trash!</span>")
+			eject_mob(M)
+		else if (istype(A, /obj/item))
+			var/obj/item/I = A
+			to_chat(user,"<span class='notice'>You found something!</span>")
+			I.forceMove(src.loc)
+	else
+		//You already searched this one bruh
+		if(user.ckey in searchedby)
+			to_chat(user,"<span class='warning'>There's nothing else for you in \the [src]!</span>")
+		//You found an item!
+		else
+			var/luck = rand(1,100)
+			if(luck <= chance_alpha)
+				produce_alpha_item()
+			else if(luck <= chance_alpha+chance_beta)
+				produce_beta_item()
+			to_chat(user,"<span class='notice'>You found something!</span>")
+			searchedby += user.ckey
+
 /obj/structure/trash_pile/attack_hand(mob/user)
 	//Human mob
 	if(ishuman(user))
@@ -49,18 +77,8 @@
 		H.visible_message("[user] searches through \the [src].","<span class='notice'>You search through \the [src].</span>")
 		//Do the searching
 		if(do_after(user,rand(4 SECONDS,6 SECONDS),target=src))
-			//You already searched this one bruh
-			if(user.ckey in searchedby)
-				to_chat(H,"<span class='warning'>There's nothing else for you in \the [src]!</span>")
-			//You found an item!
-			else
-				var/luck = rand(1,100)
-				if(luck <= chance_alpha)
-					produce_alpha_item()
-				else if(luck <= chance_alpha+chance_beta)
-					produce_beta_item()
-				to_chat(H,"<span class='notice'>You found something!</span>")
-				searchedby += user.ckey
+			if(src.loc) //Let's check if the pile still exists
+				do_search(user)
 	else
 		return ..()
 
@@ -85,3 +103,69 @@
 		return I
 	else
 		return produce_alpha_item()
+
+/obj/structure/trash_pile/MouseDrop_T(atom/movable/O, mob/user)
+	if(user == O && iscarbon(O))
+		var/mob/living/L = O
+		if(CHECK_MOBILITY(L, MOBILITY_MOVE))
+			dive_in_pile(user)
+			return
+	. = ..()
+
+/obj/structure/trash_pile/proc/eject_mob(var/mob/living/M)
+	M.forceMove(src.loc)
+	to_chat(M,"<span class='warning'>You've been found!</span>")
+	playsound(M.loc, 'sound/machines/chime.ogg', 50, FALSE, -5)
+	M.do_alert_animation(M)
+
+/obj/structure/trash_pile/proc/do_dive(mob/user)
+	if(contents.len)
+		for(var/mob/M in contents)
+			to_chat(user,"<span class='warning'>There's someone in the trash already!</span>")
+			eject_mob(M)
+			return FALSE
+	return TRUE
+
+/obj/structure/trash_pile/proc/dive_in_pile(mob/user)
+	user.visible_message("<span class='warning'>[user] starts diving into [src].</span>", \
+								"<span class='notice'>You start diving into [src]...</span>")
+	var/adjusted_dive_time = hide_person_time
+	if(user.restrained()) //hiding takes twice as long when restrained.
+		adjusted_dive_time *= 2
+
+	if(do_mob(user, user, adjusted_dive_time))
+		if(src.loc) //Checking if structure has been destroyed
+			if(do_dive(user))
+				to_chat(user,"<span class='notice'>You hide in the trashpile.</span>")
+				user.forceMove(src)
+
+/obj/structure/trash_pile/proc/can_hide_item(obj/item/I)
+	if(contents.len > 10)
+		return FALSE
+	return TRUE
+
+/obj/structure/trash_pile/attackby(obj/item/I, mob/user, params)
+	if(user.a_intent == INTENT_HELP)
+		if(can_hide_item(I))
+			to_chat(user,"<span class='notice'>You begin to stealthily hide [I] in the [src].</span>")
+			if(do_mob(user, user, hide_item_time))
+				if(src.loc)
+					if(user.transferItemToLoc(I, src))
+						to_chat(user,"<span class='notice'>You hide [I] in the trash.</span>")
+					else
+						to_chat(user, "<span class='warning'>\The [I] is stuck to your hand, you cannot put it in the trash!</span>")
+		else
+			to_chat(user,"<span class='warning'>The [src] is way too full to fit [I].</span>")
+
+	. = ..()
+
+/obj/structure/trash_pile/Destroy()
+	for(var/atom/movable/AM in src)
+		AM.forceMove(src.loc)
+	return ..()
+
+/obj/structure/trash_pile/container_resist(mob/user)
+	user.forceMove(src.loc)
+
+/obj/structure/trash_pile/relaymove(mob/user)
+	container_resist(user)

--- a/modular_skyrat/code/game/objects/structures/trash_pile.dm
+++ b/modular_skyrat/code/game/objects/structures/trash_pile.dm
@@ -156,6 +156,7 @@
 						to_chat(user, "<span class='warning'>\The [I] is stuck to your hand, you cannot put it in the trash!</span>")
 		else
 			to_chat(user,"<span class='warning'>The [src] is way too full to fit [I].</span>")
+		return
 
 	. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now hide items and yourself in trash (eww). It  takes a bit of time to climb into it and you can leave immediately. When someone searches the trash pile he gets the top content of it, be it an item someone places or you, unveiling you. If no contents are inside the trash pile it generates an item from the tables.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More hiding spots for antags

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the ability to hide items and yourself in the trash pile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
