### PR TITLE
Adds Caps to Dynamic Events

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -3,6 +3,8 @@
 	var/typepath // typepath of the event
 	var/triggering
 	var/earliest_start = 20 MINUTES
+	var/occurances_current = 0 //Don't touch this. Skyrat Change.
+	var/occurances_max = 0 //Maximum occurances for this event. Set to 0 to allow an infinite amount of this event. Skyrat change.
 
 /datum/dynamic_ruleset/event/get_blackbox_info()
 	var/list/ruleset_data = list()
@@ -30,6 +32,10 @@
 	if (!forced)
 		if(earliest_start >= world.time-SSticker.round_start_time)
 			return FALSE
+		//Start of Skyrat Change
+		if(occurances_max && occurances_current < occurances_max)
+			return FALSE
+		//End of Skyrat Change
 		var/job_check = 0
 		if (enemy_roles.len > 0)
 			for (var/mob/M in mode.current_players[CURRENT_LIVING_PLAYERS])
@@ -64,6 +70,7 @@
 	requirements = list(70,60,50,50,40,40,40,30,20,15)
 	property_weights = list("story_potential" = 1, "trust" = 1, "chaos" = 1)
 	high_population_requirement = 15
+	occurances_max = 1 //Skyrat change.
 
 /datum/dynamic_ruleset/event/pirates/ready(forced = FALSE)
 	if (!SSmapping.empty_space)
@@ -87,6 +94,8 @@
 	requirements = list(70,60,50,50,40,40,40,30,20,15)
 	high_population_requirement = 15
 	property_weights = list("chaos" = 1, "valid" = 1)
+	earliest_start = 30 MINUTES //Skyrat change.
+	occurances_max = 2 //Skyrat change.
 
 //////////////////////////////////////////////
 //                                          //
@@ -107,6 +116,7 @@
 	high_population_requirement = 5
 	repeatable = TRUE
 	property_weights = list("chaos" = 1, "extended" = 2)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/ventclog/ready()
 	if(mode.threat_level > 30 && mode.threat >= 5 && prob(20))
@@ -146,6 +156,7 @@
 	repeatable = TRUE
 	property_weights = list("story_potential" = 1, "extended" = 1)
 	always_max_weight = TRUE
+	occurances_max = 3 //Skyrat change.
 
 //////////////////////////////////////////////
 //                                          //
@@ -166,6 +177,7 @@
 	requirements = list(60,50,40,30,30,30,30,30,30,30)
 	high_population_requirement = 30
 	property_weights = list("extended" = -2)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/meteor_wave/ready()
 	if(world.time-SSticker.round_start_time > 35 MINUTES && mode.threat_level > 40 && mode.threat >= 25 && prob(30))
@@ -201,6 +213,7 @@
 	high_population_requirement = 5
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 3 //Skyrat change.
 
 /datum/dynamic_ruleset/event/anomaly_flux
 	name = "Anomaly: Hyper-Energetic Flux"
@@ -215,6 +228,7 @@
 	high_population_requirement = 10
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/anomaly_gravitational
 	name = "Anomaly: Gravitational"
@@ -227,6 +241,7 @@
 	high_population_requirement = 5
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 3 //Skyrat change.
 
 /datum/dynamic_ruleset/event/anomaly_pyroclastic
 	name = "Anomaly: Pyroclastic"
@@ -241,6 +256,7 @@
 	high_population_requirement = 10
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/anomaly_vortex
 	name = "Anomaly: Vortex"
@@ -255,6 +271,7 @@
 	high_population_requirement = 10
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 2 //Skyrat change.
 
 //////////////////////////////////////////////
 //                                          //
@@ -275,6 +292,7 @@
 	high_population_requirement = 10
 	repeatable = TRUE
 	property_weights = list("extended" = -1, "chaos" = 1)
+	occurances_max = 1 //Skyrat change.
 
 /datum/dynamic_ruleset/event/carp_migration
 	name = "Carp Migration"
@@ -288,6 +306,7 @@
 	earliest_start = 10 MINUTES
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 3 //Skyrat change.
 
 /datum/dynamic_ruleset/event/communications_blackout
 	name = "Communications Blackout"
@@ -302,6 +321,7 @@
 	high_population_requirement = 5
 	repeatable = TRUE
 	property_weights = list("extended" = 1, "chaos" = 1)
+	occurances_max = 5 //Skyrat change.
 
 /datum/dynamic_ruleset/event/processor_overload
 	name = "Processor Overload"
@@ -317,6 +337,7 @@
 	repeatable = TRUE
 	property_weights = list("extended" = 1, "chaos" = 1)
 	always_max_weight = TRUE
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/space_dust
 	name = "Minor Space Dust"
@@ -333,6 +354,7 @@
 	earliest_start = 0 MINUTES
 	property_weights = list("extended" = 1)
 	always_max_weight = TRUE
+	occurances_max = 0 //Skyrat change.
 
 /datum/dynamic_ruleset/event/major_dust
 	name = "Major Space Dust"
@@ -347,6 +369,7 @@
 	high_population_requirement = 10
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 3 //Skyrat change.
 
 /datum/dynamic_ruleset/event/electrical_storm
 	name = "Electrical Storm"
@@ -361,6 +384,7 @@
 	high_population_requirement = 5
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/heart_attack
 	name = "Random Heart Attack"
@@ -376,6 +400,7 @@
 	repeatable = TRUE
 	property_weights = list("extended" = 1)
 	always_max_weight = TRUE
+	occurances_max = 4 //Skyrat change.
 
 /datum/dynamic_ruleset/event/radiation_storm
 	name = "Radiation Storm"
@@ -388,6 +413,7 @@
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	high_population_requirement = 5
 	property_weights = list("extended" = 1,"chaos" = 1)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/portal_storm_syndicate
 	name = "Portal Storm"
@@ -401,6 +427,7 @@
 	high_population_requirement =  30
 	earliest_start = 30 MINUTES
 	property_weights = list("teamwork" = 1,"chaos" = 1, "extended" = -1)
+	occurances_max = 1 //Skyrat change.
 
 /datum/dynamic_ruleset/event/wormholes
 	name = "Wormholes"
@@ -413,6 +440,7 @@
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	high_population_requirement =  5
 	property_weights = list("extended" = 1)
+	occurances_max = 2 //Skyrat change.
 
 /datum/dynamic_ruleset/event/swarmers
 	name = "Swarmers"
@@ -426,6 +454,7 @@
 	requirements = list(101,101,101,101,101,101,101,101,101,101)
 	high_population_requirement =  5
 	property_weights = list("extended" = -2)
+	occurances_max = 1 //Skyrat change.
 
 /datum/dynamic_ruleset/event/sentient_disease
 	name = "Sentient Disease"
@@ -439,6 +468,7 @@
 	requirements = list(30,30,20,20,15,10,10,10,10,5) // yes, it can even happen in "extended"!
 	property_weights = list("story_potential" = 1, "extended" = 1, "valid" = -2)
 	high_population_requirement = 5
+	occurances_max = 1 //Skyrat change.
 
 /datum/dynamic_ruleset/event/revenant
 	name = "Revenant"
@@ -452,3 +482,4 @@
 	requirements = list(30,30,30,30,20,15,15,15,15,15)
 	high_population_requirement = 15
 	property_weights = list("story_potential" = -2, "extended" = -1)
+	occurances_max = 1 //Skyrat change.


### PR DESCRIPTION

## About The Pull Request

Hardcaps the amount of events of a certain type can spawn in a round. See the code for the specific values, please.

## Why It's Good For The Game

Dynamic can sometimes spawn 3 meteors storms in a single round. Sometimes 4 wormholes. Sometimes 3 blobs. This PR fixes that by limiting events to increase viarety and decrease annoyance. More antags have a chance to be spawned because of this, which is good because more antags means more roleplay (sometimes).

## Changelog
:cl: BurgerBB
balance: Limits the amount of events of a single type can spawn in a round.
/:cl: