### PR TITLE
Fixes missing shutters on Deltastation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -96883,10 +96883,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
-"egC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/chapel/office)
 "egD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -137107,7 +137103,7 @@ edT
 eeC
 efp
 egd
-egC
+efg
 aaa
 aad
 aaa
@@ -137364,7 +137360,7 @@ edU
 eeD
 efq
 ege
-egC
+efg
 aaa
 aad
 aaa
@@ -137621,7 +137617,7 @@ edV
 eeE
 efr
 ege
-egC
+efg
 aad
 ajr
 aaa


### PR DESCRIPTION
## About The Pull Request
Fixes missing shutters in the Chapel office.

## Why It's Good For The Game
4x1 block of windows, only the leftmost window has a shutter. Now all windows correctly have shutters.

## Changelog
:cl:
fix: Missing shutters on Deltastation Chapel office
/:cl:

## Media
![image](https://user-images.githubusercontent.com/53862927/82807327-73429500-9e7f-11ea-9d1c-8123dcae7c68.png)
![image](https://user-images.githubusercontent.com/53862927/82807336-789fdf80-9e7f-11ea-92a1-d29553e12d4d.png)
