### PR TITLE
Surrender Verb

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -8,6 +8,7 @@
 /mob/living/carbon/human/Initialize()
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
+	verbs += /mob/living/proc/surrender
 	verbs += /mob/living/carbon/human/proc/underwear_toggle //fwee
 
 	//initialize limbs first

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -469,6 +469,14 @@
 		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
 			SetSleeping(400) //Short nap
 
+//Skyrat change start
+/mob/living/proc/surrender()
+	set name = "Surrender"
+	set category = "IC"
+
+	emote("surrender")
+//Skyrat change stop
+
 /mob/proc/get_contents()
 
 /*CIT CHANGE - comments out lay_down proc to be modified in modular_citadel


### PR DESCRIPTION
## About The Pull Request

Adds a surrender verb.

## Why It's Good For The Game

Goes along well with #1971, adds a quick way to drop down and surrender mid-combat.

## Changelog
:cl: Afya
add: Added surrender verb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
