### PR TITLE
Brings Overthrow Objective more in line with server principles

### DIFF
--- a/code/game/gamemodes/overthrow/objective.dm
+++ b/code/game/gamemodes/overthrow/objective.dm
@@ -71,7 +71,7 @@
 	if(targets.len)
 		explanation_text = "Work with your team to convert, exile or kill "
 		explanation_text += english_list(targets)
-		explanation_text += ". Converting to your team will give you more points, whereas killing will give you the least. Syndicates don't want to stir up too many troubles."
+		explanation_text += ". Converting to your team will give you more points, whereas killing will give you the least. Syndicates don't want to stir up too many troubles. Permanent termination/killing of target IS NOT required or wanted." //skyrats change
 	else
 		explanation_text = "Wait until any heads arrive. Once that happens, check your objectives again to see the updated objective. It may require around [OBJECTIVE_UPDATING_TIME] seconds to update."
 
@@ -134,7 +134,7 @@
 
 /datum/objective/overthrow/target/update_explanation_text()
 	if(target)
-		explanation_text = "Work with your team to convert, exile or kill [target.name], the [target.assigned_role]. Converting to your team will give you more points, whereas killing will give you the least. Syndicates don't want to stir up too many troubles."
+		explanation_text = "Work with your team to convert, exile or kill [target.name], the [target.assigned_role]. Converting to your team will give you more points, whereas killing will give you the least. Syndicates don't want to stir up too many troubles. Permanent termination/killing of target IS NOT required or wanted." //skyrats change
 	else
 		explanation_text = "Nothing."
 


### PR DESCRIPTION
## About The Pull Request

Every other antag that is in rotation got their hard assassination objectives stripped off of them. It always said "Kill Once" in other objectives translating to not permakilling the dude. We have blackout memory loss in place and if people remember their killer after death that can be acted upon. Even changeling absorbs can be cloned when the cloner is upgraded aslong the corpse is either a head or a husk with  head with a brain in it. 

For a matter of fact the check if the people are dead or converted does not properly work. It seemingly autocompletes. But thats besides the point since greentext should be removed from any and all antags. Not the scope of this PR though.

## Why It's Good For The Game

Permakill man bad. For real though, brings overthrow more in line with the other antags objectives. Doesnt change the fact that rigid objectives are bad and somewhere down the line an 'set ambition' verb with accessable exploitable info should be done.

## Changelog
:cl:
tweak: Wording on Overthrow objective changed making it far more clearer that permakilling is not required nor actually wanted.
/:cl:


