### PR TITLE
Comments out atrocious chatspam and wire pulse/cut delays

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -134,6 +134,7 @@
 		on_cut(wire, mend = FALSE)
 
 /datum/wires/proc/cut_color(color, mob/living/user)
+	/*Skyrat change - removes delay AND CHAT SPAM on cutting/pulsing wires
 	LAZYINITLIST(current_users)
 	if(current_users[user])
 		return FALSE
@@ -147,6 +148,7 @@
 				return FALSE
 			LAZYREMOVE(current_users, user)
 	to_chat(user, "<span class='notice'>You cut [holder]'s [color] wire.</span>")
+	*/
 	cut(get_wire(color))
 	return TRUE
 
@@ -163,6 +165,7 @@
 	on_pulse(wire, user)
 
 /datum/wires/proc/pulse_color(color, mob/living/user)
+	/*Skyrat change - removes delay AND CHAT SPAM on cutting/pulsing wires
 	LAZYINITLIST(current_users)
 	if(current_users[user])
 		return FALSE
@@ -176,6 +179,7 @@
 				return FALSE
 			LAZYREMOVE(current_users, user)
 	to_chat(user, "<span class='notice'>You pulse [holder]'s [color] wire.</span>")
+	*/
 	pulse(get_wire(color), user)
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, it sucks. It isn't intuitive to have to wait a moment after you navigate through a big UI of lights and cables, leads to a lot of confusion and annoyance, on top of chat spam. I could also probably talk about how is it bad on a psychological level, cause people's brains may have issues associating what wires did what, cause of delay + information overflow.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I talked about it above

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the delay on cutting or pulsing wires
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
