### PR TITLE
You know the legion core nerf Citadel did? Yeah i fucking hate it.

### DIFF
--- a/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
+++ b/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
@@ -42,7 +42,7 @@
 		H.adjustBruteLoss(-25, 0)		
 		H.adjustFireLoss(-25, 0)
 		for(var/item/organ in H)
-			damage = 0
+			H.damage = 0
 	else 
 		H.revive(full_heal = 1)
 	qdel(src)

--- a/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
+++ b/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
@@ -1,6 +1,8 @@
 /obj/item/organ/regenerative_core/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag)
-		if(istype(target, /mob/living/simple_animal/hostile/megafauna/bubblegum))
+		if(ishuman(target))
+			apply_healing_core(target, user)
+		else if(istype(target, /mob/living/simple_animal/hostile/megafauna/bubblegum))
 			new /mob/living/simple_animal/hostile/megafauna/bubblegum/hard(target.loc)
 			visible_message("[user] turned [target] into an enraged [target]!")
 			qdel(target)
@@ -15,5 +17,33 @@
 			visible_message("[user] turned [target] into an enraged [target]!")
 			qdel(target)
 			qdel(src)
-		else
-			apply_healing_core(target, user)
+
+/obj/item/organ/regenerative_core/attack_self(mob/user)
+	if(iscarbon(user))
+		apply_healing_core(user, user)
+
+/obj/item/organ/regenerative_core/apply_healing_core(atom/target, mob/user)
+	if(!user || !ishuman(target))
+		return
+	var/mob/living/carbon/human/H = target
+	if(inert)
+		to_chat(user, "<span class='notice'>[src] has decayed and can no longer be used to heal.</span>")
+		return
+	if(H.stat == DEAD)
+		to_chat(user, "<span class='notice'>[src] are useless on the dead.</span>")
+		return
+	if(H != user)
+		H.visible_message("[user] forces [H] to apply [src]... Black tendrils entangle and reinforce [H.p_them()]!")
+		SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "other"))
+	else
+		to_chat(user, "<span class='notice'>You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?</span>")
+		SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
+	if(is_station_level(H.z))
+		H.adjustStaminaLoss(-20, 0)			
+		H.adjustBruteLoss(-25, 0)		
+		H.adjustFireLoss(-25, 0)
+	else 
+		H.revive(full_heal = 1)
+	qdel(src)
+	user.log_message("[user] used [src] to heal [H == user ? "[H.p_them()]self" : H]! Wake the fuck up, Samurai!", LOG_ATTACK, color="green") //Logging for 'old' style legion core use, when clicking on a sprite of yourself or another.
+	

--- a/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
+++ b/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
@@ -41,7 +41,7 @@
 	if(is_station_level(H.z))		
 		H.adjustBruteLoss(-25, 0)		
 		H.adjustFireLoss(-25, 0)
-		for(var/item/organ/O in H)
+		for(var/obj/item/organ/O in H)
 			O.damage = 0
 	else 
 		H.revive(full_heal = 1)

--- a/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
+++ b/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
@@ -38,10 +38,11 @@
 	else
 		to_chat(user, "<span class='notice'>You start to smear [src] on yourself. Disgusting tendrils hold you together and allow you to keep moving, but for how long?</span>")
 		SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
-	if(is_station_level(H.z))
-		H.adjustStaminaLoss(-20, 0)			
+	if(is_station_level(H.z))		
 		H.adjustBruteLoss(-25, 0)		
 		H.adjustFireLoss(-25, 0)
+		for(var/item/organ in H)
+			damage = 0
 	else 
 		H.revive(full_heal = 1)
 	qdel(src)

--- a/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
+++ b/modular_skyrat/code/modules/mining/equipment/regenerative_core.dm
@@ -41,8 +41,8 @@
 	if(is_station_level(H.z))		
 		H.adjustBruteLoss(-25, 0)		
 		H.adjustFireLoss(-25, 0)
-		for(var/item/organ in H)
-			H.damage = 0
+		for(var/item/organ/O in H)
+			O.damage = 0
 	else 
 		H.revive(full_heal = 1)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

Reverts legion cores back to our modular solution. Because the Citadel one sucks.

## Why It's Good For The Game

Our modular solution was just fine and made legion cores way less viable on PVP, while also not punishing miners on lavaland. The Citadel solution has a fucking massive oversight, and punishes lavaland miners while giving traitor miners on station an edge. The problem here is, since the miner cannot be slowed down, he needs to literally reach stamcrit to be non-lethally disabled - a massive blow to security which normally uses disablers, which are only effective because they slow the target down.

Basically it's a shit solution that makes fighting megafauna harder for no reason, and removes a get out of jail card from extremely damaged miners, while also making legion cores still very damn useful on PVP.

## Changelog
:cl:
balance: Legion cores are now actually good again (while on lavaland, at least).
/:cl:
