### PR TITLE
[Not Modular] Fluff Addition: Factions/Employers. Also rewords contract and yet again renames fed uniforms

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -227,5 +227,5 @@ GLOBAL_LIST_INIT(station_numerals, greek_letters + phonetic_alphabet + numbers_a
 GLOBAL_LIST_INIT(admiral_messages, list("Do you know how expensive these stations are?","Stop wasting my time.","I was sleeping, thanks a lot.","Stand and fight you cowards!","You knew the risks coming in.","Stop being paranoid.","Whatever's broken just build a new one.","No.", "<i>null</i>","<i>Error: No comment given.</i>", "It's a good day to die!"))
 
 // Skyrat changes. TODO: Ask loremasters for the proper confrimed/likely faction list.
-GLOBAL_LIST_INIT(factions_list, list("NanoTrasen", "Sol Federation", "Other/Independent"))
+GLOBAL_LIST_INIT(factions_list, list("NanoTrasen", "Sol Federation", "Free Trade Union", "Other/Independent"))
 // End of Skyrat changes

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -225,3 +225,7 @@ GLOBAL_LIST_INIT(numbers_as_words, world.file2list("strings/numbers_as_words.txt
 GLOBAL_LIST_INIT(station_numerals, greek_letters + phonetic_alphabet + numbers_as_words + generate_number_strings())
 
 GLOBAL_LIST_INIT(admiral_messages, list("Do you know how expensive these stations are?","Stop wasting my time.","I was sleeping, thanks a lot.","Stand and fight you cowards!","You knew the risks coming in.","Stop being paranoid.","Whatever's broken just build a new one.","No.", "<i>null</i>","<i>Error: No comment given.</i>", "It's a good day to die!"))
+
+// Skyrat changes. TODO: Ask loremasters for the proper confrimed/likely faction list.
+GLOBAL_LIST_INIT(factions_list, list("NanoTrasen", "Sol Federation", "Other/Independent"))
+// End of Skyrat changes

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -230,6 +230,7 @@
 		var/datum/data/record/G = new()
 		G.fields["id"]			= id
 		G.fields["name"]		= H.real_name
+		G.fields["faction"]		= C.prefs.flavor_faction // Skyrat Edit
 		G.fields["rank"]		= assignment
 		G.fields["age"]			= H.age
 		G.fields["species"]	= H.dna.species.name
@@ -279,6 +280,7 @@
 		var/datum/data/record/S = new()
 		S.fields["id"]			= id
 		S.fields["name"]		= H.real_name
+		S.fields["faction"]		= C.prefs.flavor_faction // Skyrat Edit
 		S.fields["criminal"]	= "None"
 		S.fields["mi_crim"]		= list()
 		S.fields["ma_crim"]		= list()
@@ -296,6 +298,7 @@
 		L.fields["id"]			= md5("[H.real_name][H.mind.assigned_role]")	//surely this should just be id, like the others?
 		L.fields["name"]		= H.real_name
 		L.fields["rank"] 		= H.mind.assigned_role
+		L.fields["faction"]		= C.prefs.flavor_faction // Skyrat Edit
 		L.fields["age"]			= H.age
 		if(H.gender == MALE)
 			G.fields["gender"]  = "Male"

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -174,7 +174,7 @@
 						<tr><td>Age:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=age'>&nbsp;[active1.fields["age"]]&nbsp;</A></td></tr>"}
 						dat += "<tr><td>Species:</td><td><A href ='?src=[REF(src)];choice=Edit Field;field=species'>&nbsp;[active1.fields["species"]]&nbsp;</A></td></tr>"
 						dat += {"<tr><td>Rank:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=rank'>&nbsp;[active1.fields["rank"]]&nbsp;</A></td></tr>
-						<tr><td>Employer:</td><td>&nbsp;[active1.fields["faction"]]&nbsp;</td></tr> //Skyrat change
+						<tr><td>Employer:</td><td>&nbsp;[active1.fields["faction"]]&nbsp;</td></tr> <!--Skyrat change-->
 						<tr><td>Fingerprint:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=fingerprint'>&nbsp;[active1.fields["fingerprint"]]&nbsp;</A></td></tr>
 						<tr><td>Physical Status:</td><td>&nbsp;[active1.fields["p_stat"]]&nbsp;</td></tr>
 						<tr><td>Mental Status:</td><td>&nbsp;[active1.fields["m_stat"]]&nbsp;</td></tr>

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -174,6 +174,7 @@
 						<tr><td>Age:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=age'>&nbsp;[active1.fields["age"]]&nbsp;</A></td></tr>"}
 						dat += "<tr><td>Species:</td><td><A href ='?src=[REF(src)];choice=Edit Field;field=species'>&nbsp;[active1.fields["species"]]&nbsp;</A></td></tr>"
 						dat += {"<tr><td>Rank:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=rank'>&nbsp;[active1.fields["rank"]]&nbsp;</A></td></tr>
+						<tr><td>Employer:</td><td>&nbsp;[active1.fields["faction"]]&nbsp;</td></tr> //Skyrat change
 						<tr><td>Fingerprint:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=fingerprint'>&nbsp;[active1.fields["fingerprint"]]&nbsp;</A></td></tr>
 						<tr><td>Physical Status:</td><td>&nbsp;[active1.fields["p_stat"]]&nbsp;</td></tr>
 						<tr><td>Mental Status:</td><td>&nbsp;[active1.fields["m_stat"]]&nbsp;</td></tr>

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -89,6 +89,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/security_records = ""
 	var/medical_records = ""
 	var/flavor_background = ""
+	var/flavor_faction = "UNSET"
 	var/character_skills = ""
 	var/exploitable_info = ""
 	var/see_chat_emotes = TRUE
@@ -380,6 +381,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += 	"<a href='?_src_=prefs;preference=flavor_background;task=input'>Background</a>"
 			dat += 	"<a href='?_src_=prefs;preference=character_skills;task=input'>Skills</a><br>"
 			dat += 	"<a href='?_src_=prefs;preference=exploitable_info;task=input'>Exploitable Information</a><br>"
+			dat += 	"<b>Faction/Employer:</b> <a href='?_src_=prefs;preference=flavor_faction;task=input'>[flavor_faction]</a><br>"
 			dat += "<b>Custom runechat color:</b> <a href='?_src_=prefs;preference=enable_personal_chat_color'>[enable_personal_chat_color ? "Enabled" : "Disabled"]</a> [enable_personal_chat_color ? "<span style='border: 1px solid #161616; background-color: [personal_chat_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=personal_chat_color;task=input'>Change</a>" : ""]<br>"
 			//END OF SKYRAT EDIT
 			dat += "<h2>Body</h2>"
@@ -1592,6 +1594,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(msg)
 						flavor_background = html_decode(msg)
 
+				if("flavor_faction")
+					var/new_faction = input(user, "Set your faction", "Character Faction") as null|anything in GLOB.factions_list
+					if(new_faction)
+						flavor_faction = new_faction
+
 				if("character_skills")
 					var/msg = stripped_multiline_input(usr, "Set your skills or hobbies", "Character Skills", character_skills, MAX_FLAVOR_LEN, TRUE)
 					if(msg)
@@ -2347,7 +2354,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							damagescreenshake = 1
 				if("nameless")
 					nameless = !nameless
-         
+
 				if("erp_pref")
 					switch(erppref)
 						if("Yes")

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -25,7 +25,7 @@
 	target = nOwner.mind
 	update_text()
 
-
+/* // handled modular by Skyrat
 /obj/item/paper/contract/employment/update_text()
 	name = "paper- [target] employment contract"
 	info = "<center>Conditions of Employment</center><BR><BR><BR><BR>This Agreement is made and entered into as of the date of last signature below, by and between [target] (hereafter referred to as SLAVE), and Nanotrasen (hereafter referred to as the omnipresent and helpful watcher of humanity).<BR>WITNESSETH:<BR>WHEREAS, SLAVE is a natural born human or humanoid, possessing skills upon which he can aid the omnipresent and helpful watcher of humanity, who seeks employment in the omnipresent and helpful watcher of humanity.<BR>WHEREAS, the omnipresent and helpful watcher of humanity agrees to sporadically provide payment to SLAVE, in exchange for permanent servitude.<BR>NOW THEREFORE in consideration of the mutual covenants herein contained, and other good and valuable consideration, the parties hereto mutually agree as follows:<BR>In exchange for paltry payments, SLAVE agrees to work for the omnipresent and helpful watcher of humanity, for the remainder of his or her current and future lives.<BR>Further, SLAVE agrees to transfer ownership of his or her soul to the loyalty department of the omnipresent and helpful watcher of humanity.<BR>Should transfership of a soul not be possible, a lien shall be placed instead.<BR>Signed,<BR><i>[target]</i>"
@@ -48,7 +48,7 @@
 		M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \
 			"<span class='userdanger'>[user] beats [M] over the head with [src]!</span>")
 	return ..()
-
+*/
 
 /obj/item/paper/contract/infernal
 	var/contractType = 0

--- a/modular_citadel/code/modules/client/preferences_savefile.dm
+++ b/modular_citadel/code/modules/client/preferences_savefile.dm
@@ -79,7 +79,7 @@
 	WRITE_FILE(S["medical_records"], medical_records)
 	WRITE_FILE(S["general_records"], general_records)
 	WRITE_FILE(S["flavor_background"], flavor_background)
-	WRITE_FILE(S["flavor_faction"], flavor_background)
+	WRITE_FILE(S["flavor_faction"], flavor_faction)
 	WRITE_FILE(S["character_skills"], character_skills)
 	WRITE_FILE(S["exploitable_info"], exploitable_info)
 	WRITE_FILE(S["enable_personal_chat_color"], enable_personal_chat_color)

--- a/modular_citadel/code/modules/client/preferences_savefile.dm
+++ b/modular_citadel/code/modules/client/preferences_savefile.dm
@@ -16,7 +16,7 @@
 	//SKYRAT CHANGES
 	S["enable_personal_chat_color"]			>> enable_personal_chat_color
 	S["personal_chat_color"]			>> personal_chat_color
-  
+
 	S["feature_ipc_chassis"] >> features["ipc_chassis"]
 
 	features["ipc_chassis"] 	= sanitize_inlist(features["ipc_chassis"], GLOB.ipc_chassis_list)
@@ -31,6 +31,7 @@
 	medical_records = sanitize_text(S["medical_records"])
 	general_records = sanitize_text(S["general_records"])
 	flavor_background = sanitize_text(S["flavor_background"])
+	flavor_faction = sanitize_text(S["flavor_faction"])
 	character_skills = sanitize_text(S["character_skills"])
 	exploitable_info = sanitize_text(S["exploitable_info"])
 	enable_personal_chat_color	= sanitize_integer(enable_personal_chat_color, 0, 1, initial(enable_personal_chat_color))
@@ -78,6 +79,7 @@
 	WRITE_FILE(S["medical_records"], medical_records)
 	WRITE_FILE(S["general_records"], general_records)
 	WRITE_FILE(S["flavor_background"], flavor_background)
+	WRITE_FILE(S["flavor_faction"], flavor_background)
 	WRITE_FILE(S["character_skills"], character_skills)
 	WRITE_FILE(S["exploitable_info"], exploitable_info)
 	WRITE_FILE(S["enable_personal_chat_color"], enable_personal_chat_color)

--- a/modular_skyrat/code/modules/clothing/refactor.dm
+++ b/modular_skyrat/code/modules/clothing/refactor.dm
@@ -740,7 +740,7 @@
 // Bonus for assistants and service.
 /obj/item/clothing/under/trek/orvi
 	name = "federation assistant uniform"
-	desc = "A federation uniform worn by officer's trainees."
+	desc = "A federation uniform worn by volunteered-for-work cadets... Or in simple terms - assistants."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -788,7 +788,7 @@
 // Changes name/desc to the jackets, makes modern/non-classic jacket to have same list of allowed suit-storage items as classic one.
 /obj/item/clothing/suit/storage/fluff/fedcoat
 	name = "federation classic uniform jacket"
-	desc = "A classic, old federation uniform jacket. Set phasers to awesome!"
+	desc = "A classic federation uniform jacket. Set phasers to awesome!"
 
 /obj/item/clothing/suit/storage/fluff/modernfedcoat
 	name = "federation uniform jacket"

--- a/modular_skyrat/code/modules/clothing/refactor.dm
+++ b/modular_skyrat/code/modules/clothing/refactor.dm
@@ -618,8 +618,8 @@
 
 // Reskinnable Trek uniforms, now using Orvi-like by default.
 /obj/item/clothing/under/trek/command
-	name = "\improper Planetary Federation command uniform"
-	desc = "An uniform worn by command officers."
+	name = "federation command uniform"
+	desc = "A federation uniform worn by command officers."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -658,8 +658,8 @@
 	)
 
 /obj/item/clothing/under/trek/engsec
-	name = "\improper Planetary Federation operations uniform"
-	desc = "An uniform worn by operations officers. You feel strangely vulnerable just seeing this..."
+	name = "federation operations uniform"
+	desc = "A federation uniform worn by operations officers."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -698,8 +698,8 @@
 	)
 
 /obj/item/clothing/under/trek/medsci
-	name = "\improper Planetary Federation medsci uniform"
-	desc = "An uniform worn by medsci officers."
+	name = "federation medsci uniform"
+	desc = "A federation uniform worn by medsci officers."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -739,8 +739,8 @@
 
 // Bonus for assistants and service.
 /obj/item/clothing/under/trek/orvi
-	name = "\improper Planetary Federation assistant uniform"
-	desc = "An uniform worn by volunteered active-duty-cadets... Or in simple terms - an assistants."
+	name = "federation assistant uniform"
+	desc = "A federation uniform worn by officer's trainees."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -764,8 +764,8 @@
 	)
 
 /obj/item/clothing/under/trek/orvi/service
-	name = "\improper Planetary Federation service uniform"
-	desc = "An uniform worn by service officers. How service department can have officers is still unknown."
+	name = "federation service uniform"
+	desc = "A federation uniform worn by service officers. How service department can have officers is still unknown."
 	icon_state = "orv_srv"
 	item_state = "g_suit"
 	unique_reskin_icons = list(
@@ -787,12 +787,12 @@
 
 // Changes name/desc to the jackets, makes modern/non-classic jacket to have same list of allowed suit-storage items as classic one.
 /obj/item/clothing/suit/storage/fluff/fedcoat
-	name = "\improper Planetary Federation classic uniform jacket"
-	desc = "A classic uniform jacket. Set phasers to awesome."
+	name = "federation classic uniform jacket"
+	desc = "A classic, old federation uniform jacket. Set phasers to awesome!"
 
 /obj/item/clothing/suit/storage/fluff/modernfedcoat
-	name = "\improper Planetary Federation uniform jacket"
-	desc = "An uniform jacket."
+	name = "federation uniform jacket"
+	desc = "A federation uniform jacket."
 	allowed = list(
 				/obj/item/tank/internals/emergency_oxygen,
 				/obj/item/flashlight,
@@ -811,8 +811,8 @@
 				/obj/item/taperecorder)
 
 /obj/item/clothing/head/caphat/formal/fedcover
-	name = "\improper Planetary Federation peaked cap"
-	desc = "A peaked cap."
+	name = "federation peaked cap"
+	desc = "A peaked cap, that demands <i>at least <u>some</u></i> discipline from its wearer."
 
 // PrisArch-like color codes for prisoners. Uses _stored variation for Warden's control.
 /obj/item/clothing/under/rank/prisoner

--- a/modular_skyrat/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/human.dm
@@ -5,7 +5,7 @@
 			var/str = "[src]'s OOC Notes : <br> <b>ERP :</b> [client.prefs.erppref] <b>| Non-Con :</b> [client.prefs.nonconpref] <b>| Vore :</b> [client.prefs.vorepref]<br>[client.prefs.ooc_notes]"
 			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s OOC information", replacetext(str, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s ooc info"))
 			onclose(usr, "[name]'s ooc info")
-	
+
 	if(href_list["general_records"])
 		if(client && usr.client.holder)
 			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s general records", replacetext(client.prefs.general_records, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s gen rec"))
@@ -20,6 +20,11 @@
 		if(client && usr.client.holder)
 			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s medical records", replacetext(client.prefs.medical_records, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s med rec"))
 			onclose(usr, "[name]'s med rec")
+
+	if(href_list["flavor_faction"])
+		if(client && usr.client.holder)
+			usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", "[name]'s background faction", replacetext(client.prefs.flavor_faction, "\n", "<BR>")), text("window=[];size=500x200", "[name]'s flav fact"))
+			onclose(usr, "[name]'s flav fact")
 
 	if(href_list["flavor_background"])
 		if(client && usr.client.holder)

--- a/modular_skyrat/code/modules/paperwork/contract.dm
+++ b/modular_skyrat/code/modules/paperwork/contract.dm
@@ -1,0 +1,24 @@
+// tweaking from code/modules/paperwork/contract.dm
+
+/obj/item/paper/contract/employment/update_text()
+	name = "paper- [target] employment contract"
+	info = "<center>Conditions of Employment</center><BR><BR><BR><BR>This Agreement is made and entered into as of the date of last signature below, by and between [target] (hereafter referred to as SLAVE), and CC-Man (hereafter referred to as the omnipresent and helpful watcher of humanity).<BR>WITNESSETH:<BR>WHEREAS, SLAVE is a natural born human or humanoid, possessing skills upon which he can aid the omnipresent and helpful watcher of humanity, who seeks employment in the omnipresent and helpful watcher of humanity.<BR>WHEREAS, the omnipresent and helpful watcher of humanity agrees to sporadically provide payment to SLAVE, in exchange for permanent servitude.<BR>NOW THEREFORE in consideration of the mutual covenants herein contained, and other good and valuable consideration, the parties hereto mutually agree as follows:<BR>In exchange for paltry payments, SLAVE agrees to work for the omnipresent and helpful watcher of humanity, for the remainder of his or her current and future lives.<BR>Further, SLAVE agrees to transfer ownership of his or her soul to the loyalty department of the omnipresent and helpful watcher of humanity.<BR>Should transfership of a soul not be possible, a lien shall be placed instead.<BR>Signed,<BR><i>[target]</i>"
+
+
+/obj/item/paper/contract/employment/attack(mob/living/M, mob/living/carbon/human/user)
+	var/deconvert = FALSE
+	if(M.mind == target && !M.owns_soul())
+		if(user.mind && (user.mind.assigned_role == "Lawyer"))
+			deconvert = TRUE
+		else if (user.mind && (user.mind.assigned_role =="Head of Personnel") || (user.mind.assigned_role == "CentCom Commander"))
+			deconvert = prob (25) // the HoP doesn't have AS much legal training
+		else
+			deconvert = prob (5)
+	if(deconvert)
+		M.visible_message("<span class='notice'>[user] reminds [M] that [M]'s soul was already purchased by CC-Man!</span>")
+		to_chat(M, "<span class='boldnotice'>You feel that your soul has returned to its rightful owner, CC-Man.</span>")
+		M.return_soul()
+	else
+		M.visible_message("<span class='danger'>[user] beats [M] over the head with [src]!</span>", \
+			"<span class='userdanger'>[user] beats [M] over the head with [src]!</span>")
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3694,6 +3694,7 @@
 #include "modular_skyrat\code\modules\ninja\suit\head.dm"
 #include "modular_skyrat\code\modules\ninja\suit\shoes.dm"
 #include "modular_skyrat\code\modules\ninja\suit\suit.dm"
+#include "modular_skyrat\code\modules\paperwork\contract.dm"
 #include "modular_skyrat\code\modules\power\cable.dm"
 #include "modular_skyrat\code\modules\procedural_mapping\mapGenerators\lavaland.dm"
 #include "modular_skyrat\code\modules\projectiles\gun.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This will allow players to set their faction/employer. For now, there's only a few: NanoTrasen, Sol Federation and Free Trade Union (per request). Option for being independent or other faction is here. Also changes contract wording and once **_again_** renames fed uniform.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Apparently, this is how lore-wise Skyrat want to operate. Correct me if I am wrong.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added option to select background faction (employer).
tweak: Rewords employment contract to accommodate factions... With yet another HL reference.
tweak: Once again renames Fed uniforms, dropping "Planetary".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
