### PR TITLE
Surgery robo fixses

### DIFF
--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -11,7 +11,6 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
-	requires_bodypart_type = 0
 /datum/surgery_step/fix_brain
 	name = "fix brain"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -10,6 +10,7 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 	requires_bodypart_type = 0
 /datum/surgery_step/fix_brain
 	name = "fix brain"

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -3,6 +3,7 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/saw, /datum/surgery_step/clamp_bleeders,
 				 /datum/surgery_step/incise_heart, /datum/surgery_step/coronary_bypass, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 
 /datum/surgery/coronary_bypass/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/heart/H = target.getorganslot(ORGAN_SLOT_HEART)

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -2,6 +2,7 @@
 	name = "dental implant"
 	steps = list(/datum/surgery_step/drill, /datum/surgery_step/insert_pill)
 	possible_locs = list(BODY_ZONE_PRECISE_MOUTH)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 
 /datum/surgery_step/insert_pill
 	name = "insert pill"

--- a/code/modules/surgery/embalming.dm
+++ b/code/modules/surgery/embalming.dm
@@ -7,7 +7,14 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-	requires_bodypart_type = 0
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
+
+//skyrat change start
+/datum/surgery/embalming/can_start(mob/user, mob/living/target, obj/item/tool)
+  . = ..()
+  if(target.stat != DEAD)
+    return FALSE
+//skyrat change stop
 
 /datum/surgery_step/embalming
 	name = "embalming body"

--- a/code/modules/surgery/emergency_cardioversion_recovery.dm
+++ b/code/modules/surgery/emergency_cardioversion_recovery.dm
@@ -3,6 +3,7 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/saw, /datum/surgery_step/clamp_bleeders,
 				 /datum/surgery_step/incise_heart, /datum/surgery_step/ventricular_electrotherapy, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 
 /datum/surgery_step/ventricular_electrotherapy
 	name = "ventricular electrotherapy"

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -3,6 +3,7 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/fix_eyes, /datum/surgery_step/close)
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_PRECISE_EYES)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 	requires_bodypart_type = 0
 //fix eyes
 /datum/surgery_step/fix_eyes

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -4,7 +4,6 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_PRECISE_EYES)
 	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
-	requires_bodypart_type = 0
 //fix eyes
 /datum/surgery_step/fix_eyes
 	name = "fix eyes"

--- a/code/modules/surgery/graft_synthtissue.dm
+++ b/code/modules/surgery/graft_synthtissue.dm
@@ -6,6 +6,7 @@
 	name = "Graft synthtissue"
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_PRECISE_EYES)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 	steps = list(
 	/datum/surgery_step/incise,
 	/datum/surgery_step/retract_skin,

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -8,7 +8,7 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-	requires_bodypart_type = FALSE
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 	replaced_by = /datum/surgery
 	ignore_clothes = TRUE
 	var/healing_step_type

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -2,6 +2,7 @@
 	name = "Lipoplasty"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/cut_fat, /datum/surgery_step/remove_fat, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 /datum/surgery/lipoplasty/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(HAS_TRAIT(target, TRAIT_FAT))
 		return 1

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -3,6 +3,7 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/saw, /datum/surgery_step/clamp_bleeders,
 				 /datum/surgery_step/lobectomy, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 
 /datum/surgery/lobectomy/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/lungs/L = target.getorganslot(ORGAN_SLOT_LUNGS)

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -2,6 +2,7 @@
 	name = "organ manipulation"
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 	requires_real_bodypart = 1
 	steps = list(
 		/datum/surgery_step/incise,

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -2,6 +2,7 @@
 	name = "Plastic surgery"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/reshape_face, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_HEAD)
+	requires_bodypart_type = BODYPART_ORGANIC //Skyrat change
 //reshape_face
 /datum/surgery_step/reshape_face
 	name = "reshape face"

--- a/modular_skyrat/code/modules/surgery/robot_healing.dm
+++ b/modular_skyrat/code/modules/surgery/robot_healing.dm
@@ -8,6 +8,7 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
+	replaced_by = /datum/surgery
 	requires_bodypart_type = BODYPART_ROBOTIC
 	ignore_clothes = TRUE
 	var/healing_step_type
@@ -117,6 +118,7 @@
 	name = "Repair robotic limbs (basic)"
 	healing_step_type = /datum/surgery_step/robot_heal/basic
 	desc = "A surgical procedure that provides repairs and maintenance to robotic limbs. Is slightly more efficient when the patient is severely damaged."
+	replaced_by = null
 
 /***************************STEPS***************************/
 

--- a/modular_skyrat/code/modules/surgery/robot_restore_looks.dm
+++ b/modular_skyrat/code/modules/surgery/robot_restore_looks.dm
@@ -1,5 +1,5 @@
 /datum/surgery/robot_restore_looks
-	name = "restore chassis looks"
+	name = "Restore chassis looks"
 	steps = list(
 	/datum/surgery_step/weld_plating,
 	/datum/surgery_step/restore_paintjob)


### PR DESCRIPTION
## About The Pull Request

Makes it so organic surgeries can't be done on robits. Also remove embalming from living people.

## Why It's Good For The Game

Realism

## Changelog
:cl: Afya
fix: Organic surgeries don't work on robo stuffs. 
tweak: Removed ability to embalm living people.
/:cl: