### PR TITLE
Dynamic Overthrow roundstart

### DIFF
--- a/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -1,4 +1,16 @@
+/datum/dynamic_ruleset/latejoin/infiltrator/New()
+	protected_roles += "Prisoner"
+	protected_roles += "Brig Physician"
+	protected_roles += "Blueshield"
+	. = ..()
+
 /datum/dynamic_ruleset/latejoin/bloodsucker/New()
+	protected_roles += "Prisoner"
+	protected_roles += "Brig Physician"
+	protected_roles += "Blueshield"
+	. = ..()
+
+/datum/dynamic_ruleset/latejoin/changeling/New()
 	protected_roles += "Prisoner"
 	protected_roles += "Brig Physician"
 	protected_roles += "Blueshield"

--- a/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -51,3 +51,43 @@
 	restricted_roles += "Brig Physician"
 	restricted_roles += "Blueshield"
 	. = ..()
+
+
+//////////////////////////////////////////
+//                                      //
+//              OVERTHROW               //
+//                                      //
+//////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/overthrow
+	name = "Overthrow"
+	config_tag = "overthrow"
+	antag_flag = ROLE_OVERTHROW
+	minimum_required_age = 0
+	protected_roles = list("Chaplain", "Security Officer", "Warden", "Detective", "Brig Physician", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster", "Prisoner", "Brig Physician", "Blueshield") 
+	restricted_roles = list("Cyborg", "AI")
+	required_candidates = 2
+	weight = 3
+	cost = 35
+	scaling_cost = 10
+	property_weights = list("story_potential" = 1, "trust" = -1, "extended" = 1, "valid" = 1)
+	requirements = list(70,65,60,55,50,50,50,50,50,50)
+	high_population_requirement = 65
+	antag_cap = list(2,2,2,2,2,2,2,2,2,2)
+
+/datum/dynamic_ruleset/roundstart/overthrow/pre_execute()
+	var/sleeping_agents = antag_cap[indice_pop] * (scaled_times + 1)
+
+	for (var/i in 1 to sleeping_agents)
+		var/mob/M = pick_n_take(candidates)
+		assigned += M.mind
+		M.mind.special_role = ROLE_OVERTHROW
+		M.mind.restricted_roles = restricted_roles
+	return TRUE
+
+/datum/dynamic_ruleset/roundstart/overthrow/execute()
+	for(var/i in assigned) // each agent will have its own team.
+		var/datum/mind/agent = i
+		var/datum/antagonist/overthrow/O = agent.add_antag_datum(/datum/antagonist/overthrow) // create_team called on_gain will create the team
+		O.equip_initial_overthrow_agent()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Overthrow as a possible roundstart antag for Dynamic. There's also some minor role fixes for late join antags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Was only available for secret, so we're bring in another gamemode into dynamic.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds the Overthrow gamemode to dynamic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
