### PR TITLE
Radiation collectors now alert engineers when empty

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -29,10 +29,20 @@
 	var/bitcoinmining = FALSE
 	rad_insulation = RAD_EXTREME_INSULATION
 
+	var/obj/item/radio/Radio // skyrat change
+
 /obj/machinery/power/rad_collector/anchored
 	anchored = TRUE
 
+// begin skyrat change
+/obj/machinery/power/rad_collector/Initialize()
+	. = ..()
+	Radio = new /obj/item/radio(src)
+	Radio.listening = 0
+	Radio.set_frequency(FREQ_ENGINEERING)
+
 /obj/machinery/power/rad_collector/Destroy()
+	QDEL_NULL(Radio) // end skyrat change
 	return ..()
 
 /obj/machinery/power/rad_collector/process()
@@ -42,6 +52,7 @@
 		if(!loaded_tank.air_contents.gases[/datum/gas/plasma])
 			investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_SINGULO)
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
+			Radio.talk_into(src, "Insufficient plasma in [get_area(src)] [src], ejecting \the [loaded_tank].", FREQ_ENGINEERING) // skyrat change
 			eject()
 		else
 			var/gasdrained = min(powerproduction_drain*drainratio,loaded_tank.air_contents.gases[/datum/gas/plasma])
@@ -55,6 +66,7 @@
 	else if(is_station_level(z) && SSresearch.science_tech)
 		if(!loaded_tank.air_contents.gases[/datum/gas/tritium] || !loaded_tank.air_contents.gases[/datum/gas/oxygen])
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
+			Radio.talk_into(src, "Insufficient oxygen and tritium in [get_area(src)] [src] to produce research points, ejecting \the [loaded_tank].", FREQ_ENGINEERING) // skyrat change
 			eject()
 		else
 			var/gasdrained = bitcoinproduction_drain*drainratio


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Engineering is now alerted via radio when the radiation collectors are out of plasma or oxygen + trit for research.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sometimes engineers don't fill up the plasma tanks and they end up running out of plasma into the shift, this will let them know if that happens.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Engineering is now notified when the radiation collectors run out of plasma
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
