### PR TITLE
[Not-Modular] Revert(?) Volumetric Storage

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -23,10 +23,13 @@
 
 /obj/item/storage/backpack/ComponentInitialize()
 	. = ..()
+	// SKYRAT EDIT: Remove Volumetric Storage
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.storage_flags = STORAGE_FLAGS_VOLUME_DEFAULT
-	STR.max_volume = STORAGE_VOLUME_BACKPACK
+	STR.storage_flags = STORAGE_FLAGS_LEGACY_DEFAULT
+	//STR.max_volume = STORAGE_VOLUME_BACKPACK
 	STR.max_w_class = MAX_WEIGHT_CLASS_BACKPACK
+	STR.max_combined_w_class = 21
+	STR.max_items = 21
 
 /*
  * Backpack Types
@@ -63,10 +66,13 @@
 
 /obj/item/storage/backpack/holding/ComponentInitialize()
 	. = ..()
+	// SKYRAT EDIT: Remove Volumetric Storage
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = MAX_WEIGHT_CLASS_BAG_OF_HOLDING
-	STR.storage_flags = STORAGE_FLAGS_VOLUME_DEFAULT
-	STR.max_volume = STORAGE_VOLUME_BAG_OF_HOLDING
+	STR.storage_flags = STORAGE_FLAGS_LEGACY_DEFAULT
+	//STR.max_volume = STORAGE_VOLUME_BAG_OF_HOLDING
+	STR.max_combined_w_class = 35
+	STR.allow_big_nesting = TRUE
 
 /obj/item/storage/backpack/holding/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is jumping into [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
@@ -343,8 +349,10 @@
 
 /obj/item/storage/backpack/duffelbag/ComponentInitialize()
 	. = ..()
+	// SKYRAT EDIT: Remove Volumetric Storage
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_volume = STORAGE_VOLUME_DUFFLEBAG
+	//STR.max_volume = STORAGE_VOLUME_DUFFLEBAG
+	STR.max_combined_w_class = 30
 
 /obj/item/storage/backpack/duffelbag/captain
 	name = "captain's duffel bag"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes volumetric stuff from backpacks, bags of holding, and duffel bags.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Volumetric is causing runtimes and errors. I believe it may be a cause of our crashing issues.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: reverted away from volumetric storage to legacy storage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
