### PR TITLE
Fuck Wiring Timers

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -142,7 +142,7 @@
 		if(level_diff > 0)
 			LAZYSET(current_users, user, TRUE)
 			to_chat(user, "<span class='notice'>You begin cutting [holder]'s [color] wire...</span>")
-			if(!do_after(user, 1.5 SECONDS * level_diff, target = holder) || !interactable(user))
+			if(!do_after(user, 0.5 SECONDS * level_diff, target = holder) || !interactable(user))
 				LAZYREMOVE(current_users, user)
 				return FALSE
 			LAZYREMOVE(current_users, user)
@@ -171,7 +171,7 @@
 		if(level_diff > 0)
 			LAZYSET(current_users, user, TRUE)
 			to_chat(user, "<span class='notice'>You begin pulsing [holder]'s [color] wire...</span>")
-			if(!do_after(user, 1.5 SECONDS * level_diff, target = holder) || !interactable(user))
+			if(!do_after(user, 0.5 SECONDS * level_diff, target = holder) || !interactable(user))
 				LAZYREMOVE(current_users, user)
 				return FALSE
 			LAZYREMOVE(current_users, user)


### PR DESCRIPTION
reduces the timers for pulsing or cutting wires while hacking to 0.5 seconds (from 1.5s, 66% reduction)