### PR TITLE
Fixes the bug in which you swallow revolvers when using a conversion kit

### DIFF
--- a/modular_skyrat/code/game/objects/items/kits.dm
+++ b/modular_skyrat/code/game/objects/items/kits.dm
@@ -23,7 +23,7 @@
 /obj/item/conversion_kit/afterattack(atom/target, mob/user, proximity)
 	if(istype(target, /obj/item/gun/ballistic/revolver/detective || /obj/item/gun/ballistic/revolver/russian) && open)
 		var/obj/item/gun/ballistic/revolver/targetrev = target
-		var/obj/item/gun/ballistic/revolver/newrev = new /obj/item/gun/ballistic/revolver(target.loc)
+		var/obj/item/gun/ballistic/revolver/newrev = new /obj/item/gun/ballistic/revolver(get_turf(user))
 		newrev.name = targetrev.name
 		newrev.desc = targetrev.desc + " This one seems a little odd."
 		newrev.icon = targetrev.icon
@@ -38,7 +38,7 @@
 		return TRUE
 	else if(istype(target, /obj/item/toy/gun) && open)
 		var/obj/item/toy/gun/targetrev = target
-		var/obj/item/gun/ballistic/revolver/newrev = new /obj/item/gun/ballistic/revolver(target.loc)
+		var/obj/item/gun/ballistic/revolver/newrev = new /obj/item/gun/ballistic/revolver(get_turf(user))
 		newrev.name = targetrev.name
 		newrev.desc = targetrev.desc + " This one seems a little odd."
 		newrev.icon = targetrev.icon


### PR DESCRIPTION
## About The Pull Request

basically i coded it in a way that the conversion kit would only ever work on the ground
if you used it on a revolver on your hands, simply put, the neew .357 revolver is created inside you. 
you swallow the revolver, with no way to get it back.

## Why It's Good For The Game

its funny as fuck but it wastes people's valuable TC

## Changelog
:cl:
fix: Conversion kit no longer makes you swallow revolvers.
/:cl:
