### PR TITLE
Less LRP Mice/Sentient Announcement

### DIFF
--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -8,22 +8,17 @@
 	var/maximum_mice = 15
 
 /datum/round_event/mice_migration/announce(fake)
-	var/cause = pick("space-winter", "budget-cuts", "Ragnarok",
-		"space being cold", "\[REDACTED\]", "climate change",
-		"bad luck")
 	var/plural = pick("a number of", "a horde of", "a pack of", "a swarm of",
-		"a whoop of", "not more than [maximum_mice]")
-	var/name = pick("rodents", "mice", "squeaking things",
-		"wire eating mammals", "\[REDACTED\]", "energy draining parasites")
-	var/movement = pick("migrated", "swarmed", "stampeded", "descended")
-	var/location = pick("maintenance tunnels", "maintenance areas",
-		"\[REDACTED\]", "place with all those juicy wires")
+		"not more than [maximum_mice]")
+	var/name = pick("rodents", "mice")
+	var/movement = pick("migrated", "swarmed", "descended")
+	var/location = pick("maintenance tunnels", "maintenance areas")
 	if(prob(50))
-		priority_announce("Due to [cause], [plural] [name] have [movement] \
-		into the [location].", "Migration Alert",
+		priority_announce("Bioscans indicate that [plural] [name] have [movement] \
+		into [location].", "Migration Alert",
 		'sound/effects/mousesqueek.ogg')
 	else
-		print_command_report("Due to [cause], [plural] [name] have [movement] into the [location].", "Rodent Migration")
+		print_command_report("Bioscans indicate that [plural] [name] have [movement] into [location].", "Rodent Migration")
 
 /datum/round_event/mice_migration/start()
 	SSminor_mapping.trigger_migration(rand(minimum_mice, maximum_mice))

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -7,7 +7,7 @@
 	var/minimum_mice = 5
 	var/maximum_mice = 15
 
-/datum/round_event/mice_migration/announce(fake)
+/datum/round_event/mice_migration/announce(fake) //Skyrat change start
 	var/plural = pick("a number of", "a horde of", "a pack of", "a swarm of",
 		"not more than [maximum_mice]")
 	var/name = pick("rodents", "mice")
@@ -18,7 +18,7 @@
 		into [location].", "Migration Alert",
 		'sound/effects/mousesqueek.ogg')
 	else
-		print_command_report("Bioscans indicate that [plural] [name] have [movement] into [location].", "Rodent Migration") //Skyrat change
+		print_command_report("Bioscans indicate that [plural] [name] have [movement] into [location].", "Rodent Migration") //Skyrat change end
 
 /datum/round_event/mice_migration/start()
 	SSminor_mapping.trigger_migration(rand(minimum_mice, maximum_mice))

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -18,7 +18,7 @@
 		into [location].", "Migration Alert",
 		'sound/effects/mousesqueek.ogg')
 	else
-		print_command_report("Bioscans indicate that [plural] [name] have [movement] into [location].", "Rodent Migration")
+		print_command_report("Bioscans indicate that [plural] [name] have [movement] into [location].", "Rodent Migration") //Skyrat change
 
 /datum/round_event/mice_migration/start()
 	SSminor_mapping.trigger_migration(rand(minimum_mice, maximum_mice))

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -19,7 +19,7 @@
 	//Skyrat change start
 	var/data = pick("Bioscans", "a recent Bioscan")
 	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms",)
-	var/strength = pick("human", "moderate", "lizard", "security", "command", "clown", "low", "very low", "sergal", "anthropromorph", "xenomorph", "alien", "shadowperson", "slime", "dwarf", "slimeperson", "catgirl", "felinid")
+	var/strength = pick("human", "moderate", "security", "command", "clown", "low", "very low", "alien")
 	//Skyrat change stop
 
 	sentience_report += "Based on [data], we believe that [one] of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -16,9 +16,11 @@
 /datum/round_event/ghost_role/sentience/announce(fake)
 	var/sentience_report = ""
 
+	//Skyrat change start
 	var/data = pick("Bioscans", "a recent Bioscan")
 	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms",)
 	var/strength = pick("human", "moderate", "lizard", "security", "command", "clown", "low", "very low", "sergal", "anthropromorph", "xenomorph", "alien", "shadowperson", "slime", "dwarf", "slimeperson", "catgirl", "felinid")
+	//Skyrat change stop
 
 	sentience_report += "Based on [data], we believe that [one] of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
 

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -16,9 +16,9 @@
 /datum/round_event/ghost_role/sentience/announce(fake)
 	var/sentience_report = ""
 
-	var/data = pick("scans from our long-range sensors", "our sophisticated probabilistic models", "our omnipotence", "the communications traffic on your station", "energy emissions we detected", "\[REDACTED\]")
-	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms", "\[REDACTED\]")
-	var/strength = pick("human", "moderate", "lizard", "security", "command", "clown", "low", "very low", "\[REDACTED\]")
+	var/data = pick("Bioscans", "a recent Bioscan")
+	var/pets = pick("animals/bots", "bots/animals", "pets", "simple animals", "lesser lifeforms",)
+	var/strength = pick("human", "moderate", "lizard", "security", "command", "clown", "low", "very low", "sergal", "anthropromorph", "xenomorph", "alien", "shadowperson", "slime", "dwarf", "slimeperson", "catgirl", "felinid")
 
 	sentience_report += "Based on [data], we believe that [one] of the station's [pets] has developed [strength] level intelligence, and the ability to communicate."
 


### PR DESCRIPTION
## About The Pull Request

This makes the mice announcement less immersion breaking. [REDACTED] feels too much a of a meme to use at this point and theres legit no reason to hide this kind of information in reports. 

The sentience command report is an absolute clusterfuck. No entity will ever achieve omnipotence or omniscience. Claiming that is extremely iffy.

Also SMH space is cold.. yeah it is. But that doesnt matter at all for said event. 

## Why It's Good For The Game

Yeah so TG has a bunch of announcements that feel out of place. They even claim omniscience and omnipotence in one. No. Nobody is ever either of that. People claiming they are have a slew of other issues. This fixes the Mice Event and sentience event to have less of an LRP feel to it in the command report. Sorry it always bothered me how these events by that particular person from TG were set up. It also adds more words for the sentience events.

## Changelog
:cl:
fix: Centcomm fired the guy responsible for making the automated announcement messages regarding rodent infestations and sentience for being massively unhinged.
/:cl:


