### PR TITLE
Surrender Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -8,7 +8,7 @@
 /mob/living/carbon/human/Initialize()
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
-	verbs += /mob/living/proc/surrender
+	verbs += /mob/living/proc/surrender //Skyrat change
 	verbs += /mob/living/carbon/human/proc/underwear_toggle //fwee
 
 	//initialize limbs first

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -377,10 +377,14 @@
 	. = ..()
 	if(. && isliving(user))
 		var/mob/living/L = user
+		//Skyrat change start
+		if(L.client?.prefs?.autostand)
+			if(!(L.combat_flags & COMBAT_FLAG_INTENTIONALLY_RESTING))
+				TOGGLE_BITFIELD(L.combat_flags, COMBAT_FLAG_INTENTIONALLY_RESTING)
 		L.DefaultCombatKnockdown(200)
 		L.Stun(20) //Skyrat Change
-		L.set_resting(TRUE) //Skyrat change
-		
+		L.disable_combat_mode(FALSE)
+		//Skyrat change stop
 /datum/emote/living/sway
 	key = "sway"
 	key_third_person = "sways"


### PR DESCRIPTION
## About The Pull Request

Fixes all cases surrender. Always on the ground. Now drop combat mode when surrendering. Adding a forgotten comment.

## Why It's Good For The Game

Fixes stuff

## Changelog
:cl: Afya
tweak: combat mode disabled when surrendering.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
