### PR TITLE
Fixes PKA manufacturing defects

### DIFF
--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -12,7 +12,8 @@
 		update_icon()
 		overheat = FALSE
 	else //this is a terrible solution, but it ensures that it wont be stuck on dischaged if it fails to reload in an obj
-		deltimer(chargetimer)
+		if(chargetimer)
+			deltimer(chargetimer)
 		chargetimer = addtimer(CALLBACK(src, .proc/reload), overheat_time * 2, TIMER_STOPPABLE)
 
 //BDM pka

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -1,4 +1,7 @@
 //Kinetic accelerator charging meme bugfix
+/obj/item/gun/energy/kinetic_accelerator/
+	var/chargetimer = null
+
 /obj/item/gun/energy/kinetic_accelerator/proc/reload()
 	if(ismob(loc) || isturf(loc)) //Kinetic accelerators won't charge inside objects. Period.
 		cell.give(cell.maxcharge)
@@ -9,7 +12,8 @@
 		update_icon()
 		overheat = FALSE
 	else //this is a terrible solution, but it ensures that it wont be stuck on dischaged if it fails to reload in an obj
-		addtimer(CALLBACK(src, .proc/reload), overheat_time * 2, TIMER_STOPPABLE)
+		deltimer(chargetimer)
+		chargetimer = addtimer(CALLBACK(src, .proc/reload), overheat_time * 2, TIMER_STOPPABLE)
 
 //BDM pka
 /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -8,6 +8,8 @@
 			to_chat(loc, "<span class='warning'>[src] silently charges up.</span>")
 		update_icon()
 		overheat = FALSE
+	else //this is a terrible solution, but it ensures that it wont be stuck on dischaged if it fails to reload in an obj
+		addtimer(CALLBACK(src, .proc/reload), recharge_time * carried, TIMER_STOPPABLE)
 
 //BDM pka
 /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -9,7 +9,7 @@
 		update_icon()
 		overheat = FALSE
 	else //this is a terrible solution, but it ensures that it wont be stuck on dischaged if it fails to reload in an obj
-		addtimer(CALLBACK(src, .proc/reload), recharge_time * carried, TIMER_STOPPABLE)
+		addtimer(CALLBACK(src, .proc/reload), overheat_time * 2, TIMER_STOPPABLE)
 
 //BDM pka
 /obj/item/gun/energy/kinetic_accelerator/premiumka/bdminer


### PR DESCRIPTION
## About The Pull Request

PKAs will no longer fry and never charge again when put on a bag or other types of containers.

## Why It's Good For The Game

i fucked up

## Changelog
:cl:
fix: NT is no longer cutting costs on their kinetic accelerators. They won't fry when put in containers anymore.
/:cl:
