### PR TITLE
Additional languages option in the character setup

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -42,7 +42,11 @@
 /datum/config_entry/number/damage_multiplier
 	config_entry_value = 1
 	integer = FALSE
-
+//SKYRAT EDIT - Extra languages
+/datum/config_entry/number/additional_languages
+	config_entry_value = 1
+	integer = FALSE
+//
 /datum/config_entry/number/minimal_access_threshold	//If the number of players is larger than this threshold, minimal access will be turned on.
 	min_val = 0
 

--- a/code/controllers/subsystem/language.dm
+++ b/code/controllers/subsystem/language.dm
@@ -2,6 +2,8 @@ SUBSYSTEM_DEF(language)
 	name = "Language"
 	init_order = INIT_ORDER_LANGUAGE
 	flags = SS_NO_FIRE
+	var/blacklistedlanguages = list(
+								)
 
 /datum/controller/subsystem/language/Initialize(timeofday)
 	for(var/L in subtypesof(/datum/language))

--- a/code/controllers/subsystem/language.dm
+++ b/code/controllers/subsystem/language.dm
@@ -2,8 +2,17 @@ SUBSYSTEM_DEF(language)
 	name = "Language"
 	init_order = INIT_ORDER_LANGUAGE
 	flags = SS_NO_FIRE
-	var/blacklistedlanguages = list(
-								)
+	var/list/blacklistedlanguages = list(/datum/language/aphasia, /datum/language/drone,\
+									/datum/language/codespeak, /datum/language/common,\
+									/datum/language/machine, /datum/language/monkey,\
+									/datum/language/mushroom, /datum/language/narsie,\
+									/datum/language/ratvar, /datum/language/slime,\
+									/datum/language/swarmer, /datum/language/vampiric,\
+									/datum/language/xenocommon, /datum/language/vox,\
+									)
+	var/list/accepted_languages = list()
+	var/list/accepted_languages_names = list()
+	var/list/accepted_languages_associated = list()
 
 /datum/controller/subsystem/language/Initialize(timeofday)
 	for(var/L in subtypesof(/datum/language))
@@ -17,4 +26,26 @@ SUBSYSTEM_DEF(language)
 
 		GLOB.language_datum_instances[language] = instance
 
+		if(!(language in blacklistedlanguages))
+			accepted_languages += language
+			accepted_languages_names += instance.name
+			accepted_languages_associated[instance.name] = language
+
 	return ..()
+
+/datum/controller/subsystem/language/proc/assignlanguages(var/mob/polyglot, client/cli)
+	if(!CONFIG_GET(number/additional_languages) || !cli)
+		return
+	else
+		if(cli.prefs.language1)
+			var/datum/language/L = accepted_languages_associated[cli.prefs.language1]
+			if(L)
+				polyglot.grant_language(L)
+		if(cli.prefs.language2)
+			var/datum/language/L = accepted_languages_associated[cli.prefs.language2]
+			if(L)
+				polyglot.grant_language(L)
+		if(cli.prefs.language3)
+			var/datum/language/L = accepted_languages_associated[cli.prefs.language3]
+			if(L)
+				polyglot.grant_language(L)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -393,6 +393,8 @@ SUBSYSTEM_DEF(ticker)
 				SSjob.EquipRank(N, player.mind.assigned_role, 0)
 				if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
 					SSquirks.AssignQuirks(N.new_character, N.client, TRUE, TRUE, SSjob.GetJob(player.mind.assigned_role), FALSE, N)
+				if(CONFIG_GET(number/additional_languages))
+					SSlanguage.assignlanguages(N.new_character, N.client)
 		CHECK_TICK
 	if(captainless)
 		for(var/mob/dead/new_player/N in GLOB.player_list)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,6 +77,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/be_random_body = 0				//whether we'll have a random body every round
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
+	var/language1 = null				//extra language no. 1
+	var/language2 = null				//extra language no. 2
+	var/language3 = null				//extra language no. 3
 	//SKYRAT CHANGES
 	var/ooc_notes
 	var/erppref = "Ask"
@@ -308,8 +311,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
 			//SKYRAT EDIT - Language selection
 			var/language_selection = CONFIG_GET(number/additional_languages)
-			for(var/i = 0, i >= language_selection, i++)
-				dat += "<a href='?_src_=prefs;preference=language[i];task=input'>[language[i] ? language[i] : "Add Language"]</a><BR>"
+			if(language_selection)
+				dat += "<b>Languages:</b><BR><a href='?_src_=prefs;preference=language1;task=input'>[language1 ? language1 : "Add Language"]</a><BR>"
+			if(language_selection >= 2)
+				dat += "<a href='?_src_=prefs;preference=language2;task=input'>[language2 ? language2 : "Add Language"]</a><BR>"
+			if(language_selection >= 3)
+				dat += "<a href='?_src_=prefs;preference=language3;task=input'>[language3 ? language3 : "Add Language"]</a><BR>"
 			//
 			dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender;task=input'>[gender == MALE ? "Male" : (gender == FEMALE ? "Female" : (gender == PLURAL ? "Non-binary" : "Object"))]</a><BR>"
 			dat += "<b>Age:</b> <a style='display:block;width:30px' href='?_src_=prefs;preference=age;task=input'>[age]</a><BR>"
@@ -1577,23 +1584,29 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						exploitable_info = html_decode(msg)
 				if("language1")
 					if(SSlanguage && SSlanguage.accepted_languages_names)
-						var/clanguage = input(usr, "Choose your extra language", "Language [i]", null) as text in SSlanguage.accepted_languages_names
-						if(clanguage)
+						var/clanguage = input(usr, "Choose your extra language", "Language 1", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
+						if(clanguage != "None")
 							language1 = clanguage
+						else
+							language1 = null
 					else
 						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
 				if("language2")
 					if(SSlanguage && SSlanguage.accepted_languages_names)
-						var/clanguage = input(usr, "Choose your extra language", "Language [i]", null) as text in SSlanguage.accepted_languages_names
-						if(clanguage)
+						var/clanguage = input(usr, "Choose your extra language", "Language 2", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
+						if(clanguage != "None" && clanguage != null)
 							language2 = clanguage
+						else
+							language2 = null
 					else
 						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
 				if("language3")
 					if(SSlanguage && SSlanguage.accepted_languages_names)
-						var/clanguage = input(usr, "Choose your extra language", "Language [i]", null) as text in SSlanguage.accepted_languages_names
-						if(clanguage)
+						var/clanguage = input(usr, "Choose your extra language", "Language 3", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
+						if(clanguage != "None" && clanguage != null)
 							language3 = clanguage
+						else
+							language3 = null
 					else
 						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
 				//END OF SKYRAT CHANGES

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1584,7 +1584,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						exploitable_info = html_decode(msg)
 				if("language1")
 					if(SSlanguage && SSlanguage.accepted_languages_names)
-						var/clanguage = input(usr, "Choose your extra language", "Language 1", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
+						var/clanguage = input(usr, "Choose your extra language", "Language", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
 						if(clanguage != "None")
 							language1 = clanguage
 						else
@@ -1593,7 +1593,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
 				if("language2")
 					if(SSlanguage && SSlanguage.accepted_languages_names)
-						var/clanguage = input(usr, "Choose your extra language", "Language 2", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
+						var/clanguage = input(usr, "Choose your extra language", "Language", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
 						if(clanguage != "None" && clanguage != null)
 							language2 = clanguage
 						else
@@ -1602,7 +1602,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
 				if("language3")
 					if(SSlanguage && SSlanguage.accepted_languages_names)
-						var/clanguage = input(usr, "Choose your extra language", "Language 3", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
+						var/clanguage = input(usr, "Choose your extra language", "Language", null) as null|anything in (SSlanguage.accepted_languages_names + "None")
 						if(clanguage != "None" && clanguage != null)
 							language3 = clanguage
 						else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -306,7 +306,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			dat += "<b>[nameless ? "Default designation" : "Name"]:</b>"
 			dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
-
+			//SKYRAT EDIT - Language selection
+			var/language_selection = CONFIG_GET(number/additional_languages)
+			for(var/i = 0, i >= language_selection, i++)
+				dat += "<a href='?_src_=prefs;preference=language[i];task=input'>[language[i] ? language[i] : "Add Language"]</a><BR>"
+			//
 			dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender;task=input'>[gender == MALE ? "Male" : (gender == FEMALE ? "Female" : (gender == PLURAL ? "Non-binary" : "Object"))]</a><BR>"
 			dat += "<b>Age:</b> <a style='display:block;width:30px' href='?_src_=prefs;preference=age;task=input'>[age]</a><BR>"
 			dat += "<b>Auto-Hiss:</b> <a href='?_src_=prefs;preference=auto_hiss'>[auto_hiss ? "Yes" : "No"]</a><BR>"
@@ -1571,6 +1575,27 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/msg = stripped_multiline_input(usr, "Set your exploitable information, this rarely will be showed to antagonists", "Exploitable Info", exploitable_info, MAX_FLAVOR_LEN, TRUE)
 					if(msg)
 						exploitable_info = html_decode(msg)
+				if("language1")
+					if(SSlanguage && SSlanguage.accepted_languages_names)
+						var/clanguage = input(usr, "Choose your extra language", "Language [i]", null) as text in SSlanguage.accepted_languages_names
+						if(clanguage)
+							language1 = clanguage
+					else
+						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
+				if("language2")
+					if(SSlanguage && SSlanguage.accepted_languages_names)
+						var/clanguage = input(usr, "Choose your extra language", "Language [i]", null) as text in SSlanguage.accepted_languages_names
+						if(clanguage)
+							language2 = clanguage
+					else
+						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
+				if("language3")
+					if(SSlanguage && SSlanguage.accepted_languages_names)
+						var/clanguage = input(usr, "Choose your extra language", "Language [i]", null) as text in SSlanguage.accepted_languages_names
+						if(clanguage)
+							language3 = clanguage
+					else
+						to_chat(usr, "<span class='danger'>The language subsystem is still initializing! Try again in a moment.</span>")
 				//END OF SKYRAT CHANGES
 
 				if("hair")
@@ -2291,7 +2316,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							damagescreenshake = 1
 				if("nameless")
 					nameless = !nameless
-         
+
 				if("erp_pref")
 					switch(erppref)
 						if("Yes")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -428,6 +428,8 @@
 
 	if(humanc && CONFIG_GET(flag/roundstart_traits))
 		SSquirks.AssignQuirks(humanc, humanc.client, TRUE, FALSE, job, FALSE)
+	if(humanc && CONFIG_GET(number/additional_languages))
+		SSlanguage.assignlanguages(humanc, humanc.client)
 
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -564,6 +564,10 @@ MICE_ROUNDSTART 10
 ## This used to be named traits, hence the config name, but it handles quirks, not the other kind of trait!
 ROUNDSTART_TRAITS
 
+## Extra languages (non-species) amount.
+## Set to 0 for no additional languages in the character setup. Up to 3 extra languages.
+ADDITIONAL_LANGUAGES 1
+
 ## Uncomment to disable human moods.
 #DISABLE_HUMAN_MOOD
 


### PR DESCRIPTION
## About The Pull Request

Title. Works based on configs, so you can have from 0 up to 3 selectable extra languages.

## Why It's Good For The Game

It's a feature that has been long requested by a lot of players, but until this moment no one was brave and courageous enough to do it. There it is.

**Do note:** This is just the framework and does not come packaged with any new languages, therefore it might feel lacking and barebones.

## Changelog
:cl:
add: Extra languages in the character setup.
/:cl:
