### PR TITLE
[WIP] Nerfs Abductor glands.

### DIFF
--- a/code/modules/antagonists/abductor/equipment/glands/transform.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/transform.dm
@@ -1,15 +1,9 @@
 /obj/item/organ/heart/gland/transform
-	true_name = "anthropmorphic transmorphosizer"
+	true_name = "Psychic Domination Device" //Cheap RA2 ref, Skyrats change start
 	cooldown_low = 900
 	cooldown_high = 1800
-	uses = -1
+	uses = 0
 	human_only = TRUE
 	icon_state = "species"
 	mind_control_uses = 7
-	mind_control_duration = 300
-
-/obj/item/organ/heart/gland/transform/activate()
-	to_chat(owner, "<span class='notice'>You feel unlike yourself.</span>")
-	randomize_human(owner)
-	var/species = pick(list(/datum/species/human, /datum/species/lizard, /datum/species/insect, /datum/species/fly))
-	owner.set_species(species)
+	mind_control_duration = 2000 //skyrats change end

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -10,6 +10,6 @@
 /obj/item/organ/heart/gland/trauma/activate()
 	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
 	if(prob(33))
-		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
+		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_BASIC)
 	else
-		owner.gain_trauma_type(BRAIN_TRAUMA_MILD)	//skyrats change end
+		owner.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_BASIC)	//skyrats change end

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -2,7 +2,7 @@
 	true_name = "white matter randomiser"
 	cooldown_low = 800
 	cooldown_high = 1200
-	uses = 3
+	uses = 3	//skyrats change start						
 	icon_state = "emp"
 	mind_control_uses = 3
 	mind_control_duration = 1800
@@ -12,4 +12,4 @@
 	if(prob(33))
 		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 	else
-		owner.gain_trauma_type(BRAIN_TRAUMA_MILD)
+		owner.gain_trauma_type(BRAIN_TRAUMA_MILD)	//skyrats change end

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -2,7 +2,7 @@
 	true_name = "white matter randomiser"
 	cooldown_low = 800
 	cooldown_high = 1200
-	uses = 5
+	uses = 3
 	icon_state = "emp"
 	mind_control_uses = 3
 	mind_control_duration = 1800
@@ -10,9 +10,6 @@
 /obj/item/organ/heart/gland/trauma/activate()
 	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
 	if(prob(33))
-		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_SURGERY))
+		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 	else
-		if(prob(20))
-			owner.gain_trauma_type(BRAIN_TRAUMA_SEVERE, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_SURGERY))
-		else
-			owner.gain_trauma_type(BRAIN_TRAUMA_MILD, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_SURGERY))
+		owner.gain_trauma_type(BRAIN_TRAUMA_MILD)

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -9,7 +9,4 @@
 
 /obj/item/organ/heart/gland/trauma/activate()
 	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
-	if(prob(33))
-		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_BASIC)
-	else
-		owner.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_BASIC)	//skyrats change end
+	owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_BASIC)


### PR DESCRIPTION
Yeah no.

## About The Pull Request

WIP. This PR is to make abductors less "I am going to cryo now because these cunts gave me trauma gland and that rolled me permanent stupor/split personality because bad RNG". For a matter of fact split personality is gone from that trauma gland altogether. So you either get quirky/interesting traumas or 'mild' traumas which are braindead easy to fix thanks to removal of surgery reqs.

On the other hand it neuters the species gland. It currently has infinite uses. Once the change is put into place it is renamed to "Psychic Domination" gland and has tweaked values but it will not change your species any longer.

This does not change the abduction trauma, since this one can only roll for "surgery" severity and removal via surgery usually cascades into side effects. If the "surgery" severity gets neutered taking a pill of neurine would cure that.

## Why It's Good For The Game

Lets see. When KnC (Kill and Clone) is a valid strategy to deal with a shitty mechanic it should be changed so KnC is no longer a valid strategy. Specially when you roll permanent/quasi permanent split personality. Thats massively shit. Species Transformation should NOT be permanent. Transformation is "I guess I cryo" material on a server about having highly customizeable characters. At most it should be random and temporary. Also transformation is a kink apparently. Not everyone is into that. 

## How does it work?

The Trauma gland rolls with 33 (?) percent chance for a special trauma and randomly chooses if its basic or surgery in case of severity. If that roll fails it rolls a 22 (?) percent chance for a severe trauma (This includes split personality) which is then randomly chosen to be basic (Neurine) or surgery. If that roll fails it defaults to a mild trauma with random assignment of basic severity or surgery. Brain surgery can and will fail causing massive braindamage resulting in further traumas.

No need to explain why this is bad but alas I still do: Severe (Surgery) traumas need surgery or nanites. If surgery fails it causes braindamage: This gives further traumas, including deep rooted ones. Deep rooted requires lobotomy or KnC. Lobotomy has a chance to turn deep rooted into permanent. Permanent is only fixable with KnC. Its not fun to be on the receiving end of stupor or split personality and constantly talking nonesense or do things that are highly out of character because you rolled a chad for a split.

What this will do: Removes severe traumas. Removes random roll between deep rooted or permanent.

The species gland has currently infinite uses.. No. Just no.  Removes species randomizer in the species gland. Buffed mind control duration, left mind control usage at 7. So abductors got a really powerful tool now to get several people into doing things for them. 

## Changelog
:cl:
tweak: Abductors are now less shit for the abductee. Several (Species and Trauma) "I go cryo now" tier glands have been nerfed hard. 
/:cl:


