### PR TITLE
Clothing self equip delay

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -153,7 +153,7 @@
 	var/image/item_overlay = image(holding)
 	item_overlay.alpha = 92
 
-	if(!user.can_equip(holding, slot_id, TRUE))
+	if(!user.can_equip(holding, slot_id, TRUE, TRUE)) //skyrat change
 		item_overlay.color = "#FF0000"
 	else
 		item_overlay.color = "#00ff00"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -138,6 +138,16 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/skill_difficulty = THRESHOLD_UNTRAINED //how difficult it's to use this item in general.
 	var/skill_gain = DEF_SKILL_GAIN //base skill value gain from using this item.
 
+	//SKYRAT CHANGE - self equip delays
+	//Time in ticks needed to equip something on yourself. Uses the equip_delay_self var.
+	//Set use_standard_equip_delay to false if you want to set a custom delay by changing equip_delay_self.
+	var/use_standard_equip_delay = FALSE //Basically sets the self equip delay on initialize to self_equip_mod * equip_delay_other
+	var/self_equip_mod = 0.65
+	var/strip_self_delay = 0
+	var/use_standard_strip_self_delay = TRUE //Basically makes the unequip delay take as long as strip_self_delay_mod * equip_delay on initialize
+	var/strip_self_delay_mod = 0.85
+	//
+
 /obj/item/Initialize()
 
 	if (attack_verb)
@@ -169,6 +179,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	if(sharpness) //give sharp objects butchering functionality, for consistency
 		AddComponent(/datum/component/butchering, 80 * toolspeed)
+	
+	//skyrat change
+	if(use_standard_equip_delay && !equip_delay_self)
+		equip_delay_self = self_equip_mod * equip_delay_other
+	if(use_standard_strip_self_delay && !strip_self_delay && equip_delay_self)
+		strip_self_delay = strip_self_delay_mod * equip_delay_self
+	//
 
 /obj/item/Destroy()
 	item_flags &= ~DROPDEL	//prevent reqdels
@@ -335,7 +352,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(loc == user)
 		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
-
+	//skyrat change - unequip delays
+	if(C.strip_self_delay && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.visible_message("<span class='notice'>[H] start unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
+		if(!do_after(user, strip_self_delay, TRUE, user))
+			return
+	//
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src, FALSE, FALSE))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -352,13 +352,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(loc == user)
 		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
-	//skyrat change - unequip delays
-	if(strip_self_delay && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.visible_message("<span class='notice'>[H] start unequipping [src]...</span>", "<span class='notice'>You start unequipping [src]...</span>")
-		if(!do_after(user, strip_self_delay, TRUE, user))
-			return
-	//
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src, FALSE, FALSE))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -353,9 +353,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
 	//skyrat change - unequip delays
-	if(C.strip_self_delay && ishuman(user))
+	if(strip_self_delay && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		H.visible_message("<span class='notice'>[H] start unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
+		H.visible_message("<span class='notice'>[H] start unequipping [src]...</span>", "<span class='notice'>You start unequipping [src]...</span>")
 		if(!do_after(user, strip_self_delay, TRUE, user))
 			return
 	//

--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -4,6 +4,9 @@
 	icon = 'icons/obj/storage.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 	var/component_type = /datum/component/storage/concrete
+	//skyrat change - equip and unequip delays
+	use_standard_equip_delay = TRUE
+	//
 
 /obj/item/storage/get_dumping_location(obj/item/storage/source,mob/user)
 	return src

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -47,12 +47,24 @@
 	//Add a "exclude" string to do the opposite, making it only only species listed that can't wear it.
 	//You append this to clothing objects.
 
+	//SKYRAT CHANGE - self equip delays
+	//Time in ticks needed to equip something on yourself.
+	//Set use_standard_equip_delay to false if you want to set a custom delay.
+	var/self_equip_delay = 0
+	var/use_standard_equip_delay = FALSE //Basically sets the self equip delay on initialize to self_equip_mod * strip_delay
+	var/self_equip_mod = 0.5
+	//
+
 /obj/item/clothing/Initialize()
 	. = ..()
 	if(CHECK_BITFIELD(clothing_flags, VOICEBOX_TOGGLABLE))
 		actions_types += /datum/action/item_action/toggle_voice_box
 	if(ispath(pocket_storage_component_path))
 		LoadComponent(pocket_storage_component_path)
+	//skyrat change
+	if(use_standard_equip_delay && !self_equip_delay)
+		self_equip_delay = self_equip_mod * strip_delay
+	//
 
 /obj/item/clothing/MouseDrop(atom/over_object)
 	. = ..()
@@ -108,8 +120,13 @@
 		user_vars_remembered = initial(user_vars_remembered) // Effectively this sets it to null.
 
 /obj/item/clothing/equipped(mob/user, slot)
-	..()
-	if (!istype(user))
+	//skyrat change - self equip delay
+	if(!self_equip_delay || do_after(user, self_equip_delay, TRUE, user))
+		..()
+	else
+		return FALSE
+	//
+	if(!istype(user))
 		return
 	if(slot_flags & slotdefine2slotbit(slot)) //Was equipped to a valid slot for this item?
 		if (LAZYLEN(user_vars_to_edit))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -48,11 +48,10 @@
 	//You append this to clothing objects.
 
 	//SKYRAT CHANGE - self equip delays
-	//Time in ticks needed to equip something on yourself.
-	//Set use_standard_equip_delay to false if you want to set a custom delay.
-	var/self_equip_delay = 0
-	var/use_standard_equip_delay = FALSE //Basically sets the self equip delay on initialize to self_equip_mod * strip_delay
-	var/self_equip_mod = 0.5
+	//Time in ticks needed to equip something on yourself. Uses the equip_delay_self var.
+	//Set use_standard_equip_delay to false if you want to set a custom delay by changing equip_delay_self.
+	var/use_standard_equip_delay = FALSE //Basically sets the self equip delay on initialize to self_equip_mod * equip_delay_other
+	var/self_equip_mod = 0.75
 	//
 
 /obj/item/clothing/Initialize()
@@ -62,8 +61,8 @@
 	if(ispath(pocket_storage_component_path))
 		LoadComponent(pocket_storage_component_path)
 	//skyrat change
-	if(use_standard_equip_delay && !self_equip_delay)
-		self_equip_delay = self_equip_mod * strip_delay
+	if(use_standard_equip_delay && !equip_delay_self)
+		equip_delay_self = self_equip_mod * equip_delay_other
 	//
 
 /obj/item/clothing/MouseDrop(atom/over_object)
@@ -120,12 +119,7 @@
 		user_vars_remembered = initial(user_vars_remembered) // Effectively this sets it to null.
 
 /obj/item/clothing/equipped(mob/user, slot)
-	//skyrat change - self equip delay
-	if(!self_equip_delay || do_after(user, self_equip_delay, TRUE, user))
-		..()
-	else
-		return FALSE
-	//
+	..()
 	if(!istype(user))
 		return
 	if(slot_flags & slotdefine2slotbit(slot)) //Was equipped to a valid slot for this item?

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -51,7 +51,7 @@
 	//Time in ticks needed to equip something on yourself. Uses the equip_delay_self var.
 	//Set use_standard_equip_delay to false if you want to set a custom delay by changing equip_delay_self.
 	var/use_standard_equip_delay = FALSE //Basically sets the self equip delay on initialize to self_equip_mod * equip_delay_other
-	var/self_equip_mod = 0.75
+	var/self_equip_mod = 0.65
 	//
 
 /obj/item/clothing/Initialize()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -47,23 +47,12 @@
 	//Add a "exclude" string to do the opposite, making it only only species listed that can't wear it.
 	//You append this to clothing objects.
 
-	//SKYRAT CHANGE - self equip delays
-	//Time in ticks needed to equip something on yourself. Uses the equip_delay_self var.
-	//Set use_standard_equip_delay to false if you want to set a custom delay by changing equip_delay_self.
-	var/use_standard_equip_delay = FALSE //Basically sets the self equip delay on initialize to self_equip_mod * equip_delay_other
-	var/self_equip_mod = 0.65
-	//
-
 /obj/item/clothing/Initialize()
 	. = ..()
 	if(CHECK_BITFIELD(clothing_flags, VOICEBOX_TOGGLABLE))
 		actions_types += /datum/action/item_action/toggle_voice_box
 	if(ispath(pocket_storage_component_path))
 		LoadComponent(pocket_storage_component_path)
-	//skyrat change
-	if(use_standard_equip_delay && !equip_delay_self)
-		equip_delay_self = self_equip_mod * equip_delay_other
-	//
 
 /obj/item/clothing/MouseDrop(atom/over_object)
 	. = ..()

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -23,6 +23,10 @@
 	dog_fashion = null
 	mutantrace_variation = STYLE_MUZZLE
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	//skyrat edit - self equip delay
+	use_standard_equip_delay = TRUE
+	self_equip_mod = 0.7
+	//
 
 /obj/item/clothing/suit/space
 	name = "space suit"
@@ -47,3 +51,7 @@
 	resistance_flags = NONE
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE //rated for cosmic radation :honk:
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_SNEK_TAURIC|STYLE_PAW_TAURIC
+	//skyrat edit - self equip delay
+	use_standard_equip_delay = TRUE
+	self_equip_mod = 0.7
+	//

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -25,7 +25,6 @@
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 	//skyrat edit - self equip delay
 	use_standard_equip_delay = TRUE
-	self_equip_mod = 0.7
 	//
 
 /obj/item/clothing/suit/space

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -23,9 +23,6 @@
 	dog_fashion = null
 	mutantrace_variation = STYLE_MUZZLE
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-	//skyrat edit - self equip delay
-	use_standard_equip_delay = TRUE
-	//
 
 /obj/item/clothing/suit/space
 	name = "space suit"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -277,6 +277,13 @@
 		return TRUE
 	if(HAS_TRAIT(I, TRAIT_NODROP) && !force)
 		return FALSE
+	//skyrat change - unequip delays
+	if(I.strip_self_delay && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.visible_message("<span class='notice'>[H] start unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
+		if(!do_after(user, strip_self_delay, TRUE, user))
+			return FALSE
+	//
 	return TRUE
 
 /mob/proc/putItemFromInventoryInHandIfPossible(obj/item/I, hand_index, force_removal = FALSE)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -321,9 +321,10 @@
 	//skyrat change - unequip delays
 	if((I.item_flags & IN_INVENTORY) && I.strip_self_delay && ishuman(src))
 		var/mob/living/carbon/human/H = src
-		H.visible_message("<span class='notice'>[H] starts unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
-		if(!do_after(H, I.strip_self_delay, TRUE, H))
-			return FALSE
+		if(!(I in H.held_items))
+			H.visible_message("<span class='notice'>[H] starts unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
+			if(!do_after(H, I.strip_self_delay, TRUE, H))
+				return FALSE
 	//
 
 	var/hand_index = get_held_index_of_item(I)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -278,10 +278,10 @@
 	if(HAS_TRAIT(I, TRAIT_NODROP) && !force)
 		return FALSE
 	//skyrat change - unequip delays
-	if(I.strip_self_delay && ishuman(user))
-		var/mob/living/carbon/human/H = user
+	if(I.strip_self_delay && ishuman(src))
+		var/mob/living/carbon/human/H = src
 		H.visible_message("<span class='notice'>[H] start unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
-		if(!do_after(user, strip_self_delay, TRUE, user))
+		if(!do_after(H, I.strip_self_delay, TRUE, H))
 			return FALSE
 	//
 	return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -277,13 +277,6 @@
 		return TRUE
 	if(HAS_TRAIT(I, TRAIT_NODROP) && !force)
 		return FALSE
-	//skyrat change - unequip delays
-	if(I.strip_self_delay && ishuman(src))
-		var/mob/living/carbon/human/H = src
-		H.visible_message("<span class='notice'>[H] start unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
-		if(!do_after(H, I.strip_self_delay, TRUE, H))
-			return FALSE
-	//
 	return TRUE
 
 /mob/proc/putItemFromInventoryInHandIfPossible(obj/item/I, hand_index, force_removal = FALSE)
@@ -321,9 +314,17 @@
 													//Invdrop is used to prevent stuff in pockets dropping. only set to false if it's going to immediately be replaced
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for TRAIT_NODROP.
 		return TRUE
-
+	
 	if(HAS_TRAIT(I, TRAIT_NODROP) && !force)
 		return FALSE
+		
+	//skyrat change - unequip delays
+	if((I.item_flags & IN_INVENTORY) && I.strip_self_delay && ishuman(src))
+		var/mob/living/carbon/human/H = src
+		H.visible_message("<span class='notice'>[H] starts unequipping [I]...</span>", "<span class='notice'>You start unequipping [I]...</span>")
+		if(!do_after(H, I.strip_self_delay, TRUE, H))
+			return FALSE
+	//
 
 	var/hand_index = get_held_index_of_item(I)
 	if(hand_index)


### PR DESCRIPTION
## About The Pull Request

Basically allows all clothing to use a default equipping delay, calculated by self_equip_mod * equip_delay_other. This will only happen on initialize if use_standard_equip_delay is set to true.
Currently only used by space suits and hardsuits, other clothing types are unaffected, but the code let's you use the feature pretty much on any clothing.

**update:** Now backpacks also have equipping delays, and items can also use unequipping delays.

## Why It's Good For The Game

hardsuits and space suits should be clunky broje

## Changelog
:cl:
balance: Some types of clothing now have equipping and unequipping delays (only spacesuits, hardsuits and storage items for the moment).
/:cl:
