### PR TITLE
False wall checks take time

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -40,24 +40,23 @@
 	new /obj/structure/falsewall/brass(loc)
 	qdel(src)
 
+/* Moved to Modular Skyrat
 /obj/structure/falsewall/attack_hand(mob/user)
-	// Skyrat change
-	to_chat(user, "<span class='notice'>You push at the wall...</span>") 
-	if(do_after(user, 4 SECONDS, target = src))
-		if(opening)
-			return
-		. = ..()
-		if(.)
-			return
+	if(opening)
+		return
+	. = ..()
+	if(.)
+		return
 
-		opening = TRUE
-		update_icon()
-		if(!density)
-			var/srcturf = get_turf(src)
-			for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
-				opening = FALSE
-				return
-		addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
+	opening = TRUE
+	update_icon()
+	if(!density)
+		var/srcturf = get_turf(src)
+		for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
+			opening = FALSE
+			return
+	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
+*/
 
 /obj/structure/falsewall/proc/toggle_open()
 	if(!QDELETED(src))

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -41,20 +41,23 @@
 	qdel(src)
 
 /obj/structure/falsewall/attack_hand(mob/user)
-	if(opening)
-		return
-	. = ..()
-	if(.)
-		return
-
-	opening = TRUE
-	update_icon()
-	if(!density)
-		var/srcturf = get_turf(src)
-		for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
-			opening = FALSE
+	// Skyrat change
+	to_chat(user, "<span class='notice'>You push at the wall...</span>") 
+	if(do_after(user, 4 SECONDS, target = src))
+		if(opening)
 			return
-	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
+		. = ..()
+		if(.)
+			return
+
+		opening = TRUE
+		update_icon()
+		if(!density)
+			var/srcturf = get_turf(src)
+			for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
+				opening = FALSE
+				return
+		addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
 
 /obj/structure/falsewall/proc/toggle_open()
 	if(!QDELETED(src))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -152,10 +152,14 @@
 	. = ..()
 	if(.)
 		return
-	user.changeNext_move(CLICK_CD_MELEE)
-	to_chat(user, "<span class='notice'>You push the wall but nothing happens!</span>")
-	playsound(src, 'sound/weapons/genhit.ogg', 25, 1)
-	add_fingerprint(user)
+		
+	// Skyrat change
+	to_chat(user, "<span class='notice'>You push at the wall...</span>") 
+	if(do_after(user, 4 SECONDS, target = src))
+		user.changeNext_move(CLICK_CD_MELEE)
+		to_chat(user, "<span class='notice'>...but nothing happens!</span>")
+		playsound(src, 'sound/weapons/genhit.ogg', 25, 1)
+		add_fingerprint(user)
 
 /turf/closed/wall/attackby(obj/item/W, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/modular_skyrat/code/game/objects/structures/false_walls.dm
+++ b/modular_skyrat/code/game/objects/structures/false_walls.dm
@@ -1,0 +1,19 @@
+/obj/structure/falsewall/attack_hand(mob/user)
+	to_chat(user, "<span class='notice'>You push at the wall...</span>") 
+	if(density && do_after(user, 4 SECONDS, target = src))
+		if(opening)
+			return
+		. = ..()
+		if(.)
+			return
+
+		opening = TRUE
+		update_icon()
+		if(!density)
+			var/srcturf = get_turf(src)
+			for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
+				opening = FALSE
+				return
+		addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
+	else
+		addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3490,6 +3490,7 @@
 #include "modular_skyrat\code\game\objects\items\storage\backpacks\blueshield.dm"
 #include "modular_skyrat\code\game\objects\items\tanks\n2_tanks.dm"
 #include "modular_skyrat\code\game\objects\structures\door_assembly.dm"
+#include "modular_skyrat\code\game\objects\structures\false_walls.dm"
 #include "modular_skyrat\code\game\objects\structures\flora.dm"
 #include "modular_skyrat\code\game\objects\structures\ghost_role_spawners.dm"
 #include "modular_skyrat\code\game\objects\structures\kitchen_spike.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clicking at a wall to push at it is no longer instant. There's a 4 second delay until you know if it's a false wall or not.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We want to give a bit more power to little antag bases, especially when maps can be quite cramped, with not that many hiding places. This change is to try and discourage random tapping at walls to see if there's something behind it, and only for opening/checking when you know there's a decent chance something is there.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Checking for false walls has a slight delay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
