### PR TITLE
Adds a secondary hotkey to combat indicator "6"

### DIFF
--- a/modular_skyrat/code/modules/keybindings/keybind/living.dm
+++ b/modular_skyrat/code/modules/keybindings/keybind/living.dm
@@ -1,5 +1,5 @@
 /datum/keybinding/living/toggle_combat_indication
-	hotkey_keys = list("CtrlC")
+	hotkey_keys = list("CtrlC", "6")
 	name = "toggle_combat_indication"
 	full_name = "Toggle combat indication"
 	description = "Toggles whether or not you're escalating or de-escalating from mechanical combat."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: "6" is not also a default hotkey for combat indicator. Make sure to check your keybindings in game preferences!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
