### PR TITLE
Add missing vox-n2 check for clown box

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -782,10 +782,16 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/reagent_containers/hypospray/medipen(src)
 
-	if(!isplasmaman(loc))
-		new /obj/item/tank/internals/emergency_oxygen(src)
-	else
+	// Skyrat change: check for different race first, else give oxy internals
+	if(isplasmaman(loc))
 		new /obj/item/tank/internals/plasmaman/belt(src)
+		return
+		
+	if(isvox(loc)) // Skyrat change: Nitrogen internals for Vox
+		new /obj/item/tank/internals/nitrogen/belt(src)
+		return
+
+	new /obj/item/tank/internals/emergency_oxygen(src)
 
 /obj/item/storage/box/rubbershot
 	name = "box of rubber shots"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
does as it says on the tin

~~also holy fuck i hate the box file. copy paste galore for now~~
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
mimes are better but lets not blame that on the vox
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix clown vox spawning without n2 in their box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
