### PR TITLE
Unfucks megafauna spawns.

### DIFF
--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(cap_megas,\
 					GLOB.remaining_megas[definite_boss] += 1
 					return FALSE
 			new definite_boss(src)
-			GLOB.remaining_megas[definite_boss] = max(0, GLOB.remainingmegas[definite_boss] - 1)
+			GLOB.remaining_megas[definite_boss] = max(0, GLOB.remaining_megas[definite_boss] - 1)
 			return TRUE
 	var/shouldspawnlegiontendril = TRUE
 	for(var/obj/structure/spawner/lavaland/legion/L in GLOB.tendrils)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -3,16 +3,16 @@
 
 //This list basically counts if we have reached the minimum quantity
 //of every megafauna type that doesn't spawn with ruins.
-GLOBAL_LIST_INIT(remaining_megas,
-	list(/mob/living/simple_animal/hostile/megafauna/dragon = 1,
-	/mob/living/simple_animal/hostile/megafauna/colossus = 1,
+GLOBAL_LIST_INIT(remaining_megas,\
+	list(/mob/living/simple_animal/hostile/megafauna/dragon = 1,\
+	/mob/living/simple_animal/hostile/megafauna/colossus = 1,\
 	/mob/living/simple_animal/hostile/megafauna/bubblegum = 1))
 
 //This list prevents spawning more than the associated amount
 //of megafauna.
-GLOBAL_LIST_INIT(cap_megas,
-	list(/mob/living/simple_animal/hostile/megafauna/dragon = 3,
-	/mob/living/simple_animal/hostile/megafauna/colossus = 3,
+GLOBAL_LIST_INIT(cap_megas,\
+	list(/mob/living/simple_animal/hostile/megafauna/dragon = 3,\
+	/mob/living/simple_animal/hostile/megafauna/colossus = 3,\
 	/mob/living/simple_animal/hostile/megafauna/bubblegum = 3))
 
 /turf/open/floor/plating/asteroid/airless/cave/volcanic
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(cap_megas,
 					GLOB.remaining_megas[definite_boss] += 1
 					return FALSE
 			new definite_boss(src)
-			GLOB.remaining_megas[definite_boss] = max(0, remainingmegas[definite_boss] - 1)
+			GLOB.remaining_megas[definite_boss] = max(0, GLOB.remainingmegas[definite_boss] - 1)
 			return TRUE
 	var/shouldspawnlegiontendril = TRUE
 	for(var/obj/structure/spawner/lavaland/legion/L in GLOB.tendrils)
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(cap_megas,
 					for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
 						if(istype(M, maybe_boss))
 							count++
-					if(count < cap_megas[maybe_boss])
+					if(count < GLOB.cap_megas[maybe_boss])
 						randumb = maybe_boss
 					else
 						randumb = pickweight(mob_spawn_list)

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -1,8 +1,19 @@
 #define SPAWN_MEGAFAUNA "bluh bluh huge boss"
 #define SPAWN_BUBBLEGUM 6
 
-/turf/open/floor/plating/asteroid/airless/cave
-	var/list/remainingmegas = list(/mob/living/simple_animal/hostile/megafauna/dragon = 4, /mob/living/simple_animal/hostile/megafauna/colossus = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = SPAWN_BUBBLEGUM)
+//This list basically counts if we have reached the minimum quantity
+//of every megafauna type that doesn't spawn with ruins.
+GLOBAL_LIST_INIT(remaining_megas,
+	list(/mob/living/simple_animal/hostile/megafauna/dragon = 1,
+	/mob/living/simple_animal/hostile/megafauna/colossus = 1,
+	/mob/living/simple_animal/hostile/megafauna/bubblegum = 1))
+
+//This list prevents spawning more than the associated amount
+//of megafauna.
+GLOBAL_LIST_INIT(cap_megas,
+	list(/mob/living/simple_animal/hostile/megafauna/dragon = 3,
+	/mob/living/simple_animal/hostile/megafauna/colossus = 3,
+	/mob/living/simple_animal/hostile/megafauna/bubblegum = 3))
 
 /turf/open/floor/plating/asteroid/airless/cave/volcanic
 	mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast/random = 50, /obj/structure/spawner/lavaland/goliath = 3, \
@@ -17,16 +28,17 @@
 	if(!isarea(loc))
 		return
 	var/area/A = loc
-	var/definite_boss = pick_n_take(remainingmegas)
+	var/definite_boss = pick_n_take(GLOB.remaining_megas)
 	var/shouldspawnboss = TRUE
 	if(definite_boss)
 		for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
-			if(definite_boss == M.type)
+			if(istype(M, definite_boss))
 				shouldspawnboss = FALSE
 		if(shouldspawnboss && A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len)
-			for(var/mob/living/simple_animal/hostile/H in urange(12,T)) //prevents megafauan from spawning too near to each other.
+			for(var/mob/living/simple_animal/hostile/H in urange(7,T)) //prevents megafauna from spawning too near to other megafauna
 				if(ismegafauna(H) && get_dist(src, H) <= 7)
-					return
+					GLOB.remaining_megas[definite_boss] += 1
+					return FALSE
 			new definite_boss(src)
 			return TRUE
 	var/shouldspawnlegiontendril = TRUE
@@ -34,8 +46,7 @@
 		shouldspawnlegiontendril = FALSE
 	if(shouldspawnlegiontendril)
 		for(var/obj/structure/spawner/lavaland/L in urange(12,T))
-			if(istype(L, /obj/structure/spawner/lavaland) && (get_dist(src, L) <= 3))
-				return //prevents tendrils spawning in each other's collapse range
+			return //prevents tendrils spawning in each other's collapse range
 		new /obj/structure/spawner/lavaland/legion(src)
 		return TRUE
 	if(prob(30))
@@ -48,7 +59,14 @@
 			if(A.megafauna_spawn_allowed && megafauna_spawn_list && megafauna_spawn_list.len) //this is danger. it's boss time.
 				var/maybe_boss = pickweight(megafauna_spawn_list)
 				if(megafauna_spawn_list[maybe_boss])
-					randumb = maybe_boss
+					var/count = 0
+					for(var/mob/living/simple_animal/hostile/megafauna/M in GLOB.mob_living_list)
+						if(istype(M, maybe_boss))
+							count++
+					if(count < cap_megas[maybe_boss])
+						randumb = maybe_boss
+					else
+						randumb = pickweight(mob_spawn_list)
 			else //this is not danger, don't spawn a boss, spawn something else
 				randumb = pickweight(mob_spawn_list)
 

--- a/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
+++ b/modular_skyrat/code/game/turfs/simulated/floor/asteroid.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_INIT(cap_megas,
 					GLOB.remaining_megas[definite_boss] += 1
 					return FALSE
 			new definite_boss(src)
+			GLOB.remaining_megas[definite_boss] = max(0, remainingmegas[definite_boss] - 1)
 			return TRUE
 	var/shouldspawnlegiontendril = TRUE
 	for(var/obj/structure/spawner/lavaland/legion/L in GLOB.tendrils)


### PR DESCRIPTION
## About The Pull Request

Basically fixed the code around so that there won't be anymore megafauna spawn.
Every type of non-ruin fauna will spawn at least once, but they can only spawn up to 3 tims and no more.

## Why It's Good For The Game

6 bubblegums in a single round bad

## Changelog
:cl:
fix: Lavaland won't spawn an absurd amount of megafauna anymore. It will only spawn up to 3 of each type of megafauna, with a minimum of 1 for each type.
/:cl:
