### PR TITLE
Fully custom job titles

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -509,3 +509,6 @@
 
 //Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 /datum/config_entry/flag/allow_custom_skintones
+
+//Allows admins to bypass the custom job title whitelist
+/datum/config_entry/flag/nepotism

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1213,7 +1213,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/rank_title_line = "[displayed_rank]"
 			if((rank in GLOB.command_positions) || (rank == "AI"))//Bold head jobs
 				rank_title_line = "<b>[rank_title_line]</b>"
-			if(job.alt_titles.len || (user.client.ckey in GLOB.titlewhitelist) || (CONFIG_GET(flag/nepotism) && check_rights_for(user.client, R_ADMIN)))
+			if(job.alt_titles.len || (user.client.ckey in GLOB.titlewhitelist) && job.customtitles || (CONFIG_GET(flag/nepotism) && check_rights_for(user.client, R_ADMIN) && job.customtitles))
 				rank_title_line = "<a href='?_src_=prefs;preference=job;task=alt_title;job_title=[job.title]'>[rank_title_line]</a>"
 			else
 				rank_title_line = "<span class='dark'>[rank_title_line]</span>" //Make it dark if we're not adding a button for alt titles

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1213,7 +1213,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/rank_title_line = "[displayed_rank]"
 			if((rank in GLOB.command_positions) || (rank == "AI"))//Bold head jobs
 				rank_title_line = "<b>[rank_title_line]</b>"
-			if(job.alt_titles.len || (user.client.ckey in GLOB.titlewhitelist) && job.customtitles || (CONFIG_GET(flag/nepotism) && check_rights_for(user.client, R_ADMIN) && job.customtitles))
+			if((user.client.ckey in GLOB.titlewhitelist) && job.customtitles || (CONFIG_GET(flag/nepotism) && check_rights_for(user.client, R_ADMIN) && job.customtitles))
+				rank_title_line = "<a style='background-color: #FFDF00;color:#000000' href='?_src_=prefs;preference=job;task=alt_title;job_title=[job.title]'>[rank_title_line]</a>"
+			else if(job.alt_titles.len)
 				rank_title_line = "<a href='?_src_=prefs;preference=job;task=alt_title;job_title=[job.title]'>[rank_title_line]</a>"
 			else
 				rank_title_line = "<span class='dark'>[rank_title_line]</span>" //Make it dark if we're not adding a button for alt titles
@@ -1333,6 +1335,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /datum/preferences/proc/ResetJobs()
 	job_preferences = list()
+	//SKYRAT EDIT - alternate job titles
+	alt_titles_preferences = list()
+	//
 
 /datum/preferences/proc/SetQuirks(mob/user)
 	if(!SSquirks)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -407,6 +407,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			to_chat(parent, "<span class='warning'>You're attempting to load your character a little too fast. Wait half a second, then try again.</span>")
 		return "SLOW THE FUCK DOWN" //the reason this isn't null is to make sure that people don't have their character slots overridden by random chars if they accidentally double-click a slot
 	loadcharcooldown = world.time + PREF_SAVELOAD_COOLDOWN
+	//Skyrat edit - full custom job titles
+	var/client/jobbed
+	if(istype(parent))
+		jobbed = parent
+	//
 	if(!fexists(path))
 		return 0
 	var/savefile/S = new /savefile(path)
@@ -675,8 +680,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	vore_flags						= sanitize_integer(vore_flags, 0, MAX_VORE_FLAG, 0)
 	vore_taste						= copytext(vore_taste, 1, MAX_TASTE_LEN)
 	belly_prefs 					= SANITIZE_LIST(belly_prefs)
-
-	cit_character_pref_load(S)
+	//SKYRAT EDIT - full custom job titles
+	if(jobbed)
+		cit_character_pref_load(S, jobbed)
+	else
+		cit_character_pref_load(S)
+	//
 
 	return 1
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -68,6 +68,8 @@
 
 	/// Starting skill modifiers.
 	var/list/starting_modifiers
+	//SKYRAT CHANGE - custom job title
+	var/customtitles = FALSE //Boolean. Can this job use custom job titles at all?
 
 //Only override this proc
 //H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -17,6 +17,8 @@ Assistant
 	display_order = JOB_DISPLAY_ORDER_ASSISTANT
 	dresscodecompliant = FALSE
 	threat = 0.2
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 /datum/job/assistant/get_access()
 	if(CONFIG_GET(flag/assistants_have_maint_access) || !CONFIG_GET(flag/jobs_have_minimal_access)) //Config has assistant maint access set

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -16,6 +16,8 @@
 	minimal_access = list(ACCESS_BAR, ACCESS_MINERAL_STOREROOM)
 	display_order = JOB_DISPLAY_ORDER_BARTENDER
 	threat = 0.5
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 /datum/outfit/job/bartender
 	name = "Bartender"

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -16,6 +16,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_CHAPLAIN
 	threat = 0.5
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 
 /datum/job/chaplain/after_spawn(mob/living/H, mob/M)

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -22,6 +22,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_CLOWN
 	threat = 0 // honk
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 /datum/outfit/job/clown
 	name = "Clown"

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -16,6 +16,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_CURATOR
 	threat = 0.3
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 /datum/outfit/job/curator
 	name = "Curator"

--- a/code/modules/jobs/job_types/lawyer.dm
+++ b/code/modules/jobs/job_types/lawyer.dm
@@ -19,6 +19,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_LAWYER
 	threat = 0.3
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 /datum/outfit/job/lawyer
 	name = "Lawyer"

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -21,6 +21,8 @@
 	display_order = JOB_DISPLAY_ORDER_MIME
 
 	threat = 0
+	//SKYRAT CHANGE - Custom job titles
+	customtitles = TRUE
 
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -666,5 +666,5 @@ BODY_SIZE_SLOWDOWN_MULTIPLIER 0.25
 ## Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 ALLOW_CUSTOM_SKINTONES
 
-## Admins are allowed to use custom job titles by default, to change this simply this out
+## Admins are allowed to use custom job titles by default, to change this simply comment this out
 NEPOTISM

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -665,3 +665,6 @@ BODY_SIZE_SLOWDOWN_MULTIPLIER 0.25
 
 ## Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 ALLOW_CUSTOM_SKINTONES
+
+## Admins are allowed to use custom job titles by default, to change this simply this out
+NEPOTISM

--- a/config/titlewhitelist.txt
+++ b/config/titlewhitelist.txt
@@ -1,0 +1,1 @@
+bobjoga

--- a/modular_citadel/code/modules/client/preferences_savefile.dm
+++ b/modular_citadel/code/modules/client/preferences_savefile.dm
@@ -1,4 +1,4 @@
-/datum/preferences/proc/cit_character_pref_load(savefile/S)
+/datum/preferences/proc/cit_character_pref_load(savefile/S, var/client/cli)
 	//ipcs
 	S["feature_ipc_screen"] >> features["ipc_screen"]
 	S["feature_ipc_antenna"] >> features["ipc_antenna"]
@@ -24,8 +24,13 @@
 	if(SSjob)
 		for(var/datum/job/job in sortList(SSjob.occupations, /proc/cmp_job_display_asc))
 			if(alt_titles_preferences[job.title])
-				if(!(alt_titles_preferences[job.title] in job.alt_titles))
-					alt_titles_preferences.Remove(job.title)
+				if(!(alt_titles_preferences[job.title] in job.alt_titles)) 
+					var/client/snowflake = cli
+					if(snowflake)
+						if(!(snowflake.ckey in GLOB.titlewhitelist) && !(CONFIG_GET(flag/nepotism) && check_rights_for(snowflake, R_ADMIN)))
+							alt_titles_preferences.Remove(job.title)
+					else 
+						alt_titles_preferences.Remove(job.title)
 
 	features["ipc_chassis"] 	= sanitize_inlist(features["ipc_chassis"], GLOB.ipc_chassis_list)
 	skyrat_ooc_notes = sanitize_text(S["skyrat_ooc_notes"])

--- a/modular_citadel/code/modules/client/preferences_savefile.dm
+++ b/modular_citadel/code/modules/client/preferences_savefile.dm
@@ -27,7 +27,10 @@
 				if(!(alt_titles_preferences[job.title] in job.alt_titles)) 
 					var/client/snowflake = cli
 					if(snowflake)
-						if(!(snowflake.ckey in GLOB.titlewhitelist) && !(CONFIG_GET(flag/nepotism) && check_rights_for(snowflake, R_ADMIN)))
+						if(job.customtitles)
+							if(!(snowflake.ckey in GLOB.titlewhitelist) && !(CONFIG_GET(flag/nepotism) && check_rights_for(snowflake, R_ADMIN)))
+								alt_titles_preferences.Remove(job.title)
+						else
 							alt_titles_preferences.Remove(job.title)
 					else 
 						alt_titles_preferences.Remove(job.title)

--- a/modular_skyrat/code/modules/jobs/customtitlewhitelist.dm
+++ b/modular_skyrat/code/modules/jobs/customtitlewhitelist.dm
@@ -1,0 +1,8 @@
+//Custom job titles
+//Loads the ckeys from the file below
+//I was too lazy to code in shit so i could do comments on the file itself lol
+#define TITLEWHITELIST "[global.config.directory]/titlewhitelist.txt"
+
+GLOBAL_LIST_INIT(titlewhitelist, world.file2list(TITLEWHITELIST))
+
+#undef TITLEWHITELIST

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3646,6 +3646,7 @@
 #include "modular_skyrat\code\modules\hydroponics\plant_genes.dm"
 #include "modular_skyrat\code\modules\hydroponics\seeds.dm"
 #include "modular_skyrat\code\modules\jobs\access.dm"
+#include "modular_skyrat\code\modules\jobs\customtitlewhitelist.dm"
 #include "modular_skyrat\code\modules\jobs\job_types\_job.dm"
 #include "modular_skyrat\code\modules\jobs\job_types\_job_alt_titles.dm"
 #include "modular_skyrat\code\modules\jobs\job_types\blueshield.dm"


### PR DESCRIPTION
## About The Pull Request

Adds fully custom job titles, for admins and the people whitelisted in the config.
It could be used for actually good and fun gimmicks (i trust it will since i put the above restrictions to prevent Penis Inspector mains)...

...or just straight up dumb shit like this (Please don't).
![perfectstation](https://user-images.githubusercontent.com/25989101/82008918-55399100-9644-11ea-9235-adb2e81979fe.png)

**UPDATE:** Only a few jobs (those marked in golden) are able to have custom titles now. This will limit the potential for confusion.
![gimmicks](https://user-images.githubusercontent.com/25989101/82078943-61f7cc80-96b8-11ea-8e20-19df69d0ff8d.png)

## Why It's Good For The Game

It allows for a select group of people to ~~be snowflakes~~ do fun gimmicks, and if they abuse this right, it can easily be taken away.
My intention is for this to be used as a donator reward ~~and reward for me for, doing the PR~~ and admin privilege.

## Changelog
:cl:
add: Fully custom job titles are now possible, for some jobs.
/:cl:
