### PR TITLE
Removes gigantism and small traits, because we have sprite size % pref now

### DIFF
--- a/modular_skyrat/code/_DEFINES/traits.dm
+++ b/modular_skyrat/code/_DEFINES/traits.dm
@@ -1,4 +1,2 @@
-#define TRAIT_GIGANTISM			"gigantism"		// large boy
-#define TRAIT_SMALL				"small"		// smol boy
 #define TRAIT_SYNTH				"synthetic"		// robotic boy
 #define TRAIT_TOXIMMUNE			"toxin_immune"

--- a/modular_skyrat/code/datums/traits/neutral.dm
+++ b/modular_skyrat/code/datums/traits/neutral.dm
@@ -1,38 +1,3 @@
-//gigantism
-/datum/quirk/gigantism
-	name = "Gigantism"
-	desc = "You are exceptionally big."
-	value = 0
-	mob_trait = TRAIT_GIGANTISM
-	medical_record_text = "Patient's body is exceptionally large."
-
-/datum/quirk/gigantism/add()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(H)
-		H.transform = H.transform.Scale(1.25, 1.25)
-
-/datum/quirk/gigantism/remove()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(H)
-		H.transform = H.transform.Scale(0.8, 0.8)
-
-//small
-/datum/quirk/small
-	name = "Small"
-	desc = "You are a bit... small. With none of the benefits."
-	value = 0
-	mob_trait = TRAIT_SMALL
-
-/datum/quirk/small/add()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(H)
-		H.transform = H.transform.Scale(0.9, 0.9)
-
-/datum/quirk/small/remove()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(H)
-		H.transform = H.transform.Scale(1.1, 1.1)
-
 //synth thing (doing it as an actual species thing would be wayyy harder to do).
 /datum/quirk/synthetic
 	name = "Synthetic"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, we never intended to have such a big sprite size changes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People being too big or too small are bad for the game, both when it comes to visuals and gameplay (harder to click)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed gigantism and small quirk. Use the sprite size % pref in character appearance instead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
