### PR TITLE
Material Cost Scaling for those of OCD

### DIFF
--- a/code/__DEFINES/materials.dm
+++ b/code/__DEFINES/materials.dm
@@ -9,3 +9,5 @@
 #define MATERIAL_ADD_PREFIX (1<<1)
 #define MATERIAL_EFFECTS (1<<2)
 #define MATERIAL_AFFECT_STATISTICS (1<<3)
+
+#define MAT_COST_WITH_COEFF(cost,coeff) (CEILING(cost*coeff,CEILING(50*coeff,5))) //Skyrat Change. Materials OCD update.

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -82,7 +82,7 @@
 	. = ..()
 	var/datum/component/remote_materials/materials = GetComponent(/datum/component/remote_materials)
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Storing up to <b>[materials.local_size]</b> material units locally.<br>Material usage cost at <b>[print_cost_coeff*100]%</b>.</span>"
+		. += "<span class='notice'>The status display reads: Storing up to <b>[materials.local_size]</b> material units locally.<br>Material usage cost at <b>[CEILING(print_cost_coeff*100,5)]%</b>.</span>" //Skyrat Change. Materials OCD update.
 
 //we eject the materials upon deconstruction.
 /obj/machinery/rnd/production/on_deconstruction()
@@ -113,7 +113,7 @@
 	// these types don't have their .materials set in do_print, so don't allow
 	// them to be constructed efficiently
 	var/ef = efficient_with(being_built.build_path) ? print_cost_coeff : 1
-	return round(A / max(1, all_materials[mat] * ef))
+	return round(A / max(1, MAT_COST_WITH_COEFF(all_materials[mat],ef))) //Skyrat Change. Materials OCD update.
 
 /obj/machinery/rnd/production/proc/efficient_with(path)
 	return !ispath(path, /obj/item/stack/sheet) && !ispath(path, /obj/item/stack/ore/bluespace_crystal)
@@ -155,18 +155,18 @@
 	var/coeff = efficient_with(D.build_path) ? print_cost_coeff : 1
 	var/list/efficient_mats = list()
 	for(var/MAT in D.materials)
-		efficient_mats[MAT] = D.materials[MAT] * coeff
+		efficient_mats[MAT] = MAT_COST_WITH_COEFF(D.materials[MAT],coeff) //Skyrat Change. Materials OCD update.
 	if(!materials.mat_container.has_materials(efficient_mats, amount))
 		say("Not enough materials to complete prototype[amount > 1? "s" : ""].")
 		return FALSE
 	for(var/R in D.reagents_list)
-		if(!reagents.has_reagent(R, D.reagents_list[R] * amount * coeff))
+		if(!reagents.has_reagent(R, MAT_COST_WITH_COEFF(D.reagents_list[R],coeff) * amount)) //Skyrat Change. Materials OCD update.
 			say("Not enough reagents to complete prototype[amount > 1? "s" : ""].")
 			return FALSE
 	materials.mat_container.use_materials(efficient_mats, amount)
 	materials.silo_log(src, "built", -amount, "[D.name]", efficient_mats)
 	for(var/R in D.reagents_list)
-		reagents.remove_reagent(R, D.reagents_list[R] * amount * coeff)
+		reagents.remove_reagent(R, MAT_COST_WITH_COEFF(D.reagents_list[R],coeff) * amount) //Skyrat Change. Materials OCD update.
 	busy = TRUE
 	if(production_animation)
 		flick(production_animation, src)
@@ -276,9 +276,9 @@
 		t = check_mat(D, M)
 		temp_material += " | "
 		if (t < 1)
-			temp_material += "<span class='bad'>[all_materials[M] * coeff] [CallMaterialName(M)]</span>"
+			temp_material += "<span class='bad'>[MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]</span>" //Skyrat Change. Materials OCD update.
 		else
-			temp_material += " [all_materials[M] * coeff] [CallMaterialName(M)]"
+			temp_material += " [MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]" //Skyrat Change. Materials OCD update.
 		c = min(c,t)
 
 	var/clearance = !(obj_flags & EMAGGED) && (offstation_security_levels || is_station_level(z))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -299,9 +299,9 @@ Nothing else in the console has ID requirements.
 			var/t = linked_lathe.check_mat(D, M)
 			temp_material += " | "
 			if (t < 1)
-				temp_material += "<span class='bad'>[all_materials[M] * coeff] [CallMaterialName(M)]</span>"
+				temp_material += "<span class='bad'>[MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]</span>" //Skyrat Change. Materials OCD update.
 			else
-				temp_material += " [all_materials[M] * coeff] [CallMaterialName(M)]"
+				temp_material += " [MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]" //Skyrat Change. Materials OCD update.
 			c = min(c,t)
 
 		var/clearance = !(linked_lathe.obj_flags & EMAGGED) && (linked_lathe.offstation_security_levels || is_station_level(linked_lathe.z))
@@ -363,9 +363,9 @@ Nothing else in the console has ID requirements.
 			var/t = linked_lathe.check_mat(D, M)
 			temp_material += " | "
 			if (t < 1)
-				temp_material += "<span class='bad'>[all_materials[M] * coeff] [CallMaterialName(M)]</span>"
+				temp_material += "<span class='bad'>[MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]</span>" //Skyrat Change. Materials OCD update.
 			else
-				temp_material += " [all_materials[M] * coeff] [CallMaterialName(M)]"
+				temp_material += " [MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]" //Skyrat Change. Materials OCD update.
 			c = min(c,t)
 
 		if (c >= 1)
@@ -465,9 +465,9 @@ Nothing else in the console has ID requirements.
 			temp_materials += " | "
 			if (!linked_imprinter.check_mat(D, M))
 				check_materials = FALSE
-				temp_materials += " <span class='bad'>[all_materials[M] * coeff] [CallMaterialName(M)]</span>"
+				temp_materials += " <span class='bad'>[MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]</span>" //Skyrat Change. Materials OCD update.
 			else
-				temp_materials += " [all_materials[M] * coeff] [CallMaterialName(M)]"
+				temp_materials += " [MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]" //Skyrat Change. Materials OCD update.
 		if (check_materials)
 			l += "<A href='?src=[REF(src)];imprint=[D.id]'>[D.name]</A>[temp_materials]"
 		else
@@ -495,9 +495,9 @@ Nothing else in the console has ID requirements.
 			temp_materials += " | "
 			if (!linked_imprinter.check_mat(D, M))
 				check_materials = FALSE
-				temp_materials += " <span class='bad'>[all_materials[M] * coeff] [CallMaterialName(M)]</span>"
+				temp_materials += " <span class='bad'>[MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]</span>" //Skyrat Change. Materials OCD update.
 			else
-				temp_materials += " [all_materials[M] * coeff] [CallMaterialName(M)]"
+				temp_materials += " [MAT_COST_WITH_COEFF(all_materials[M],coeff)] [CallMaterialName(M)]" //Skyrat Change. Materials OCD update.
 		if (check_materials)
 			l += "<A href='?src=[REF(src)];imprint=[D.id]'>[D.name]</A>[temp_materials]"
 		else


### PR DESCRIPTION
## About The Pull Request

Material cost scaling is now even slightly more complex with all material costs rounding upwards based on manipulator upgrades, with currently 45 at T1 and 25 at T4. This means that If an object costs 10 units of iron to make, it will need 25 iron actually.

## Why It's Good For The Game

In reality, small designs can sometimes cost the same amount of materials as larger designs due to the precision of the printer. This is also a nice balance change for an upcoming PR that adds T5 and T6 parts that I am currently making.

## Changelog
:cl: BurgerBB
balance: Balanced material part scaling.
/:cl: