### PR TITLE
Dynamic roundstart scaling rule config

### DIFF
--- a/code/controllers/configuration/entries/dynamic.dm
+++ b/code/controllers/configuration/entries/dynamic.dm
@@ -4,6 +4,18 @@
 /datum/config_entry/number/added_threat
 	config_entry_value = 5
 	min_val = 0
+
+/datum/config_entry/number/traitor_scale_cost
+	config_entry_value = 10
+	min_val = 0
+
+/datum/config_entry/number/bro_scale_cost
+	config_entry_value = 10
+	min_val = 0
+
+/datum/config_entry/number/bloodsucker_scale_cost
+	config_entry_value = 10
+	min_val = 0
 // Skyrat change END
 
 /datum/config_entry/number/dynamic_high_pop_limit

--- a/config/dynamic_config.txt
+++ b/config/dynamic_config.txt
@@ -27,6 +27,11 @@ DYNAMIC_FIRST_LATEJOIN_DELAY_MAX 30
 ## Arbitrary number added to the threat on roundstart
 ADDED_THREAT 50
 
+## Scaling up costs for roundstart rules
+TRAITOR_SCALE_COST 10
+BRO_SCALE_COST 10
+BLOODSUCKER_SCALE_COST 10
+
 ## How many roundstart players required for high population override to take effect.
 DYNAMIC_HIGH_POP_LIMIT 80 #80 instead of 55 because fewer robust players
 

--- a/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -2,12 +2,24 @@
 	protected_roles += "Prisoner"
 	protected_roles += "Brig Physician"
 	protected_roles += "Blueshield"
+
+	scaling_cost = CONFIG_GET(number/traitor_scale_cost)
 	. = ..()
 
 /datum/dynamic_ruleset/roundstart/traitorbro/New()
 	protected_roles += "Prisoner"
 	protected_roles += "Brig Physician"
 	protected_roles += "Blueshield"
+
+	scaling_cost = CONFIG_GET(number/bro_scale_cost)
+	. = ..()
+
+/datum/dynamic_ruleset/roundstart/bloodsucker/New()
+	restricted_roles += "Prisoner"
+	restricted_roles += "Brig Physician"
+	restricted_roles += "Blueshield"
+
+	scaling_cost = CONFIG_GET(number/bloodsucker_scale_cost)
 	. = ..()
 
 /datum/dynamic_ruleset/roundstart/changeling/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds scaling costs to the config for roundstart rules.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better tweaking of how we want antags to spawn roundstart.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: adds in scaling cost for roundstart dynamic rules
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
