### PR TITLE
[MIRROR FIX] "Removes the absolute istype fest from footsteps"

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -331,8 +331,6 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		if(mutant_bodyparts["meat_type"]) //I can't believe it's come to the meat
 			H.type_of_meat = GLOB.meat_types[H.dna.features["meat_type"]]
 
-<<<<<<< HEAD
-=======
 		if(H.physiology)
 			if(mutant_bodyparts["taur"])
 				var/datum/sprite_accessory/taur/T = GLOB.taur_list[H.dna.features["taur"]]
@@ -347,11 +345,12 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 						H.physiology.footstep_type = null
 			else
 				H.physiology.footstep_type = null
-
+				
+	/* SKYRAT EDIT - START, COMMENTED OUT
 		if(H.client && has_field_of_vision && CONFIG_GET(flag/use_field_of_vision))
 			H.LoadComponent(/datum/component/field_of_vision, H.field_of_vision_type)
+	SKYRAT EDIT - END */
 
->>>>>>> 75dec8ce2c... Ports "Removes the absolute istype fest from footsteps" (#12259)
 	C.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/species, TRUE, multiplicative_slowdown = speedmod)
 
 	SEND_SIGNAL(C, COMSIG_SPECIES_GAIN, src, old_species)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -49,11 +49,8 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	see_in_dark = 4
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-<<<<<<< HEAD
-=======
 	footstep_type = FOOTSTEP_MOB_CLAW
-	has_field_of_vision = FALSE // 360° vision.
->>>>>>> 75dec8ce2c... Ports "Removes the absolute istype fest from footsteps" (#12259)
+	//has_field_of_vision = FALSE // 360° vision. - SKYRAT EDIT, COMMENTED
 	var/playable_spider = FALSE
 	var/datum/action/innate/spider/lay_web/lay_web
 	var/directive = "" //Message passed down to children, to relay the creator's orders

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/spaceman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/spaceman.dm
@@ -23,13 +23,8 @@
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	del_on_death = 0
-<<<<<<< HEAD
-
-	do_footstep = TRUE
-=======
 	footstep_type = FOOTSTEP_MOB_SHOE
-	has_field_of_vision = FALSE //Legacy gameplay experience. Also they only have one dir visually.
->>>>>>> 75dec8ce2c... Ports "Removes the absolute istype fest from footsteps" (#12259)
+	//has_field_of_vision = FALSE //Legacy gameplay experience. Also they only have one dir visually. - SKYRAT EDIT, COMMENTED OUT
 
 /mob/living/simple_animal/hostile/retaliate/nanotrasenpeace //this should be in a different file
 	name = "Nanotrasen Private Security Officer"

--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -11,7 +11,7 @@ Removes slaughterlings (because they are bullshit), instead replacing them with 
 /mob/living/simple_animal/hostile/megafauna/bubblegum
 	death_sound = 'modular_skyrat/sound/misc/gorenest.ogg' //fuck it
 	var/movesound = 'sound/effects/meteorimpact.ogg'
-	do_footstep = TRUE
+	footstep_type = FOOTSTEP_MOB_HEAVY
 	song = sound('modular_skyrat/sound/ambience/bfgdivision.ogg', 100) //Thanks Mr. Infringio!
 	songlength = 1860
 

--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/glaurung.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/glaurung.dm
@@ -60,7 +60,7 @@ Difficulty: Medium
 	move_resist = MOVE_FORCE_NORMAL
 	pull_force = MOVE_FORCE_NORMAL
 	songlength = 0
-	do_footstep = TRUE
+	footstep_type = FOOTSTEP_MOB_HEAVY
 
 /mob/living/simple_animal/hostile/megafauna/dragon/glaurung/Initialize()
 	smallsprite.Grant(src)

--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/shamblingminer.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/mining_mobs/shamblingminer.dm
@@ -32,7 +32,7 @@
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/mask
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/human = 2, /obj/item/stack/sheet/animalhide/human = 1, /obj/item/stack/sheet/bone = 1)
 	robust_searching = FALSE
-	do_footstep = TRUE
+	footstep_type = FOOTSTEP_MOB_SHOE
 	minimum_distance = 1
 	glorymessageshand = list("grabs the miner's eyes and rips them out, shoving the bloody miner aside!", "grabs and crushes the miner's skull apart with their bare hands!", "rips the miner's head clean off with their bare hands!")
 	glorymessagespka = list("sticks their PKA into the miner's mouth and shoots it, showering everything in gore!", "bashes the miner's head into their chest with their PKA!", "shoots off both legs of the miner with their PKA!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes PR #2029 and adds in equivalent Skyrat code.

Glaurung has big stompies now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
