### PR TITLE
Shambling miner kinetic crusher drop fix

### DIFF
--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/shamblingminer.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/shamblingminer.dm
@@ -28,9 +28,8 @@
 	move_force = MOVE_FORCE_VERY_STRONG
 	move_resist = MOVE_FORCE_VERY_STRONG
 	pull_force = MOVE_FORCE_VERY_STRONG
-	loot = list(/obj/item/twohanded/kinetic_crusher)
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/mask
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human = 2, /obj/item/stack/sheet/animalhide/human = 1, /obj/item/stack/sheet/bone = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human = 2, /obj/item/stack/sheet/animalhide/human = 1, /obj/item/stack/sheet/bone = 1, /obj/item/twohanded/kinetic_crusher = 1)
 	robust_searching = FALSE
 	do_footstep = TRUE
 	minimum_distance = 1


### PR DESCRIPTION
The shambling miner was reported to have not been able to drop the Kinetic crusher anymore this fixes that by making it a butcherable item.