### PR TITLE
[READY] Fixes missing trek icons

### DIFF
--- a/modular_skyrat/code/modules/clothing/refactor.dm
+++ b/modular_skyrat/code/modules/clothing/refactor.dm
@@ -619,7 +619,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_ALL_TAURIC|STYLE_NO_ANTHRO_ICON
 	taur_mob_worn_overlay = 'modular_skyrat/icons/mob/suits_taur.dmi'
 
-// Reskinnable Trek uniforms, now using Orvi-like by default.
+// Reskinnable Trek uniforms
 /obj/item/clothing/under/trek/command
 	name = "enterprise command uniform"
 	desc = "An enterprise corps uniform worn by command officers."

--- a/modular_skyrat/code/modules/clothing/refactor.dm
+++ b/modular_skyrat/code/modules/clothing/refactor.dm
@@ -624,7 +624,7 @@
 	name = "enterprise command uniform"
 	desc = "An enterprise corps uniform worn by command officers."
 	unique_reskin_icons = list(
-	"Orvi-like" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
+	"Orvlike" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
 	"The Original Series" = 'icons/obj/clothing/uniforms.dmi',
 	"The New Generation" = 'icons/obj/clothing/uniforms.dmi',
 	"Voyager" = 'icons/obj/clothing/uniforms.dmi',
@@ -632,7 +632,7 @@
 	"Enterprise" = 'icons/obj/clothing/uniforms.dmi'
 	)
 	unique_reskin_worn = list(
-	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
+	"Orvlike" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform.dmi',
@@ -640,7 +640,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform.dmi'
 	)
 	unique_reskin_worn_anthro = list(
-	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
+	"Orvlike" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform_digi.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform_digi.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform_digi.dmi',
@@ -648,7 +648,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform_digi.dmi'
 	)
 	unique_reskin = list(
-	"Orvi-like" = "orv_com",
+	"Orvlike" = "orv_com",
 	"The Original Series" = "trek_command",
 	"The New Generation" = "trek_next_command",
 	"Voyager" = "trek_voy_command",
@@ -656,7 +656,7 @@
 	"Enterprise" = "trek_ent_command"
 	)
 	unique_desc = list(
-	"Orvi-like" = "An uniform worn by command officers since 2420s.",
+	"Orvlike" = "An uniform worn by command officers since 2420s.",
 	"The Original Series" = "An uniform worn by command officers in the mid 2260s.",
 	"The New Generation" = "An uniform worn by command officers. This one is from the mid 2360s.",
 	"Voyager" = "An uniform worn by command officers of the 2370s.",
@@ -668,7 +668,7 @@
 	name = "enterprise operations uniform"
 	desc = "An enterprise corps uniform worn by operations officers."
 	unique_reskin_icons = list(
-	"Orvi-like" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
+	"Orvlike" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
 	"The Original Series" = 'icons/obj/clothing/uniforms.dmi',
 	"The New Generation" = 'icons/obj/clothing/uniforms.dmi',
 	"Voyager" = 'icons/obj/clothing/uniforms.dmi',
@@ -676,7 +676,7 @@
 	"Enterprise" = 'icons/obj/clothing/uniforms.dmi'
 	)
 	unique_reskin_worn = list(
-	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
+	"Orvlike" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform.dmi',
@@ -684,7 +684,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform.dmi'
 	)
 	unique_reskin_worn_anthro = list(
-	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
+	"Orvlike" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform_digi.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform_digi.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform_digi.dmi',
@@ -692,7 +692,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform_digi.dmi'
 	)
 	unique_reskin = list(
-	"Orvi-like" = "orv_ops",
+	"Orvlike" = "orv_ops",
 	"The Original Series" = "trek_engsec",
 	"The New Generation" = "trek_next_engsec",
 	"Voyager" = "trek_voy_engsec",
@@ -700,7 +700,7 @@
 	"Enterprise" = "trek_ent_engsec"
 	)
 	unique_desc = list(
-	"Orvi-like" = "An uniform worn by operations officers since 2420s.",
+	"Orvlike" = "An uniform worn by operations officers since 2420s.",
 	"The Original Series" = "An uniform worn by operations officers in the mid 2260s. You feel strangely vulnerable just seeing this...",
 	"The New Generation" = "An uniform worn by operations officers. This one is from the mid 2360s.",
 	"Voyager" = "An uniform worn by operations officers of the 2370s.",
@@ -712,7 +712,7 @@
 	name = "enterprise medsci uniform"
 	desc = "An enterprise corps uniform worn by medsci officers."
 	unique_reskin_icons = list(
-	"Orvi-like" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
+	"Orvlike" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
 	"The Original Series" = 'icons/obj/clothing/uniforms.dmi',
 	"The New Generation" = 'icons/obj/clothing/uniforms.dmi',
 	"Voyager" = 'icons/obj/clothing/uniforms.dmi',
@@ -720,7 +720,7 @@
 	"Enterprise" = 'icons/obj/clothing/uniforms.dmi'
 	)
 	unique_reskin_worn = list(
-	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
+	"Orvlike" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform.dmi',
@@ -728,7 +728,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform.dmi'
 	)
 	unique_reskin_worn_anthro = list(
-	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
+	"Orvlike" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform_digi.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform_digi.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform_digi.dmi',
@@ -736,7 +736,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform_digi.dmi'
 	)
 	unique_reskin = list(
-	"Orvi-like" = "orv_medsci",
+	"Orvlike" = "orv_medsci",
 	"The Original Series" = "trek_medsci",
 	"The New Generation" = "trek_next_medsci",
 	"Voyager" = "trek_voy_medsci",
@@ -744,7 +744,7 @@
 	"Enterprise" = "trek_ent_medsci"
 	)
 	unique_desc = list(
-	"Orvi-like" = "An uniform worn by medsci officers since 2420s.",
+	"Orvlike" = "An uniform worn by medsci officers since 2420s.",
 	"The Original Series" = "An uniform worn by medsci officers in the mid 2260s.",
 	"The New Generation" = "An uniform worn by medsci officers. This one is from the mid 2360s.",
 	"Voyager" = "An uniform worn by medsci officers of the 2370s.",

--- a/modular_skyrat/code/modules/clothing/refactor.dm
+++ b/modular_skyrat/code/modules/clothing/refactor.dm
@@ -623,12 +623,8 @@
 /obj/item/clothing/under/trek/command
 	name = "enterprise command uniform"
 	desc = "An enterprise corps uniform worn by command officers."
-	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
-	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
-	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
-	icon_state = "orv_com"
 	unique_reskin_icons = list(
-	"Default" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
 	"The Original Series" = 'icons/obj/clothing/uniforms.dmi',
 	"The New Generation" = 'icons/obj/clothing/uniforms.dmi',
 	"Voyager" = 'icons/obj/clothing/uniforms.dmi',
@@ -636,7 +632,7 @@
 	"Enterprise" = 'icons/obj/clothing/uniforms.dmi'
 	)
 	unique_reskin_worn = list(
-	"Default" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform.dmi',
@@ -644,7 +640,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform.dmi'
 	)
 	unique_reskin_worn_anthro = list(
-	"Default" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform_digi.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform_digi.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform_digi.dmi',
@@ -652,7 +648,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform_digi.dmi'
 	)
 	unique_reskin = list(
-	"Default" = "orv_com",
+	"Orvi-like" = "orv_com",
 	"The Original Series" = "trek_command",
 	"The New Generation" = "trek_next_command",
 	"Voyager" = "trek_voy_command",
@@ -660,7 +656,7 @@
 	"Enterprise" = "trek_ent_command"
 	)
 	unique_desc = list(
-	"Default" = "An uniform worn by command officers since 2420s.",
+	"Orvi-like" = "An uniform worn by command officers since 2420s.",
 	"The Original Series" = "An uniform worn by command officers in the mid 2260s.",
 	"The New Generation" = "An uniform worn by command officers. This one is from the mid 2360s.",
 	"Voyager" = "An uniform worn by command officers of the 2370s.",
@@ -671,12 +667,8 @@
 /obj/item/clothing/under/trek/engsec
 	name = "enterprise operations uniform"
 	desc = "An enterprise corps uniform worn by operations officers."
-	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
-	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
-	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
-	icon_state = "orv_ops"
 	unique_reskin_icons = list(
-	"Default" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
 	"The Original Series" = 'icons/obj/clothing/uniforms.dmi',
 	"The New Generation" = 'icons/obj/clothing/uniforms.dmi',
 	"Voyager" = 'icons/obj/clothing/uniforms.dmi',
@@ -684,7 +676,7 @@
 	"Enterprise" = 'icons/obj/clothing/uniforms.dmi'
 	)
 	unique_reskin_worn = list(
-	"Default" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform.dmi',
@@ -692,7 +684,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform.dmi'
 	)
 	unique_reskin_worn_anthro = list(
-	"Default" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform_digi.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform_digi.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform_digi.dmi',
@@ -700,7 +692,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform_digi.dmi'
 	)
 	unique_reskin = list(
-	"Default" = "orv_ops",
+	"Orvi-like" = "orv_ops",
 	"The Original Series" = "trek_engsec",
 	"The New Generation" = "trek_next_engsec",
 	"Voyager" = "trek_voy_engsec",
@@ -708,7 +700,7 @@
 	"Enterprise" = "trek_ent_engsec"
 	)
 	unique_desc = list(
-	"Default" = "An uniform worn by operations officers since 2420s.",
+	"Orvi-like" = "An uniform worn by operations officers since 2420s.",
 	"The Original Series" = "An uniform worn by operations officers in the mid 2260s. You feel strangely vulnerable just seeing this...",
 	"The New Generation" = "An uniform worn by operations officers. This one is from the mid 2360s.",
 	"Voyager" = "An uniform worn by operations officers of the 2370s.",
@@ -719,12 +711,8 @@
 /obj/item/clothing/under/trek/medsci
 	name = "enterprise medsci uniform"
 	desc = "An enterprise corps uniform worn by medsci officers."
-	icon = 'modular_skyrat/icons/obj/clothing/uniform.dmi'
-	mob_overlay_icon = 'modular_skyrat/icons/mob/clothing/uniform.dmi'
-	anthro_mob_worn_overlay = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi'
-	icon_state = "orv_medsci"
 	unique_reskin_icons = list(
-	"Default" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/obj/clothing/uniform.dmi',
 	"The Original Series" = 'icons/obj/clothing/uniforms.dmi',
 	"The New Generation" = 'icons/obj/clothing/uniforms.dmi',
 	"Voyager" = 'icons/obj/clothing/uniforms.dmi',
@@ -732,7 +720,7 @@
 	"Enterprise" = 'icons/obj/clothing/uniforms.dmi'
 	)
 	unique_reskin_worn = list(
-	"Default" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform.dmi',
@@ -740,7 +728,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform.dmi'
 	)
 	unique_reskin_worn_anthro = list(
-	"Default" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
+	"Orvi-like" = 'modular_skyrat/icons/mob/clothing/uniform_digi.dmi',
 	"The Original Series" = 'icons/mob/clothing/uniform_digi.dmi',
 	"The New Generation" = 'icons/mob/clothing/uniform_digi.dmi',
 	"Voyager" = 'icons/mob/clothing/uniform_digi.dmi',
@@ -748,7 +736,7 @@
 	"Enterprise" = 'icons/mob/clothing/uniform_digi.dmi'
 	)
 	unique_reskin = list(
-	"Default" = "orv_medsci",
+	"Orvi-like" = "orv_medsci",
 	"The Original Series" = "trek_medsci",
 	"The New Generation" = "trek_next_medsci",
 	"Voyager" = "trek_voy_medsci",
@@ -756,7 +744,7 @@
 	"Enterprise" = "trek_ent_medsci"
 	)
 	unique_desc = list(
-	"Default" = "An uniform worn by medsci officers since 2420s.",
+	"Orvi-like" = "An uniform worn by medsci officers since 2420s.",
 	"The Original Series" = "An uniform worn by medsci officers in the mid 2260s.",
 	"The New Generation" = "An uniform worn by medsci officers. This one is from the mid 2360s.",
 	"Voyager" = "An uniform worn by medsci officers of the 2370s.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes missing trek uniforms (the ones that are downward of trek).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
MISSING ICONS ARE BAD
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Anonymous
fix: Fixes missing trek uniforms that wasn't TOS by object path. This will, however, revert default appearance of enterprise corp uniforms (cmd/medsci/ops) back to TOS-era. Use reskinning!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

~~Remind me to not use VSCode to put PRs~~