### PR TITLE
Adds Voice Scrambler Balacava

### DIFF
--- a/modular_skyrat/code/modules/uplink/uplink_stealth.dm
+++ b/modular_skyrat/code/modules/uplink/uplink_stealth.dm
@@ -9,3 +9,11 @@
 	desc = "A tight-fitting stealth suit, able to make you near completely invisible."
 	item = /obj/item/clothing/under/syndicate/stealthsuit
 	cost = 5
+	
+/datum/uplink_item/stealthy_weapons/balacava
+	name = "Voice Scrambler Balacava"
+	desc = "A high tech Balacava with an inbuild voice scrambler to conceal your identity. \
+			Does not let you mimic voices."
+	item = /obj/item/clothing/mask/infiltrator
+	cost = 1
+	surplus = 5


### PR DESCRIPTION
About The Pull Request
Adds a voice scrambler Balacava to the uplink. This is the same you get from the Syndicate infiltrator kit but without armor or a sneaksuit. Its a standalone. This allows you to hide your voice as "Unknown" allowing you to state demands over comms and talk to people without compromosing your idenity. Does not allow you to mimick voices.

Why It's Good For The Game
Because spending 1/5 to 1/4 of your budge to just get voice concealment and a disguise that can be replaced by generic clothing feels wrong. Yeah sure the infiltrator kit gets some armor but what if one just wants the balacava/scrambler alone to state some demands? Hopefully this would let traitors be more open about their demands since they can hide their voice with a cheap mask. 1 TC because it doesnt give anything outside from voice and face concealment and its not even good at it.

Changelog
🆑
add: Standalone purchase of the infiltrator kits voice scrambler balacava. Good for stating demands over comms or being an armed robber in maintenance or something.
/🆑
