### PR TITLE
[Map Edits] Roundstart OreSilo Removed

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -14857,7 +14857,6 @@
 /area/ai_monitored/nuke_storage)
 "aGb" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -125171,20 +125171,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fFK" = (
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
 "fGq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -175763,7 +175749,7 @@ bvT
 bvP
 byz
 bvP
-fFK
+bvP
 but
 aad
 bHq

--- a/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
@@ -7966,7 +7966,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqX" = (
-/obj/machinery/ore_silo,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},

--- a/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
@@ -14393,7 +14393,6 @@
 "aCd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -7144,7 +7144,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -22,5 +22,5 @@
 	new /obj/item/door_remote/quartermaster(src)
 	new /obj/item/circuitboard/machine/techfab/department/cargo(src)
 	new /obj/item/storage/photo_album/QM(src)
-	new /obj/item/circuitboard/machine/ore_silo(src)
+	//new /obj/item/circuitboard/machine/ore_silo(src) SKYRAT EDIT: Remove roundstart ore silos.
 	new /obj/item/clothing/suit/hooded/wintercoat/qm(src)


### PR DESCRIPTION

## About The Pull Request

Removes roundstart ore silos from all maps.

## Why It's Good For The Game

Makes QM and Cargo Technicians more useful, by making them deliver materials.
You can of course set up a Silo, but that requires science to research it, the QM to set it up, etc.

## Changelog
:cl:
del: Removed roundstart ore silos.
/:cl:

