### PR TITLE
Partially removes lavaland RNG megafauna spawns

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -130,6 +130,7 @@
 	description = "A strange, square chunk of metal of massive size. Inside awaits only death and many, many squares."
 	suffix = "lavaland_surface_hierophant.dmm"
 	always_place = TRUE
+	cost = 0 //Skyrat change - FUCK RNG
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/blood_drunk_miner
@@ -138,6 +139,7 @@
 	description = "A strange arrangement of stone tiles and an insane, beastly miner contemplating them."
 	suffix = "lavaland_surface_blooddrunk1.dmm"
 	cost = 0
+	always_place = TRUE //Skyrat change - FUCK RNG
 	allow_duplicates = FALSE //will only spawn one variant of the ruin
 
 /datum/map_template/ruin/lavaland/blood_drunk_miner/guidance
@@ -218,7 +220,7 @@
 	description = "A Syndicate shuttle had an unfortunate stowaway..."
 	suffix = "lavaland_surface_swarmer_crash.dmm"
 	allow_duplicates = FALSE
-	cost = 20
+	cost = 10  //Skyrat change - FUCK SWARMERS
 
 /datum/map_template/ruin/lavaland/miningripley
 	name = "Ripley"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -220,7 +220,7 @@
 	description = "A Syndicate shuttle had an unfortunate stowaway..."
 	suffix = "lavaland_surface_swarmer_crash.dmm"
 	allow_duplicates = FALSE
-	cost = 10  //Skyrat change - FUCK SWARMERS
+	cost = 20
 
 /datum/map_template/ruin/lavaland/miningripley
 	name = "Ripley"
@@ -252,4 +252,4 @@
 	cost = 5
 	placement_weight = 3
 	always_place = TRUE
-	allow_duplicates = TRUE 
+	allow_duplicates = TRUE

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -220,7 +220,7 @@
 	description = "A Syndicate shuttle had an unfortunate stowaway..."
 	suffix = "lavaland_surface_swarmer_crash.dmm"
 	allow_duplicates = FALSE
-	cost = 20
+	cost = 10  //Skyrat change - FUCK SWARMERS
 
 /datum/map_template/ruin/lavaland/miningripley
 	name = "Ripley"
@@ -252,4 +252,4 @@
 	cost = 5
 	placement_weight = 3
 	always_place = TRUE
-	allow_duplicates = TRUE
+	allow_duplicates = TRUE 

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -223,7 +223,7 @@
 
 /turf/open/floor/plating/asteroid/airless/cave/snow/underground/has_data //subtype for producing a tunnel with given data
 	has_data = TRUE
-/*
+
 /turf/open/floor/plating/asteroid/airless/cave/Initialize()
 	if (!mob_spawn_list)
 		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
@@ -235,7 +235,7 @@
 	. = ..()
 	if(!has_data)
 		produce_tunnel_from_data()
-*/ //moved to modular_skyrat
+
 /// Sets the tunnel length and direction
 /turf/open/floor/plating/asteroid/airless/cave/proc/get_cave_data(set_length, exclude_dir = -1)
 	// If set_length (arg1) isn't defined, get a random length; otherwise assign our length to the length arg.

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -223,7 +223,7 @@
 
 /turf/open/floor/plating/asteroid/airless/cave/snow/underground/has_data //subtype for producing a tunnel with given data
 	has_data = TRUE
-
+/*
 /turf/open/floor/plating/asteroid/airless/cave/Initialize()
 	if (!mob_spawn_list)
 		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
@@ -235,7 +235,7 @@
 	. = ..()
 	if(!has_data)
 		produce_tunnel_from_data()
-
+*/ //moved to modular_skyrat
 /// Sets the tunnel length and direction
 /turf/open/floor/plating/asteroid/airless/cave/proc/get_cave_data(set_length, exclude_dir = -1)
 	// If set_length (arg1) isn't defined, get a random length; otherwise assign our length to the length arg.

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -336,7 +336,7 @@
 		if(!spawned_flora) // no rocks beneath mob spawners / mobs.
 			SpawnMonster(T)
 	T.ChangeTurf(turf_type, null, CHANGETURF_IGNORE_AIR)
-
+/*
 /// Spawns a random mob or megafauna in the tunnel
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
 	if(!isarea(loc))
@@ -368,7 +368,7 @@
 
 		new randumb(T)
 	return TRUE
-
+*/ //moved to modular_skyrat
 #undef SPAWN_MEGAFAUNA
 #undef SPAWN_BUBBLEGUM
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -89,9 +89,11 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize()
 	. = ..()
+	/*
 	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in GLOB.mob_list)
 		if(B != src)
 			return INITIALIZE_HINT_QDEL //There can be only one
+	*/ //Skyrat change - There can be many
 	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
 	AddSpell(bloodspell)
 	if(istype(loc, /obj/effect/dummy/phased_mob/slaughter))

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -25,6 +25,15 @@
 				return
 		new definite_boss(src)
 		return TRUE
+	var/shouldspawnlegiontendril = TRUE
+	for(var/structure/spawner/lavaland/legion in GLOB.tendrils)
+		shouldspawnlegiontendril = FALSE
+	if(shouldspawnlegiontendril)
+		for(var/structure/spawner/lavaland/L in urange(12,T))
+			if(istype(L, /obj/structure/spawner/lavaland) && get_dist(src, L) <= 3)
+				return //prevents tendrils spawning in each other's collapse range
+		new /obj/structure/spawner/lavaland/legion(src)
+		return TRUE
 	if(prob(30))
 		if(!A.mob_spawn_allowed)
 			return
@@ -44,7 +53,9 @@
 				return //if there's a megafauna within standard view don't spawn anything at all
 			if(ispath(randumb, /mob/living/simple_animal/hostile/asteroid) || istype(H, /mob/living/simple_animal/hostile/asteroid))
 				return //if the random is a standard mob, avoid spawning if there's another one within 12 tiles
-			if((ispath(randumb, /obj/structure/spawner/lavaland) || istype(H, /obj/structure/spawner/lavaland)) && get_dist(src, H) <= 2)
+		if(ispath(randumb, /obj/structure/spawner/lavaland))
+			for(var/structure/spawner/lavaland/L in urange(12,T))
+				istype(L, /obj/structure/spawner/lavaland)) && get_dist(src, L) <= 3
 				return //prevents tendrils spawning in each other's collapse range
 
 		new randumb(T)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -1,6 +1,9 @@
 #define SPAWN_MEGAFAUNA "bluh bluh huge boss"
 #define SPAWN_BUBBLEGUM 6
 
+/turf/open/floor/plating/asteroid/airless/cave
+	var/list/remainingmegas = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
+
 /turf/open/floor/plating/asteroid/airless/cave/volcanic
 	mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast/random = 50, /obj/structure/spawner/lavaland/goliath = 3, \
 		/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random = 40, /obj/structure/spawner/lavaland = 2, \
@@ -9,12 +12,6 @@
 		/mob/living/simple_animal/hostile/asteroid/imp = 20, /obj/structure/spawner/lavaland/imp = 1, \
 		SPAWN_MEGAFAUNA = 6, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10)
 		//imps are rare because boy they annoying
-
-/turf/open/floor/plating/asteroid/airless/cave
-	var/list/remainingmegas = list()
-
-/turf/open/floor/plating/asteroid/airless/cave/New()
-	remainingmegas = megafauna_spawn_list.Copy()
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
 	if(!isarea(loc))

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -8,13 +8,29 @@
 		/mob/living/simple_animal/hostile/asteroid/miner = 40, /obj/structure/spawner/lavaland/shamblingminer = 2, \
 		/mob/living/simple_animal/hostile/asteroid/imp = 20, /obj/structure/spawner/lavaland/imp = 1, \
 		SPAWN_MEGAFAUNA = 6, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10)
-//imps are rare because boy they annoying
+		//imps are rare because boy they annoying
+
+/turf/open/floor/plating/asteroid/airless/cave
+	var/list/remainingmegas = list()
+
+/turf/open/floor/plating/asteroid/airless/cave/Initialize()
+	if (!mob_spawn_list)
+		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
+	if (!megafauna_spawn_list)
+		megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
+	if (!flora_spawn_list)
+		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
+	remainingmegas = megafauna_spawn_list.Copy()
+
+	. = ..()
+	if(!has_data)
+		produce_tunnel_from_data()
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
 	if(!isarea(loc))
 		return
 	var/area/A = loc
-	var/definite_boss = pickweight(megafauna_spawn_list)
+	var/definite_boss = pick_n_take(remainingmegas)
 	var/shouldspawnboss = TRUE
 	for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
 		if(definite_boss == M.type)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -13,18 +13,8 @@
 /turf/open/floor/plating/asteroid/airless/cave
 	var/list/remainingmegas = list()
 
-/turf/open/floor/plating/asteroid/airless/cave/Initialize()
-	if (!mob_spawn_list)
-		mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 1, /mob/living/simple_animal/hostile/asteroid/goliath = 5, /mob/living/simple_animal/hostile/asteroid/basilisk = 4, /mob/living/simple_animal/hostile/asteroid/hivelord = 3)
-	if (!megafauna_spawn_list)
-		megafauna_spawn_list = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
-	if (!flora_spawn_list)
-		flora_spawn_list = list(/obj/structure/flora/ash/leaf_shroom = 2 , /obj/structure/flora/ash/cap_shroom = 2 , /obj/structure/flora/ash/stem_shroom = 2 , /obj/structure/flora/ash/cacti = 1, /obj/structure/flora/ash/tall_shroom = 2)
+/turf/open/floor/plating/asteroid/airless/cave/New()
 	remainingmegas = megafauna_spawn_list.Copy()
-
-	. = ..()
-	if(!has_data)
-		produce_tunnel_from_data()
 
 /turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
 	if(!isarea(loc))

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -16,7 +16,7 @@
 	var/area/A = loc
 	var/definite_boss = pickweight(megafauna_spawn_list)
 	var/shouldspawnboss = TRUE
-	for(var/mob/living/megafauna/M in GLOB.mob_living_list)
+	for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
 		if(definite_boss == M.type)
 			shouldspawnboss = FALSE
 	if(shouldspawnboss && A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -9,3 +9,43 @@
 		/mob/living/simple_animal/hostile/asteroid/imp = 20, /obj/structure/spawner/lavaland/imp = 1, \
 		SPAWN_MEGAFAUNA = 6, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10)
 //imps are rare because boy they annoying
+
+/turf/open/floor/plating/asteroid/airless/cave/proc/SpawnMonster(turf/T)
+	if(!isarea(loc))
+		return
+	var/area/A = loc
+	var/definite_boss = pickweight(megafauna_spawn_list)
+	var/shouldspawnboss = TRUE
+	for(var/mob/living/megafauna/M in GLOB.mob_living_list)
+		if(definite_boss == M.type)
+			shouldspawnboss = FALSE
+	if(shouldspawnboss && A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len)
+		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents mob clumps
+			if(ismegafauna(H) && get_dist(src, H) <= 7)
+				return
+		new definite_boss(src)
+		return TRUE
+	if(prob(30))
+		if(!A.mob_spawn_allowed)
+			return
+		var/randumb = pickweight(mob_spawn_list)
+		if(!randumb)
+			return
+		while(randumb == SPAWN_MEGAFAUNA)
+			if(A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len) //this is danger. it's boss time.
+				var/maybe_boss = pickweight(megafauna_spawn_list)
+				if(megafauna_spawn_list[maybe_boss])
+					randumb = maybe_boss
+			else //this is not danger, don't spawn a boss, spawn something else
+				randumb = pickweight(mob_spawn_list)
+
+		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents mob clumps
+			if((ispath(randumb, /mob/living/simple_animal/hostile/megafauna) || ismegafauna(H)) && get_dist(src, H) <= 7)
+				return //if there's a megafauna within standard view don't spawn anything at all
+			if(ispath(randumb, /mob/living/simple_animal/hostile/asteroid) || istype(H, /mob/living/simple_animal/hostile/asteroid))
+				return //if the random is a standard mob, avoid spawning if there's another one within 12 tiles
+			if((ispath(randumb, /obj/structure/spawner/lavaland) || istype(H, /obj/structure/spawner/lavaland)) && get_dist(src, H) <= 2)
+				return //prevents tendrils spawning in each other's collapse range
+
+		new randumb(T)
+	return TRUE

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -26,11 +26,11 @@
 		new definite_boss(src)
 		return TRUE
 	var/shouldspawnlegiontendril = TRUE
-	for(var/structure/spawner/lavaland/legion in GLOB.tendrils)
+	for(var/obj/structure/spawner/lavaland/legion/L in GLOB.tendrils)
 		shouldspawnlegiontendril = FALSE
 	if(shouldspawnlegiontendril)
-		for(var/structure/spawner/lavaland/L in urange(12,T))
-			if(istype(L, /obj/structure/spawner/lavaland) && get_dist(src, L) <= 3)
+		for(var/obj/structure/spawner/lavaland/L in urange(12,T))
+			if(istype(L, /obj/structure/spawner/lavaland) && (get_dist(src, L) <= 3))
 				return //prevents tendrils spawning in each other's collapse range
 		new /obj/structure/spawner/lavaland/legion(src)
 		return TRUE
@@ -54,8 +54,7 @@
 			if(ispath(randumb, /mob/living/simple_animal/hostile/asteroid) || istype(H, /mob/living/simple_animal/hostile/asteroid))
 				return //if the random is a standard mob, avoid spawning if there's another one within 12 tiles
 		if(ispath(randumb, /obj/structure/spawner/lavaland))
-			for(var/structure/spawner/lavaland/L in urange(12,T))
-				istype(L, /obj/structure/spawner/lavaland)) && get_dist(src, L) <= 3
+			for(var/obj/structure/spawner/lavaland/L in urange(12,T))
 				return //prevents tendrils spawning in each other's collapse range
 
 		new randumb(T)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -20,7 +20,7 @@
 		if(definite_boss == M.type)
 			shouldspawnboss = FALSE
 	if(shouldspawnboss && A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len)
-		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents mob clumps
+		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents megafauan from spawning too near to each other.
 			if(ismegafauna(H) && get_dist(src, H) <= 7)
 				return
 		new definite_boss(src)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -19,15 +19,16 @@
 	var/area/A = loc
 	var/definite_boss = pick_n_take(remainingmegas)
 	var/shouldspawnboss = TRUE
-	for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
-		if(definite_boss == M.type)
-			shouldspawnboss = FALSE
-	if(shouldspawnboss && A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len)
-		for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents megafauan from spawning too near to each other.
-			if(ismegafauna(H) && get_dist(src, H) <= 7)
-				return
-		new definite_boss(src)
-		return TRUE
+	if(definite_boss)
+		for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
+			if(definite_boss == M.type)
+				shouldspawnboss = FALSE
+		if(shouldspawnboss && A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len)
+			for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents megafauan from spawning too near to each other.
+				if(ismegafauna(H) && get_dist(src, H) <= 7)
+					return
+			new definite_boss(src)
+			return TRUE
 	var/shouldspawnlegiontendril = TRUE
 	for(var/obj/structure/spawner/lavaland/legion/L in GLOB.tendrils)
 		shouldspawnlegiontendril = FALSE


### PR DESCRIPTION
## About The Pull Request

Title. Also makes sure that lavaland always has at least one legion tendril.
Basically, you always get at least one of each megafauna spawned and one legion tendril spawned - the rest are purely chance, like it was before.

Also changes it so lavaland can have more than one bubblegum. Because it's the only megafauna with this stupid restriction.

## Why It's Good For The Game

Being cockblocked by bad RNG is yucky.

## Changelog
:cl:
balance: Lavaland now always has at least one legion tendril and at least one of each megafauna.
balance: More than one bubblegum can now exist at the same time.
/:cl:
