### PR TITLE
Better IC spawning loadout, and minor tweaks for spawning others

### DIFF
--- a/modular_citadel/code/modules/clothing/outfits/standard.dm
+++ b/modular_citadel/code/modules/clothing/outfits/standard.dm
@@ -29,15 +29,16 @@
 /obj/item/clothing/shoes/combat/debug
 	clothing_flags = NOSLIP
 
+/obj/item/storage/belt/utility/chief/full/debug
+	name = "\improper Bluespace Tech's belt"
+
 /datum/outfit/debug/bst //Debug objs
 	name = "Bluespace Tech"
 	uniform = /obj/item/clothing/under/syndicate/combat
 	suit = /obj/item/clothing/suit/armor/vest/darkcarapace/debug
-	glasses = /obj/item/clothing/glasses/debug
 	ears = /obj/item/radio/headset/headset_cent/commander/alt/generic
-	mask = /obj/item/clothing/mask/gas/welding/up
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
-	belt = /obj/item/storage/belt/utility/chief/full
+	belt = /obj/item/storage/belt/utility/chief/full/debug
 	shoes = /obj/item/clothing/shoes/combat/debug
 	id = /obj/item/card/id/debug/bst
 	back = /obj/item/storage/backpack/holding
@@ -47,7 +48,10 @@
 		/obj/item/melee/transforming/energy/axe=1,\
 		/obj/item/storage/part_replacer/bluespace/tier4=1,\
 		/obj/item/debug/human_spawner=1,\
-		/obj/item/gun/energy/taser/debug=1
+		/obj/item/gun/energy/taser/debug=1,\
+		/obj/item/clothing/glasses/debug,\
+		/obj/item/clothing/mask/gas/welding/up,\
+		/obj/item/tank/internals/oxygen,\
 		)
 
 /datum/outfit/debug/bsthardsuit //Debug objs plus hardsuit
@@ -58,7 +62,7 @@
 	ears = /obj/item/radio/headset/headset_cent/commander/alt/generic
 	mask = /obj/item/clothing/mask/gas/welding/up
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
-	belt = /obj/item/storage/belt/utility/chief/full
+	belt = /obj/item/storage/belt/utility/chief/full/debug
 	shoes = /obj/item/clothing/shoes/combat/debug
 	id = /obj/item/card/id/debug/bst
 	back = /obj/item/storage/backpack/holding

--- a/modular_skyrat/code/modules/mob/dead/observer/observer.dm
+++ b/modular_skyrat/code/modules/mob/dead/observer/observer.dm
@@ -30,6 +30,14 @@
 		else 
 			dresscode = outfits[initial_outfits] 
 
+		// We're spawning someone else
+		var/give_return
+		if (user != usr)
+			give_return = alert("Do you want to give them the power to return? Not recommended for non-admins.","Give power?","Yes","No", "Cancel")
+			if(give_return == "Cancel")
+				return
+
+
 		var/turf/current_turf = get_turf(src)
 		var/mob/living/carbon/human/spawned_player = new(src)
 
@@ -51,7 +59,8 @@
 		else
 			transfer_ckey(spawned_player)
 
-		spawned_player.mind.AddSpell(new /obj/effect/proc_holder/spell/self/return_back, FALSE)
+		if(give_return == "Yes")
+			spawned_player.mind.AddSpell(new /obj/effect/proc_holder/spell/self/return_back, FALSE)
 		
 		if(dresscode != "Naked")
 			spawned_player.equipOutfit(dresscode)

--- a/modular_skyrat/code/modules/mob/dead/observer/observer.dm
+++ b/modular_skyrat/code/modules/mob/dead/observer/observer.dm
@@ -20,13 +20,13 @@
 		if (character_option == "Cancel")
 			return
 		var/initial_outfits = input("Select outfit", "Quick Dress") as null|anything in outfits
+		if (!initial_outfits || initial_outfits == "" || initial_outfits == "Cancel")
+			return
 
 		if (initial_outfits == "Show All")
 			dresscode = client.robust_dress_shop()
 			if (!dresscode)
 				return
-		else if (initial_outfits == "")
-			return
 		else 
 			dresscode = outfits[initial_outfits] 
 

--- a/modular_skyrat/code/modules/mob/dead/observer/observer.dm
+++ b/modular_skyrat/code/modules/mob/dead/observer/observer.dm
@@ -59,7 +59,7 @@
 		else
 			transfer_ckey(spawned_player)
 
-		if(give_return == "Yes")
+		if(give_return != "No")
 			spawned_player.mind.AddSpell(new /obj/effect/proc_holder/spell/self/return_back, FALSE)
 		
 		if(dresscode != "Naked")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Giving the return power is optional when using it to spawn others (likely nonadmins) in. Also slight changes to the loadout so it's a bit cleaner.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Spawning people in via the IC spawner gave regular players the return power, and they usually didn't know what it was, so it deleted them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Tweaks to the IC spawner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
