### PR TITLE
Added in small nitrogen tanks to the Vox survival box

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isstartjelly(A) (is_species(A, /datum/species/jelly/roundstartslime))
 
 // Skyrat specific species
-#define isvox(A) (is_species(A, /datum/species/vox))
+#define isvox(A) (is_species(A, /datum/species/vox))	//Defines Vox for an !istype verb. Skyrat change.
 
 //more carbon mobs
 #define ismonkey(A) (istype(A, /mob/living/carbon/monkey))

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -83,6 +83,9 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isxenoperson(A) (is_species(A, /datum/species/xeno))
 #define isstartjelly(A) (is_species(A, /datum/species/jelly/roundstartslime))
 
+// Skyrat specific species
+#define isvox(A) (is_species(A, /datum/species/vox))
+
 //more carbon mobs
 #define ismonkey(A) (istype(A, /mob/living/carbon/monkey))
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -110,7 +110,7 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
-	if(!isvox(loc))
+	if(!isvox(loc))													//Makes a check if the player is a Vox and spawns a Nitrogen tank instead of an oxygen one. Skyrat change.
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/nitrogen/belt(src)
@@ -128,7 +128,7 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
-	if(!isvox(loc))
+	if(!isvox(loc))													//Makes a check if the player is a Vox and spawns a Nitrogen tank instead of an oxygen one. Skyrat change.
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/nitrogen/belt(src)
@@ -142,7 +142,7 @@
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
-	if(!isvox(loc))
+	if(!isvox(loc))													//Makes a check if the player is a Vox and spawns a Nitrogen tank instead of an oxygen one. Skyrat change.
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/nitrogen/belt(src)
@@ -159,7 +159,7 @@
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
-	if(!isvox(loc))
+	if(!isvox(loc))													//Makes a check if the player is a Vox and spawns a Nitrogen tank instead of an oxygen one. Skyrat change.
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/nitrogen/belt(src)
@@ -173,7 +173,7 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
-	if(!isvox(loc))
+	if(!isvox(loc))													//Makes a check if the player is a Vox and spawns a Nitrogen tank instead of an oxygen one. Skyrat change.
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/nitrogen/belt(src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -110,6 +110,10 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
+	if(!isvox(loc))
+		new /obj/item/tank/internals/emergency_oxygen(src)
+	else
+		new /obj/item/tank/internals/nitrogen/belt(src)
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.
@@ -124,6 +128,10 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
+	if(!isvox(loc))
+		new /obj/item/tank/internals/emergency_oxygen(src)
+	else
+		new /obj/item/tank/internals/nitrogen/belt(src)
 
 // Engineer survival box
 /obj/item/storage/box/engineer/PopulateContents()
@@ -134,6 +142,10 @@
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
+	if(!isvox(loc))
+		new /obj/item/tank/internals/emergency_oxygen(src)
+	else
+		new /obj/item/tank/internals/nitrogen/belt(src)
 
 /obj/item/storage/box/engineer/radio/PopulateContents()
 	..() // we want the regular items too.
@@ -147,6 +159,10 @@
 		new /obj/item/tank/internals/emergency_oxygen/engi(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
+	if(!isvox(loc))
+		new /obj/item/tank/internals/emergency_oxygen(src)
+	else
+		new /obj/item/tank/internals/nitrogen/belt(src)
 
 // Security survival box
 /obj/item/storage/box/security/PopulateContents()
@@ -157,6 +173,10 @@
 		new /obj/item/tank/internals/emergency_oxygen(src)
 	else
 		new /obj/item/tank/internals/plasmaman/belt(src)
+	if(!isvox(loc))
+		new /obj/item/tank/internals/emergency_oxygen(src)
+	else
+		new /obj/item/tank/internals/nitrogen/belt(src)
 
 /obj/item/storage/box/security/radio/PopulateContents()
 	..() // we want the regular stuff too


### PR DESCRIPTION
Adds in an extra small Nitrogen tank inside of the Vox emergency survival box for all job lists this was from a suggestion.