### PR TITLE
Show ckey on roundend stats preference 2.0

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -400,7 +400,9 @@
 	for (var/i in GLOB.ai_list)
 		var/mob/living/silicon/ai/aiPlayer = i
 		if(aiPlayer.mind)
-			parts += "<b>[aiPlayer.name]</b> (Played by: <b>[aiPlayer.mind.key]</b>)'s laws [aiPlayer.stat != DEAD ? "at the end of the round" : "when it was <span class='redtext'>deactivated</span>"] were:"
+//SKYRAT CHANGES
+			parts += "<b>[aiPlayer.name]</b> (Played by: <b>[aiPlayer.mind.appear_in_round_end_report ? aiPlayer.mind.key : "Unknown"]</b>)'s laws [aiPlayer.stat != DEAD ? "at the end of the round" : "when it was <span class='redtext'>deactivated</span>"] were:"
+//END OF SKYRAT CHANGES
 			parts += aiPlayer.laws.get_law_list(include_zeroth=TRUE)
 
 		parts += "<b>Total law changes: [aiPlayer.law_change_counter]</b>"
@@ -411,14 +413,18 @@
 			for(var/mob/living/silicon/robot/robo in aiPlayer.connected_robots)
 				borg_num--
 				if(robo.mind)
-					robolist += "<b>[robo.name]</b> (Played by: <b>[robo.mind.key]</b>)[robo.stat == DEAD ? " <span class='redtext'>(Deactivated)</span>" : ""][borg_num ?", ":""]<br>"
+//SKYRAT CHANGES
+					robolist += "<b>[robo.name]</b> (Played by: <b>[robo.mind.appear_in_round_end_report ? robo.mind.key : "Unknown"]</b>)[robo.stat == DEAD ? " <span class='redtext'>(Deactivated)</span>" : ""][borg_num ?", ":""]<br>"
+//END OF SKYRAT CHANGES
 			parts += "[robolist]"
 		if(!borg_spacer)
 			borg_spacer = TRUE
 
 	for (var/mob/living/silicon/robot/robo in GLOB.silicon_mobs)
 		if (!robo.connected_ai && robo.mind)
-			parts += "[borg_spacer?"<br>":""]<b>[robo.name]</b> (Played by: <b>[robo.mind.key]</b>) [(robo.stat != DEAD)? "<span class='greentext'>survived</span> as an AI-less borg!" : "was <span class='redtext'>unable to survive</span> the rigors of being a cyborg without an AI."] Its laws were:"
+//SKYRAT CHANGES
+			parts += "[borg_spacer?"<br>":""]<b>[robo.name]</b> (Played by: <b>[robo.mind.appear_in_round_end_report ? robo.mind.key : "Unknown"]</b>) [(robo.stat != DEAD)? "<span class='greentext'>survived</span> as an AI-less borg!" : "was <span class='redtext'>unable to survive</span> the rigors of being a cyborg without an AI."] Its laws were:"
+//END OF SKYRAT CHANGES
 
 			if(robo) //How the hell do we lose robo between here and the world messages directly above this?
 				parts += robo.laws.get_law_list(include_zeroth=TRUE)
@@ -527,7 +533,9 @@
 	var/jobtext = ""
 	if(ply.assigned_role)
 		jobtext = " the <b>[ply.assigned_role]</b>"
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
+//SKYRAT CHANGES
+	var/text = "<b>[ply.appear_in_round_end_report ? ply.key : "Unknown"]</b> was <b>[ply.name]</b>[jobtext] and"
+//END OF SKYRAT CHANGES
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " <span class='redtext'>died</span>"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -60,6 +60,10 @@
 	var/unconvertable = FALSE
 	var/late_joiner = FALSE
 
+//SKYRAT CHANGES
+	var/appear_in_round_end_report = TRUE  //Skyrat change
+//END OF SKYRAT CHANGES
+
 	var/force_escaped = FALSE  // Set by Into The Sunset command of the shuttle manipulator
 	var/list/learned_recipes //List of learned recipe TYPES.
 
@@ -134,6 +138,10 @@
 		var/mob/living/L = new_character
 		if(L.client?.prefs && L.client.prefs.auto_ooc && L.client.prefs.chat_toggles & CHAT_OOC)
 			DISABLE_BITFIELD(L.client.prefs.chat_toggles,CHAT_OOC)
+
+//SKYRAT CHANGES
+	appear_in_round_end_report = current.client?.prefs?.appear_in_round_end_report
+//END OF SKYRAT CHANGES
 
 	SEND_SIGNAL(src, COMSIG_MIND_TRANSFER, new_character, old_character)
 	SEND_SIGNAL(new_character, COMSIG_MOB_ON_NEW_MIND)
@@ -776,6 +784,9 @@
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src
+//SKYRAT CHANGES
+	mind.appear_in_round_end_report = client?.prefs?.appear_in_round_end_report
+//END OF SKYRAT CHANGES
 
 /mob/living/carbon/mind_initialize()
 	..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -124,6 +124,8 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 	var/maxdislikes = 3 //Skyrat additions END
 
 	var/list/alt_titles_preferences = list()
+
+	var/appear_in_round_end_report = TRUE //whether the player of the character is listed on the round-end report
 	//END OF SKYRAT CHANGES
 	var/underwear = "Nude"				//underwear type
 	var/undie_color = "FFF"
@@ -346,7 +348,10 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 			if(jobban_isbanned(user, "appearance"))
 				dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
 			dat += "<a style='display:block;width:100px' href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
-			dat += "<b>Always Random Name:</b><a style='display:block;width:30px' href='?_src_=prefs;preference=name'>[be_random_name ? "Yes" : "No"]</a><BR>"
+//SKYRAT CHANGES
+			dat += "<b>Always Random Name:</b> <a href='?_src_=prefs;preference=name'>[be_random_name ? "Yes" : "No"]</a><BR>"  //Skyrat change
+			dat += "<b>Show player name at round-end report:</b> <a href='?_src_=prefs;preference=appear_in_round_end_report'>[appear_in_round_end_report ? "Yes" : "No"]</a><BR>"  //Skyrat change
+//END OF SKYRAT CHANGES
 
 			dat += "<b>[nameless ? "Default designation" : "Name"]:</b>"
 			dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
@@ -2745,6 +2750,12 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 
 				if("name")
 					be_random_name = !be_random_name
+
+//SKYRAT CHANGES
+				if("appear_in_round_end_report")
+					appear_in_round_end_report = !appear_in_round_end_report
+					user.mind?.appear_in_round_end_report = appear_in_round_end_report
+//END OF SKYRAT CHANGES
 
 				if("all")
 					be_random_body = !be_random_body

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -89,6 +89,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 	var/show_credits = TRUE
 	var/event_participation = FALSE
 	var/event_prefs = ""
+	var/appear_in_round_end_report = TRUE //whether the player of the character is listed on the round-end report
 	// SKYRAT CHANGE END
 
 	var/uses_glasses_colour = 0
@@ -124,8 +125,6 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 	var/maxdislikes = 3 //Skyrat additions END
 
 	var/list/alt_titles_preferences = list()
-
-	var/appear_in_round_end_report = TRUE //whether the player of the character is listed on the round-end report
 	//END OF SKYRAT CHANGES
 	var/underwear = "Nude"				//underwear type
 	var/undie_color = "FFF"
@@ -348,10 +347,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 			if(jobban_isbanned(user, "appearance"))
 				dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
 			dat += "<a style='display:block;width:100px' href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
-//SKYRAT CHANGES
+//SKYRAT EDIT
 			dat += "<b>Always Random Name:</b> <a href='?_src_=prefs;preference=name'>[be_random_name ? "Yes" : "No"]</a><BR>"
-			dat += "<b>Show player name at round-end report:</b> <a href='?_src_=prefs;preference=appear_in_round_end_report'>[appear_in_round_end_report ? "Yes" : "No"]</a><BR>"
-//END OF SKYRAT CHANGES
+//END OF SKYRAT EDIT
 
 			dat += "<b>[nameless ? "Default designation" : "Name"]:</b>"
 			dat += "<a href='?_src_=prefs;preference=name;task=input'>[real_name]</a><BR>"
@@ -988,6 +986,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 			else
 				p_chaos = preferred_chaos
 			dat += "<b>Preferred Chaos Amount:</b> <a href='?_src_=prefs;preference=preferred_chaos;task=input'>[p_chaos]</a><br>"
+//SKYRAT CHANGES
+			dat += "<b>Show name at round-end report:</b> <a href='?_src_=prefs;preference=appear_in_round_end_report'>[appear_in_round_end_report ? "Yes" : "No"]</a><br>"
+//END OF SKYRAT CHANGES
 			dat += "<br>"
 			dat += "</td>"
 			dat += "</tr></table>"
@@ -2469,6 +2470,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 				if ("preferred_chaos")
 					var/pickedchaos = input(user, "Choose your preferred level of chaos. This will help with dynamic threat level ratings.", "Character Preference") as null|anything in list(CHAOS_NONE,CHAOS_LOW,CHAOS_MED,CHAOS_HIGH,CHAOS_MAX)
 					preferred_chaos = pickedchaos
+
 				if ("clientfps")
 					var/desiredfps = input(user, "Choose your desired fps. (0 = synced with server tick rate (currently:[world.fps]))", "Character Preference", clientfps)  as null|num
 					if (!isnull(desiredfps))
@@ -2725,6 +2727,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 					see_chat_emotes = !see_chat_emotes
 				if("enable_personal_chat_color")
 					enable_personal_chat_color = !enable_personal_chat_color
+				if("appear_in_round_end_report")
+					appear_in_round_end_report = !appear_in_round_end_report
+					user.mind?.appear_in_round_end_report = appear_in_round_end_report
 				//End of skyrat changes
 				if("action_buttons")
 					buttons_locked = !buttons_locked
@@ -2750,12 +2755,6 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 
 				if("name")
 					be_random_name = !be_random_name
-
-//SKYRAT CHANGES
-				if("appear_in_round_end_report")
-					appear_in_round_end_report = !appear_in_round_end_report
-					user.mind?.appear_in_round_end_report = appear_in_round_end_report
-//END OF SKYRAT CHANGES
 
 				if("all")
 					be_random_body = !be_random_body

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -349,8 +349,8 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 				dat += "<b>You are banned from using custom names and appearances. You can continue to adjust your characters, but you will be randomised once you join the game.</b><br>"
 			dat += "<a style='display:block;width:100px' href='?_src_=prefs;preference=name;task=random'>Random Name</A> "
 //SKYRAT CHANGES
-			dat += "<b>Always Random Name:</b> <a href='?_src_=prefs;preference=name'>[be_random_name ? "Yes" : "No"]</a><BR>"  //Skyrat change
-			dat += "<b>Show player name at round-end report:</b> <a href='?_src_=prefs;preference=appear_in_round_end_report'>[appear_in_round_end_report ? "Yes" : "No"]</a><BR>"  //Skyrat change
+			dat += "<b>Always Random Name:</b> <a href='?_src_=prefs;preference=name'>[be_random_name ? "Yes" : "No"]</a><BR>"
+			dat += "<b>Show player name at round-end report:</b> <a href='?_src_=prefs;preference=appear_in_round_end_report'>[appear_in_round_end_report ? "Yes" : "No"]</a><BR>"
 //END OF SKYRAT CHANGES
 
 			dat += "<b>[nameless ? "Default designation" : "Name"]:</b>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -455,6 +455,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["auto_hiss"]				>> auto_hiss
 	S["custom_species"]			>> custom_species
 	S["name_is_always_random"]	>> be_random_name
+//SKYRAT CHANGES
+	S["appear_in_round_end_report"]	>> appear_in_round_end_report
+//END OF SKYRAT CHANGES
 	S["body_is_always_random"]	>> be_random_body
 	S["gender"]					>> gender
 	S["body_model"]				>> features["body_model"]
@@ -593,6 +596,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	nameless		= sanitize_integer(nameless, 0, 1, initial(nameless))
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
+//SKYRAT CHANGES
+	appear_in_round_end_report	= sanitize_integer(appear_in_round_end_report, 0, 1, initial(appear_in_round_end_report))
+//END OF SKYRAT CHANGES
 	be_random_body	= sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
 
 	hair_style					= sanitize_inlist(hair_style, GLOB.hair_styles_list)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -282,6 +282,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["auto_ooc"]			>> auto_ooc
 	S["no_tetris_storage"]		>> no_tetris_storage
 
+//SKYRAT CHANGES
+	S["appear_in_round_end_report"]	>> appear_in_round_end_report
+//END OF SKYRAT CHANGES
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -332,6 +335,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	see_chat_emotes	= sanitize_integer(see_chat_emotes, 0, 1, initial(see_chat_emotes))
 	event_participation = sanitize_integer(event_participation, 0, 1, initial(event_participation))
 	event_prefs = sanitize_text(event_prefs)
+	appear_in_round_end_report	= sanitize_integer(appear_in_round_end_report, 0, 1, initial(appear_in_round_end_report))
 	//SKYRAT CHANGES END
 
 	return 1
@@ -406,6 +410,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["see_chat_emotes"], see_chat_emotes)
 	WRITE_FILE(S["event_participation"], event_participation)
 	WRITE_FILE(S["event_prefs"], event_prefs)
+	WRITE_FILE(S["appear_in_round_end_report"], appear_in_round_end_report)
 	//SKYRAT CHANGES END
 
 	return 1
@@ -455,9 +460,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["auto_hiss"]				>> auto_hiss
 	S["custom_species"]			>> custom_species
 	S["name_is_always_random"]	>> be_random_name
-//SKYRAT CHANGES
-	S["appear_in_round_end_report"]	>> appear_in_round_end_report
-//END OF SKYRAT CHANGES
 	S["body_is_always_random"]	>> be_random_body
 	S["gender"]					>> gender
 	S["body_model"]				>> features["body_model"]
@@ -596,9 +598,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	nameless		= sanitize_integer(nameless, 0, 1, initial(nameless))
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
-//SKYRAT CHANGES
-	appear_in_round_end_report	= sanitize_integer(appear_in_round_end_report, 0, 1, initial(appear_in_round_end_report))
-//END OF SKYRAT CHANGES
 	be_random_body	= sanitize_integer(be_random_body, 0, 1, initial(be_random_body))
 
 	hair_style					= sanitize_inlist(hair_style, GLOB.hair_styles_list)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -238,6 +238,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["see_chat_emotes"] 	>> see_chat_emotes
 	S["event_participation"] >> event_participation
 	S["event_prefs"] >> event_prefs
+	S["appear_in_round_end_report"]	>> appear_in_round_end_report
 	//SKYRAT CHANGES END
 
 
@@ -281,10 +282,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["preferred_chaos"]	>> preferred_chaos
 	S["auto_ooc"]			>> auto_ooc
 	S["no_tetris_storage"]		>> no_tetris_storage
-
-//SKYRAT CHANGES
-	S["appear_in_round_end_report"]	>> appear_in_round_end_report
-//END OF SKYRAT CHANGES
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -52,6 +52,10 @@
 				var/datum/callback/CB = foo
 				CB.Invoke()
 
+//SKYRAT CHANGES
+	mind?.appear_in_round_end_report = client?.prefs?.appear_in_round_end_report
+//END OF SKYRAT CHANGES
+
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)
 	SEND_SIGNAL(src, COMSIG_MOB_CLIENT_LOGIN, client)
 


### PR DESCRIPTION
Redid #2127

Fixes these issues on the other PR:
* Includes silicons.
* Uses the associative list pref format, which is more easily reversible.
* Keeps the ckeys in the database, which is, unless disclosed, server/admin only.
* Works even if the client disconnects.

This PR doesn't include the name list, and instead defaults the hidden user to "Unknown". A list of spoofed ckeys can be added later if needed.