### PR TITLE
Comments out coom menu mousedrop functions

### DIFF
--- a/modular_skyrat/code/interactions/interaction_interface.dm
+++ b/modular_skyrat/code/interactions/interaction_interface.dm
@@ -7,7 +7,7 @@
 		try_interaction(dropped_on)
 		return
 	return ..()
-*/
+
 
 /mob/living/carbon/human/MouseDrop_T(mob/M as mob, mob/living/carbon/human/user as mob)
 	. = ..()
@@ -21,6 +21,7 @@
 		return
 
 	user.try_interaction(src)
+*/
 
 /mob/living/carbon/human/verb/interact_with()
 	set name = "Interact With"


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

It's generally a useless hassle to deal with. I'm removing it because it conflicts with other mouse drop functions, such as opening the equipment menu of other people, and because it won't affect much since you're never in a hurry to open a fucking sex menu. Goodbye, mousedropping sex functions - no one will miss you.

## Changelog
no