### PR TITLE
Add delay to wheelchair unbuckling

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -68,6 +68,14 @@
 	..()
 	handle_rotation(newdir)
 
+/obj/vehicle/ridden/wheelchair/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
+	if(has_buckled_mobs())
+		user.visible_message("<span class='warning'>[user] starts undoing the straps of the wheelchair.</span>")
+		if(do_mob(user, src, 20))
+			. = ..()
+		else
+			user.visible_message("<span class='warning'>[user] has stopped undoing the straps of the wheelchair.</span>")
+
 /obj/vehicle/ridden/wheelchair/wrench_act(mob/living/user, obj/item/I)	//Attackby should stop it attacking the wheelchair after moving away during decon
 	to_chat(user, "<span class='notice'>You begin to detach the wheels...</span>")
 	if(I.use_tool(src, user, 40, volume=50))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rewritten version of https://github.com/JGlitch/Citadel-Station-13-RP/commit/aa854a0fe0b1c60eec4b7c1191c6d7e2aa55ffa3#diff-8a3cbbef6084270e35382fc04b509adc
Adds a mob_do() delay before unbuckling someone from the wheelchair.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People don't just fall down from a wheelchair in .001s
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added delay to wheelchair unbuckling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
