### PR TITLE
Adds in a non-combat mode combat indicator hotkey

### DIFF
--- a/code/modules/mob/living/living_combat.dm
+++ b/code/modules/mob/living/living_combat.dm
@@ -84,6 +84,4 @@
 					combatmessagecooldown = world.time + 10 SECONDS
 					//SKYRAT CHANGES - no more friendly message when help intent
 					visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
-					playsound(src, 'sound/machines/chime.ogg', 10) 
-					flick_emote_popup_on_mob(src, "combat", 20)
 					//END OF SKYRAT CHANGES

--- a/modular_skyrat/code/modules/keybindings/keybind/living.dm
+++ b/modular_skyrat/code/modules/keybindings/keybind/living.dm
@@ -1,0 +1,13 @@
+/datum/keybinding/living/toggle_combat_indication
+	hotkey_keys = list("CtrlC")
+	name = "toggle_combat_indication"
+	full_name = "Toggle combat indication"
+	description = "Toggles whether or not you're escalating or de-escalating from mechanical combat."
+
+/datum/keybinding/living/toggle_combat_indication/can_use(client/user)
+	return isliving(user.mob)	
+
+/datum/keybinding/living/toggle_combat_indication/down(client/user)
+	var/mob/living/L = user.mob
+	L.user_toggle_intentional_combat_indication()
+	return TRUE

--- a/modular_skyrat/code/modules/mob/living/combat_indicator.dm
+++ b/modular_skyrat/code/modules/mob/living/combat_indicator.dm
@@ -1,20 +1,51 @@
+/mob/living
+	var/enabled_combat_indicator = FALSE
+	var/nextcombatpopup = 0
+
+
 var/static/mutable_appearance/combat_indicator
 
-/mob/living/proc/set_combat_indicator(var/state)
+/mob/living/proc/set_combat_indicator(state)
+	if(enabled_combat_indicator == state)
+		return
+
 	if(!combat_indicator)
 		combat_indicator = mutable_appearance('modular_skyrat/icons/mob/combat_indicator.dmi', "combat", FLY_LAYER)
 		combat_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 
 	if(state && stat != DEAD)
 		add_overlay(combat_indicator)
+		enabled_combat_indicator = TRUE
 	else
 		cut_overlay(combat_indicator)
+		enabled_combat_indicator = FALSE
+
+/mob/living/proc/change_combat_indicator(state)
+	if(state && !enabled_combat_indicator && world.time >= nextcombatpopup) //No cooldown
+		nextcombatpopup = world.time + 10 SECONDS
+		playsound(src, 'sound/machines/chime.ogg', 10) 
+		flick_emote_popup_on_mob(src, "combat", 20)
+	if(state && world.time >= combatmessagecooldown) //If combat mode didn't make a message
+		combatmessagecooldown = world.time + 10 SECONDS
+		visible_message("<span class='warning'>[src] gets ready for combat!</span>")
+
+	set_combat_indicator(state)
 
 /mob/living/disable_combat_mode(silent = TRUE, was_forced = FALSE, visible = FALSE, update_icon = TRUE)
 	. = ..()
-	set_combat_indicator(FALSE)
+	change_combat_indicator(FALSE)
 
 
 /mob/living/enable_combat_mode(silent = TRUE, was_forced = FALSE, visible = FALSE, update_icon = TRUE)
 	. = ..()
-	set_combat_indicator(TRUE) 
+	change_combat_indicator(TRUE) 
+
+/mob/living/proc/user_toggle_intentional_combat_indication()
+	if(CAN_TOGGLE_COMBAT_MODE(src))
+		var/combat_enabled = (combat_flags & COMBAT_FLAG_COMBAT_TOGGLED)
+		if(combat_enabled)
+			to_chat(src, "<span class='warning'>Disable combat mode first!</span>")
+		else if (enabled_combat_indicator)
+			change_combat_indicator(FALSE)
+		else
+			change_combat_indicator(TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3681,6 +3681,7 @@
 #include "modular_skyrat\code\modules\jobs\job_types\security_officer.dm"
 #include "modular_skyrat\code\modules\jobs\job_types\warden.dm"
 #include "modular_skyrat\code\modules\keybindings\bindings_mob.dm"
+#include "modular_skyrat\code\modules\keybindings\keybind\living.dm"
 #include "modular_skyrat\code\modules\language\dragon.dm"
 #include "modular_skyrat\code\modules\language\terrorspider.dm"
 #include "modular_skyrat\code\modules\language\vox.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, properly respects combat mode indicator

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some people want to escalate into mechanics but not use combat mode

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a hotkey for a combat indicator that doesn't require combat mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
