### PR TITLE
Automatic Protolathe Hand

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -98,6 +98,7 @@
 		if(efficient_with(O.type))
 			O.set_custom_materials(matlist.Copy())
 			O.rnd_crafted(src)
+			user.put_in_active_hand(O) // SKYRAT EDIT: Puts what you printed in your hand.
 	SSblackbox.record_feedback("nested tally", "item_printed", amount, list("[type]", "[path]"))
 	investigate_log("[key_name(user)] built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
 


### PR DESCRIPTION

## About The Pull Request

Places items you print in your active hand. If it cant, it places them where they normally go: on top of the protolathe.

## Why It's Good For The Game

Requested by Chock. Prevent thiefs when you are trying to do your job.

## Changelog
:cl:
tweak: make items go into your hand from protolathe.
/:cl: