### PR TITLE
Firealarm Alert

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -33,7 +33,20 @@
 	var/buildstage = 2 // 2 = complete, 1 = no wires, 0 = circuit gone
 	var/last_alarm = 0
 	var/area/myarea = null
-
+//Skyrat changes start
+/obj/machinery/firealarm/examine(mob/user)
+	. = ..()
+	if(GLOB.security_level == SEC_LEVEL_GREEN)
+		. += "The current alert level is green."
+	if(GLOB.security_level == SEC_LEVEL_BLUE)
+		. += "The current alert level is blue."
+	if(GLOB.security_level == SEC_LEVEL_AMBER)
+		. += "The current alert level is amber."
+	if(GLOB.security_level == SEC_LEVEL_RED)
+		. += "The current alert level is red!"
+	if(GLOB.security_level == SEC_LEVEL_DELTA)
+		. += "The current alert level is delta! Evacuate!"
+//Skyrat changes stop
 /obj/machinery/firealarm/Initialize(mapload, dir, building)
 	. = ..()
 	if(dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fire alarms now show the alert level when examined.

## Why It's Good For The Game

Fire alarm sprites already flash the current alert level, having an easy to see way of telling can be nice.

## Changelog
:cl: Afya
add: Fire alarms now show the alert level when examined.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
