### PR TITLE
Reworks Wormholes

### DIFF
--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -6,7 +6,6 @@
 	min_players = 2
 	gamemode_blacklist = list("dynamic")
 
-
 /datum/round_event/wormholes
 	announceWhen = 10
 	endWhen = 60
@@ -35,12 +34,14 @@
 /datum/round_event/wormholes/announce(fake)
 	priority_announce("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert", "spanomalies")
 
+/* SKYRAT CHANGE: NO WORMHOLE SHIFTING.
 /datum/round_event/wormholes/tick()
 	if(activeFor % shift_frequency == 0)
 		for(var/obj/effect/portal/wormhole/O in wormholes)
 			var/turf/T = pick(pick_turfs)
 			if(T)
 				O.forceMove(T)
+*/
 
 /datum/round_event/wormholes/end()
 	QDEL_LIST(wormholes)
@@ -48,7 +49,7 @@
 
 /obj/effect/portal/wormhole
 	name = "wormhole"
-	desc = "It looks highly unstable; It could close at any moment."
+	desc = "It looks highly unstable. You could end up literally anywhere." //SKYRAT CHANGE.
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "anom"
 	mech_sized = TRUE

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -27,9 +27,18 @@
 				continue
 			pick_turfs += T
 
-	for(var/i = 1, i <= number_of_wormholes, i++)
+	//Start of Skyrat Changes.
+	for(var/i = 1, i <= CEILING(number_of_wormholes,2), i++) //Force even number of wormholes.
 		var/turf/T = pick(pick_turfs)
-		wormholes += new /obj/effect/portal/wormhole(T, null, 0, null, FALSE)
+		var/obj/effect/portal/wormhole/W = new /obj/effect/portal/wormhole(T, null, 0, null, FALSE)
+		animate(W,alpha = 75, time = (endWhen - startWhen)*10, easing = CIRCULAR_EASING | EASE_IN) //Animate it.
+		if(i > 0 && i % 2 == 0) //Only trigger on even numbers greater than 0.
+			//Link the two wormholes together.
+			var/obj/effect/portal/wormhole/OLD_W = wormholes[i - 1]
+			OLD_W.hard_target = W.loc
+			W.hard_target = OLD_W.loc
+		wormholes += W
+	//End of Skyrat changes.
 
 /datum/round_event/wormholes/announce(fake)
 	priority_announce("Space-time anomalies detected on the station. There is no additional data.", "Anomaly Alert", "spanomalies")
@@ -62,7 +71,7 @@
 			return
 
 	if(ismovable(M))
-		if(GLOB.portals.len)
+		if(!hard_target && GLOB.portals.len) //SKYRAT CHANGE, CHECK IF IT HAS A HARD TARGET.
 			var/obj/effect/portal/P = pick(GLOB.portals)
 			if(P && isturf(P.loc))
 				hard_target = P.loc


### PR DESCRIPTION
## About The Pull Request

Wormholes no longer shift their location every 3 seconds. The wormholes that start during the event are wormholes that will always stay.

Wormholes now have persistent/consistent teleport locations.

Wormholes now have animation effects.

## Why It's Good For The Game

Wormholes are pretty shit. This hasn't happened to me but I don't think it's good game design that you can easily space yourself because you walked into a tile that spawned directly in front of you while moving and without much warning. This PR makes it so you can easily save yourself that this occurs, so it doesn't remove the danger of it.

## Changelog
:cl: BurgerBB
balance: Reworks/rebalances wormholes.
/:cl: