### PR TITLE
makes synthetic trait users not die from famine

### DIFF
--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -31,6 +31,8 @@
 	//variables used for snowflakey ass races and stuff god i fukcing hate this
 	var/storedeardamage = 0
 	var/storedtaildamage = 0
+	//AAAAAAAAAAAAAAAAAAAAAAAA I CANT EAT AAAAAAAAAAAAAAAAAAAAAAAAAA
+	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 
 /datum/species/synth/proc/assume_disguise(datum/species/S, mob/living/carbon/human/H) //rework the proc for it to NOT fuck up with dunmer/other skyrat custom races
 	if(S && !istype(S, type))


### PR DESCRIPTION
## About The Pull Request

i forgot to give them a power cord to get the delicious nutritious power

## Why It's Good For The Game

https://youtu.be/0Ea1ZiOugEE

## Changelog
:cl:
fix: Synthetic trait users no longer die of communism.
/:cl:
