### PR TITLE
Custom examine icons

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -56,6 +56,10 @@
 	var/chat_color
 	/// A luminescence-shifted value of the last color calculated for chatmessage overlays
 	var/chat_color_darkened
+	//skyrat edit - custom examine icon
+	var/examine_icon
+	var/examine_icon_state
+	//
 
 /atom/New(loc, ...)
 	//atom creation method that preloads variables at creation
@@ -300,8 +304,10 @@
 		. = override.Join("")
 
 ///Generate the full examine string of this atom (including icon for goonchat)
+//skyrat change - custom examine icons
 /atom/proc/get_examine_string(mob/user, thats = FALSE)
-	return "[icon2html(src, user)] [thats? "That's ":""][get_examine_name(user)]"
+	return "[icon2html(examine_icon ? examine_icon : src, user, examine_icon_state ? examine_icon_state : icon_state)] [thats? "That's ":""][get_examine_name(user)]"
+//end changes (yeah the whole proc was modified)
 
 /atom/proc/examine(mob/user)
 	. = list("[get_examine_string(user, TRUE)].")

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -189,6 +189,9 @@
 	desc = "Gloves made with completely frictionless, insulated cloth, easier to steal from people with."
 	icon_state = "thief"
 	item_state = "blackgloves"
+	//skyrat change - custom examine icons
+	examine_icon_state = "black"
+	//
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
 	strip_delay = 80


### PR DESCRIPTION
## About The Pull Request

Gives atoms the ability of using custom icons and icon_states for examine, which might prove useful for some stuff. In this case, i did it so the thieving gloves can keep their unique sprite, while still being stealthy when worn.

## Why It's Good For The Game

code QoL

## Changelog
:cl:
balance: Thieving gloves now appear as normal gloves in examine.
/:cl:

