### PR TITLE
Lowers down carp event weights on non-dynamic

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/carp_migration
 	name = "Carp Migration"
 	typepath = /datum/round_event/carp_migration
-	weight = 15
+	weight = 10 //Skyrat change
 	min_players = 2
 	earliest_start = 10 MINUTES
 	max_occurrences = 6

--- a/modular_skyrat/code/modules/events/tiger_carp_frenzy.dm
+++ b/modular_skyrat/code/modules/events/tiger_carp_frenzy.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/tiger_carp_frenzy
 	name = "Tiger Carp Frenzy"
 	typepath = /datum/round_event/tiger_carp_frenzy
-	weight = 10
+	weight = 5
 	min_players = 15
 	earliest_start = 20 MINUTES
 	max_occurrences = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks down tiger carp weights by 50% and normal carp by 33% down. There's usually a big amount of carp at most times, making it a pain if you need to EVA to do anything, and given its often occurence it's not  something people want to clear over and over again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less carps more space, explained above

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked down spawn rate of the carp events on non-dynamic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
