### PR TITLE
[Modular] Renames OrviTrek uniforms YET YET AGAIN to be EntCorp's

### DIFF
--- a/modular_skyrat/code/modules/client/loadout/head.dm
+++ b/modular_skyrat/code/modules/client/loadout/head.dm
@@ -123,11 +123,20 @@
 	name = "Cyan Beanie"
 	path = /obj/item/clothing/head/beanie/cyan
 
+/datum/gear/trekcap
+	name = "EntCorp Officer's Cap (White)"
+
 /datum/gear/trekcapmedisci
+	name = "EntCorp Officer's Cap (Blue)"
 	restricted_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Virologist", "Paramedic", "Geneticist", "Research Director", "Scientist", "Roboticist")
 
 /datum/gear/trekcapsec
+	name = "EntCorp Officer's Cap (Red)"
 	restricted_roles = list("Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster", "Blueshield", "Brig Physician", "Warden", "Detective", "Security Officer")
 
+/datum/gear/trekcapeng
+	name = "EntCorp Officer's Cap (Yellow)"
+
 /datum/gear/trekcapcap
+	name = "EntCorp Officer's Cap (Black)"
 	restricted_roles = list("Captain", "Head of Personnel", "Blueshield")

--- a/modular_skyrat/code/modules/client/loadout/suit.dm
+++ b/modular_skyrat/code/modules/client/loadout/suit.dm
@@ -3,6 +3,7 @@
 	name = "Desperate Assistance Battleforce suit"
 
 /datum/gear/trekds9_coat
+	name = "DS9 Overcoat (use reskin of EntCorp uniform)"
 	restricted_roles = NOCIV_ROLES
 
 /datum/gear/trekmedscimov
@@ -12,10 +13,18 @@
 	restricted_roles = list("Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster", "Blueshield", "Brig Physician", "Warden", "Detective", "Security Officer")
 
 /datum/gear/trekmedscimod
+	name = "EntCorp uniform, Blue"
 	restricted_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Virologist", "Paramedic", "Geneticist", "Research Director", "Scientist", "Roboticist")
 
 /datum/gear/trekcmdmod
+	name = "EntCorp uniform, Red"
 	restricted_roles = list("Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster", "Blueshield", "Brig Physician", "Warden", "Detective", "Security Officer")
+
+/datum/gear/trekcmdcapmod
+	name = "EntCorp uniform, White"
+
+/datum/gear/trekengmod
+	name = "EntCorp uniform, Yellow"
 
 /datum/gear/trekcmdcap
 	restricted_roles = list("Captain", "Head of Personnel", "Blueshield")

--- a/modular_skyrat/code/modules/client/loadout/uniform.dm
+++ b/modular_skyrat/code/modules/client/loadout/uniform.dm
@@ -16,14 +16,14 @@
 	path = /obj/item/clothing/under/syndicate/tacticool/skirt
 
 /datum/gear/trekcmdtos
-	name = "Fed uniform, cmd"
+	name = "EntCorp uniform, cmd"
 
 /datum/gear/trekmedscitos
-	name = "Fed uniform, medsci"
+	name = "EntCorp uniform, medsci"
 	restricted_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Virologist", "Paramedic", "Geneticist", "Research Director", "Scientist", "Roboticist")
 
 /datum/gear/trekengtos
-	name = "Fed uniform, ops"
+	name = "EntCorp uniform, ops"
 	restricted_roles = list("Chief Engineer", "Atmospheric Technician", "Station Engineer", "Warden", "Detective", "Security Officer", "Head of Security", "Brig Physician", "Blueshield", "Cargo Technician", "Shaft Miner", "Quartermaster")
 
 /datum/gear/trekfedutil
@@ -31,11 +31,11 @@
 	restricted_roles = NOCIV_ROLES // Accomodates for modular and forgotten roles.
 
 /datum/gear/trekfedtrainee
-	name = "Fed uniform, trainee/assistant"
+	name = "EntCorp uniform, trainee/assistant"
 	path = /obj/item/clothing/under/trek/orvi
 
 /datum/gear/trekfedservice
-	name = "Fed uniform, service"
+	name = "EntCorp uniform, service"
 	path = /obj/item/clothing/under/trek/orvi/service
 	restricted_roles = CIV_ROLES
 	restricted_desc = "Civilian and Service"

--- a/modular_skyrat/code/modules/clothing/refactor.dm
+++ b/modular_skyrat/code/modules/clothing/refactor.dm
@@ -621,8 +621,8 @@
 
 // Reskinnable Trek uniforms, now using Orvi-like by default.
 /obj/item/clothing/under/trek/command
-	name = "federation command uniform"
-	desc = "A federation uniform worn by command officers."
+	name = "enterprise command uniform"
+	desc = "An enterprise corps uniform worn by command officers."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -669,8 +669,8 @@
 	)
 
 /obj/item/clothing/under/trek/engsec
-	name = "federation operations uniform"
-	desc = "A federation uniform worn by operations officers."
+	name = "enterprise operations uniform"
+	desc = "An enterprise corps uniform worn by operations officers."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -717,8 +717,8 @@
 	)
 
 /obj/item/clothing/under/trek/medsci
-	name = "federation medsci uniform"
-	desc = "A federation uniform worn by medsci officers."
+	name = "enterprise medsci uniform"
+	desc = "An enterprise corps uniform worn by medsci officers."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -766,8 +766,8 @@
 
 // Bonus for assistants and service.
 /obj/item/clothing/under/trek/orvi
-	name = "federation assistant uniform"
-	desc = "A federation uniform worn by volunteered-for-work cadets... Or in simple terms - assistants."
+	name = "enterprise assistant uniform"
+	desc = "An enterprise corps uniform worn by adjutants."
 	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
 	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
 	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
@@ -790,17 +790,17 @@
 	"The Motion Picture (The Original Series)" = "trek_tmp_trainee"
 	)
 	unique_name = list(
-	"Default" = "federation assistant uniform",
+	"Default" = "enterprise assistant uniform",
 	"The Motion Picture (The Original Series)" = "federation trainee uniform"
 	)
 	unique_desc = list(
-	"Default" = "An uniform worn by cadet-assistants since 2550s.",
+	"Default" = "An uniform worn by adjutants since 2550s.",
 	"The Motion Picture (The Original Series)" = "An uniform worn by enlisted trainees in 2285s."
 	)
 
 /obj/item/clothing/under/trek/orvi/service
-	name = "federation service uniform"
-	desc = "A federation uniform worn by service officers. How service department can have officers is still unknown."
+	name = "enterprise service uniform"
+	desc = "An enterprise corps uniform worn by service officers... Or is it just <i>service uniform</i> worn by officers?"
 	icon_state = "orv_srv"
 	item_state = "g_suit"
 	unique_reskin_icons = list(
@@ -820,7 +820,7 @@
 	"The Motion Picture (The Original Series)" = "trek_tmp_service"
 	)
 	unique_name = list(
-	"Default" = "federation service uniform",
+	"Default" = "enterprise service uniform",
 	"The Motion Picture (The Original Series)" = "federation service uniform"
 	)
 	unique_desc = list(
@@ -831,11 +831,11 @@
 // Changes name/desc to the jackets, makes modern/non-classic jacket to have same list of allowed suit-storage items as classic one.
 /obj/item/clothing/suit/storage/fluff/fedcoat
 	name = "federation classic uniform jacket"
-	desc = "A classic federation uniform jacket. Set phasers to awesome!"
+	desc = "The federation's classic uniform jacket. Set phasers to awesome!"
 
 /obj/item/clothing/suit/storage/fluff/modernfedcoat
-	name = "federation uniform jacket"
-	desc = "A federation uniform jacket."
+	name = "enterprise uniform jacket"
+	desc = "An enterprise corps uniform jacket."
 	allowed = list(
 				/obj/item/tank/internals/emergency_oxygen,
 				/obj/item/flashlight,
@@ -854,7 +854,7 @@
 				/obj/item/taperecorder)
 
 /obj/item/clothing/head/caphat/formal/fedcover
-	name = "federation peaked cap"
+	name = "enterprise officer cap"
 	desc = "A peaked cap, that demands <i>at least <u>some</u></i> discipline from its wearer."
 
 // PrisArch-like color codes for prisoners. Uses _stored variation for Warden's control.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames everything orvi/trek to be of enterprise corps. Because only one voted for it being Enterprise. [You **might** still change it, though!](https://poal.me/fdb2yg)
![the_non_meme_vote](https://user-images.githubusercontent.com/36963049/82459281-6a894200-9ac0-11ea-8a50-104d2f1e4fce.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less affiliation to the Sol Federation. Whenever EntCorp is (or will be) own thing or part of SolFed is still unknown. ~~I probably should pitch this to the lore channel.~~ And no, it will not require you to *salute every goddamn thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Anonymous
tweak: Renamed everything Fed to be EntCorp for the OrviTrek uniforms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
