### PR TITLE
Moves var definitions to their object definitions

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -24,16 +24,6 @@
 	return
 
 
-/client
-	var/list/atom/selected_target[2]
-	var/obj/item/active_mousedown_item = null
-	var/mouseParams = ""
-	var/mouseLocation = null
-	var/mouseObject = null
-	var/mouseControlObject = null
-	var/middragtime = 0
-	var/atom/middragatom
-
 /client/MouseDown(object, location, control, params)
 	if (mouse_down_icon)
 		mouse_pointer_icon = mouse_down_icon
@@ -83,12 +73,6 @@
 
 /obj/item/proc/onMouseUp(object, location, params, mob)
 	return
-
-/obj/item
-	var/canMouseDown = FALSE
-
-/obj/item/gun
-	var/automatic = 0 //can gun use it, 0 is no, anything above 0 is the delay between clicks in ds
 
 /obj/item/gun/CanItemAutoclick(object, location, params)
 	. = automatic

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -642,9 +642,6 @@ so as to remain in compliance with the most up-to-date laws."
 		mymob.client.screen |= alert
 	return 1
 
-/mob
-	var/list/alerts = list() // contains /obj/screen/alert only // On /mob so clientless mobs will throw alerts properly
-
 /obj/screen/alert/Click(location, control, params)
 	if(!usr || !usr.client)
 		return

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -1,7 +1,3 @@
-
-/mob
-	var/list/screens = list()
-
 /mob/proc/overlay_fullscreen(category, type, severity)
 	var/obj/screen/fullscreen/screen = screens[category]
 	if (!screen || screen.type != type)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -114,8 +114,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 	return ..()
 
-/mob
-	var/hud_type = /datum/hud
 
 /mob/proc/create_mob_hud()
 	if(!client || hud_used)

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -1,16 +1,4 @@
 
-/client
-	var/list/parallax_layers
-	var/list/parallax_layers_cached
-	var/atom/movable/movingmob
-	var/turf/previous_turf
-	var/dont_animate_parallax //world.time of when we can state animate()ing parallax again
-	var/last_parallax_shift //world.time of last update
-	var/parallax_throttle = 0 //ds between updates
-	var/parallax_movedir = 0
-	var/parallax_layers_max = 3
-	var/parallax_animate_timer
-
 /datum/hud/proc/create_parallax(mob/viewmob)
 	var/mob/screenmob = viewmob || mymob
 	var/client/C = screenmob.client

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -11,9 +11,6 @@
 		if(A.attachable)
 			return TRUE
 
-/atom
-	var/datum/wires/wires = null
-
 /atom/proc/attempt_wire_interaction(mob/user)
 	if(!wires)
 		return WIRE_INTERACTION_FAIL

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -44,6 +44,8 @@
 	///Modifier that raises/lowers the effect of the amount of a material, prevents small and easy to get items from being death machines.
 	var/material_modifier = 1
 
+	var/datum/wires/wires = null
+
 	var/icon/blood_splatter_icon
 	var/list/fingerprints
 	var/list/fingerprintshidden

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -2,8 +2,7 @@
 
 GLOBAL_VAR_INIT(hsboxspawn, TRUE)
 
-/mob
-	var/datum/hSB/sandbox = null
+
 /mob/proc/CanBuild()
 	sandbox = new/datum/hSB
 	sandbox.owner = src.ckey

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -138,6 +138,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/skill_difficulty = THRESHOLD_UNTRAINED //how difficult it's to use this item in general.
 	var/skill_gain = DEF_SKILL_GAIN //base skill value gain from using this item.
 
+	var/canMouseDown = FALSE
+
+
 /obj/item/Initialize()
 
 	if (attack_verb)

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -17,11 +17,6 @@
 	//eg: "Bloody screen" > "goggles colour" as the former is much more important
 
 
-/mob
-	var/list/client_colours = list()
-
-
-
 /*
 	Adds an instance of colour_type to the mob's client_colours list
 	colour_type - a typepath (subtyped from /datum/client_colour)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -99,5 +99,35 @@
 	/// custom movement keys for this client
 	var/list/movement_keys = list()
 
+	///Autoclick list of two elements, first being the clicked thing, second being the parameters.
+	var/list/atom/selected_target[2]
+	///Autoclick variable referencing the associated item.
+	var/obj/item/active_mousedown_item = null
+	///Used in MouseDrag to preserve the original mouse click parameters
+	var/mouseParams = ""
+	///Used in MouseDrag to preserve the last mouse-entered location.
+	var/mouseLocation = null
+	///Used in MouseDrag to preserve the last mouse-entered object.
+	var/mouseObject = null
+	var/mouseControlObject = null
+	//Middle-mouse-button click dragtime control for aimbot exploit detection.
+	var/middragtime = 0
+	//Middle-mouse-button clicked object control for aimbot exploit detection.
+	var/atom/middragatom
+
 	/// Messages currently seen by this client
 	var/list/seen_messages
+
+	var/list/parallax_layers
+	var/list/parallax_layers_cached
+	var/atom/movable/movingmob
+	var/turf/previous_turf
+	///world.time of when we can state animate()ing parallax again
+	var/dont_animate_parallax
+	///world.time of last parallax update
+	var/last_parallax_shift
+	///ds between parallax updates
+	var/parallax_throttle = 0
+	var/parallax_movedir = 0
+	var/parallax_layers_max = 3
+	var/parallax_animate_timer

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -127,6 +127,13 @@
 
 	var/registered_z
 
+	var/list/alerts = list() // contains /obj/screen/alert only // On /mob so clientless mobs will throw alerts properly
+	var/list/screens = list()
+	var/list/client_colours = list()
+	var/hud_type = /datum/hud
+
+	var/datum/hSB/sandbox = null
+
 	var/mob/audiovisual_redirect //Mob to redirect messages, speech, and sounds to
 
 	var/siliconaccessareas = list()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -80,6 +80,8 @@
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
 
+	var/automatic = 0 //can gun use it, 0 is no, anything above 0 is the delay between clicks in ds
+
 /obj/item/gun/Initialize()
 	. = ..()
 	if(pin)


### PR DESCRIPTION
Being defined elsewhere breaks the langserv's go to definition feature, plus it promotes messy and unclear code.