### PR TITLE
[Not Modular] Mining Voucher Radials

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -147,11 +147,16 @@
 	if(default_deconstruction_crowbar(I))
 		return
 	return ..()
-
+// SKYRAT EDIT: Equipment Radials
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)
-	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Mining Conscription Kit")
+	var/items = list(	"Survival Capsule and Explorer's Webbing" = image(icon = 'icons/obj/storage.dmi', icon_state = "explorerpack"),
+						"Resonator Kit" = image(icon = 'icons/obj/mining.dmi', icon_state = "resonator"),
+						"Minebot Kit" = image(icon = 'icons/mob/aibots.dmi', icon_state = "mining_drone"),
+						"Extraction and Rescue Kit" = image(icon = 'icons/obj/fulton.dmi', icon_state = "extraction_pack"),
+						"Crusher Kit" = image(icon = 'icons/obj/mining.dmi', icon_state = "crusher"),
+						"Mining Conscription Kit" = image(icon = 'icons/obj/storage.dmi', icon_state = "duffel"))
 
-	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in items
+	var/selection = show_radial_menu(redeemer, src, items, require_near = TRUE, tooltips = TRUE)
 	if(!selection || !Adjacent(redeemer) || QDELETED(voucher) || voucher.loc != redeemer)
 		return
 	var/drop_location = drop_location()
@@ -320,11 +325,12 @@
 	new /obj/item/card/id/mining(src)
 	new /obj/item/storage/bag/ore(src)
 	new /obj/item/clothing/glasses/meson/prescription(src)
-
+// SKYRAT EDIT: Equipment Radials
 /obj/machinery/mineral/equipment_vendor/proc/RedeemSVoucher(obj/item/suit_voucher/voucher, mob/redeemer)
-	var/items = list("Exo-suit", "SEVA suit")
+	var/items = list(	"Exo-suit" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "exo"),
+						"SEVA suit" = image(icon = 'icons/obj/clothing/suits.dmi', icon_state = "seva"))
 
-	var/selection = input(redeemer, "Pick your suit.", "Suit Voucher Redemption") as null|anything in items
+	var/selection = show_radial_menu(redeemer, src, items, require_near = TRUE, tooltips = TRUE)
 	if(!selection || !Adjacent(redeemer) || QDELETED(voucher) || voucher.loc != redeemer)
 		return
 	var/drop_location = drop_location()

--- a/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
+++ b/modular_skyrat/code/modules/mining/equipment/explorer_gear.dm
@@ -1,6 +1,6 @@
 //seva shit
 /obj/item/clothing/suit/hooded/explorer/seva
-	icon = 'modular_skyrat/icons/obj/clothing/suits.dmi'
+	icon = 'icons/obj/clothing/suits.dmi'
 	icon_state = "seva"
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/suit.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/suit_digi.dmi'
@@ -22,7 +22,7 @@
 	)
 
 /obj/item/clothing/head/hooded/explorer/seva
-	icon = 'modular_skyrat/icons/obj/clothing/hats.dmi'
+	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "seva"
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/head.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/head_muzzled.dmi'
@@ -75,7 +75,7 @@
 
 //exosuit shit
 /obj/item/clothing/suit/hooded/explorer/exo
-	icon = 'modular_skyrat/icons/obj/clothing/suits.dmi'
+	icon = 'icons/obj/clothing/suits.dmi'
 	icon_state = "exo"
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/suit.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/suit_digi.dmi'
@@ -97,7 +97,7 @@
 	)
 
 /obj/item/clothing/head/hooded/explorer/exo
-	icon = 'modular_skyrat/icons/obj/clothing/hats.dmi'
+	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "exo"
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/head.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/head_muzzled.dmi'
@@ -119,7 +119,7 @@
 	)
 
 /obj/item/clothing/mask/gas/exo
-	icon = 'modular_skyrat/icons/obj/clothing/masks.dmi'
+	icon = 'icons/obj/clothing/masks.dmi'
 	icon_state = "exo"
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/mask.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/mask_muzzled.dmi'


### PR DESCRIPTION
## About The Pull Request

Yog has radials for mining vouchers... let us also have them.
https://github.com/yogstation13/Yogstation/pull/8433

![image](https://user-images.githubusercontent.com/55967837/81511003-2a69d880-92e4-11ea-850f-7d2d512ad3dd.png)
![image](https://user-images.githubusercontent.com/55967837/81511011-3e153f00-92e4-11ea-899c-f9c69613267d.png)


## Why It's Good For The Game

Radials make picking stuff easier for new players who have no idea what something looks like.

## Changelog
:cl:
add: Added radials to mining vouchers
add: Added the old eva and seva suit icons to the default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
