### PR TITLE
Ambitions and Objectives

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -56,6 +56,10 @@
 #define ADMIN_SET_SD_CODE "(<a href='?_src_=holder;[HrefToken(TRUE)];set_selfdestruct_code=1'>SETCODE</a>)"
 #define ADMIN_FULLMONTY_NONAME(user) "[ADMIN_QUE(user)] [ADMIN_PP(user)] [ADMIN_VV(user)] [ADMIN_SM(user)] [ADMIN_FLW(user)] [ADMIN_TP(user)] [ADMIN_INDIVIDUALLOG(user)] [ADMIN_SMITE(user)]"
 #define ADMIN_FULLMONTY(user) "[key_name_admin(user)] [ADMIN_FULLMONTY_NONAME(user)]"
+//SKYRAT CHANGES BEGIN
+#define ADMIN_TPMONTY_NONAME(user) "[ADMIN_QUE(user)] [ADMIN_JMP(user)] [ADMIN_FLW(user)]"
+#define ADMIN_TPMONTY(user) "[key_name_admin(user)] [ADMIN_TPMONTY_NONAME(user)]"
+//SKYRAT CHANGES END
 #define ADMIN_JMP(src) "(<a href='?_src_=holder;[HrefToken(TRUE)];adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)"
 #define COORD(src) "[src ? "([src.x],[src.y],[src.z])" : "nonexistent location"]"
 #define AREACOORD(src) "[src ? "[get_area_name(src, TRUE)] ([src.x], [src.y], [src.z])" : "nonexistent location"]"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -81,3 +81,9 @@
 #define BLOB_SPREAD_COST 4
 #define BLOB_ATTACK_REFUND 3 //blob refunds this much if it attacks and doesn't spread also SKYRAT CHANGE FROM 2
 #define BLOB_REFLECTOR_COST 15
+
+//Objectives-Ambitions Panel
+#define REQUEST_NEW_OBJECTIVE "new_objective"
+#define REQUEST_DEL_OBJECTIVE "del_objective"
+#define REQUEST_WIN_OBJECTIVE "win_objective"
+#define REQUEST_LOSE_OBJECTIVE "lose_objective"

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -28,6 +28,7 @@
 //INDEXES
 #define COOLDOWN_AMBITION	"ambition"
 #define COOLDOWN_OBJECTIVES	"objectives"
+#define COOLDOWN_OBJ_ADMIN_PING	"obj_admin_ping"
 
 
 //TIMER COOLDOWN MACROS

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -7,6 +7,7 @@
 
 //INDEXES
 #define COOLDOWN_AMBITION	"ambition"
+#define COOLDOWN_OBJECTIVES	"objectives"
 
 //MACROS
 #define COOLDOWN_START(cd_source, cd_index, cd_time) LAZYSET(cd_source.cooldowns, cd_index, addtimer(CALLBACK(GLOBAL_PROC, /proc/end_cooldown, cd_source, cd_index), cd_time))

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -1,17 +1,71 @@
+//// COOLDOWN SYSTEMS
+/*
+ * We have 2 cooldown systems: timer cooldowns (divided between stoppable and regular) and world.time cooldowns.
+ *
+ * When to use each?
+ *
+ * * Adding a commonly-checked cooldown, like on a subsystem to check for processing
+ * * * Use the world.time ones, as they are cheaper.
+ *
+ * * Adding a rarely-used one for special situations, such as giving an uncommon item a cooldown on a target.
+ * * * Timer cooldown, as adding a new variable on each mob to track the cooldown of said uncommon item is going too far.
+ *
+ * * Triggering events at the end of a cooldown.
+ * * * Timer cooldown, registering to its signal.
+ *
+ * * Being able to check how long left for the cooldown to end.
+ * * * Either world.time or stoppable timer cooldowns, depending on the other factors. Regular timer cooldowns do not support this.
+ *
+ * * Being able to stop the timer before it ends.
+ * * * Either world.time or stoppable timer cooldowns, depending on the other factors. Regular timer cooldowns do not support this.
+*/
+
+
 /*
  * Cooldown system based on an datum-level associative lazylist using timers.
- * If you are running hot procs that require high performance, checking world.time directly through a variable will always be faster.
- * If you are not, then this should be fine to use, it's not very expensive.
- * If you want a stoppable timer either make new macros or use a different system. Do not make every timer stoppable, that increases performance cost.
 */
 
 //INDEXES
 #define COOLDOWN_AMBITION	"ambition"
 #define COOLDOWN_OBJECTIVES	"objectives"
 
-//MACROS
-#define COOLDOWN_START(cd_source, cd_index, cd_time) LAZYSET(cd_source.cooldowns, cd_index, addtimer(CALLBACK(GLOBAL_PROC, /proc/end_cooldown, cd_source, cd_index), cd_time))
 
-#define COOLDOWN_CHECK(cd_source, cd_index) LAZYACCESS(cd_source.cooldowns, cd_index)
+//TIMER COOLDOWN MACROS
 
-#define COOLDOWN_END(cd_source, cd_index) LAZYREMOVE(cd_source.cooldowns, cd_index)
+#define COMSIG_CD_STOP(cd_index) "cooldown_[cd_index]"
+#define COMSIG_CD_RESET(cd_index) "cd_reset_[cd_index]"
+
+#define TIMER_COOLDOWN_START(cd_source, cd_index, cd_time) LAZYSET(cd_source.cooldowns, cd_index, addtimer(CALLBACK(GLOBAL_PROC, /proc/end_cooldown, cd_source, cd_index), cd_time))
+
+#define TIMER_COOLDOWN_CHECK(cd_source, cd_index) LAZYACCESS(cd_source.cooldowns, cd_index)
+
+#define TIMER_COOLDOWN_END(cd_source, cd_index) LAZYREMOVE(cd_source.cooldowns, cd_index)
+
+/*
+ * Stoppable timer cooldowns.
+ * Use indexes the same as the regular tiemr cooldowns.
+ * They make use of the TIMER_COOLDOWN_CHECK() and TIMER_COOLDOWN_END() macros the same, just not the TIMER_COOLDOWN_START() one.
+ * A bit more expensive than the regular timers, but can be reset before they end and the time left can be checked.
+*/
+
+#define S_TIMER_COOLDOWN_START(cd_source, cd_index, cd_time) LAZYSET(cd_source.cooldowns, cd_index, addtimer(CALLBACK(GLOBAL_PROC, /proc/end_cooldown, cd_source, cd_index), cd_time, TIMER_STOPPABLE))
+
+#define S_TIMER_COOLDOWN_RESET(cd_source, cd_index) reset_cooldown(cd_source, cd_index)
+
+#define S_TIMER_COOLDOWN_TIMELEFT(cd_source, cd_index) (timeleft(TIMER_COOLDOWN_CHECK(cd_source, cd_index)))
+
+
+/*
+ * Cooldown system based on storing world.time on a variable, plus the cooldown time.
+ * Better performance over timer cooldowns, lower control. Same functionality.
+*/
+
+#define COOLDOWN_DECLARE(cd_index) var/##cd_index = 0
+
+#define COOLDOWN_START(cd_source, cd_index, cd_time) (cd_source.cd_index = world.time + cd_time)
+
+#define COOLDOWN_CHECK(cd_source, cd_index) (cd_source.cd_index < world.time)
+
+#define COOLDOWN_RESET(cd_source, cd_index) cd_source.cd_index = 0
+
+#define COOLDOWN_TIMELEFT(cd_source, cd_index) ((cd_source.cd_index - world.time) < 0 ? 0 : cd_source.cd_index - world.time)

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -68,4 +68,4 @@
 
 #define COOLDOWN_RESET(cd_source, cd_index) cd_source.cd_index = 0
 
-#define COOLDOWN_TIMELEFT(cd_source, cd_index) ((cd_source.cd_index - world.time) < 0 ? 0 : cd_source.cd_index - world.time)
+#define COOLDOWN_TIMELEFT(cd_source, cd_index) (max(0, cd_source.cd_index - world.time))

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -1,0 +1,16 @@
+/*
+ * Cooldown system based on an datum-level associative lazylist using timers.
+ * If you are running hot procs that require high performance, checking world.time directly through a variable will always be faster.
+ * If you are not, then this should be fine to use, it's not very expensive.
+ * If you want a stoppable timer either make new macros or use a different system. Do not make every timer stoppable, that increases performance cost.
+*/
+
+//INDEXES
+#define COOLDOWN_AMBITION	"ambition"
+
+//MACROS
+#define COOLDOWN_START(cd_source, cd_index, cd_time) LAZYSET(cd_source.cooldowns, cd_index, addtimer(CALLBACK(GLOBAL_PROC, /proc/end_cooldown, cd_source, cd_index), cd_time))
+
+#define COOLDOWN_CHECK(cd_source, cd_index) LAZYACCESS(cd_source.cooldowns, cd_index)
+
+#define COOLDOWN_END(cd_source, cd_index) LAZYREMOVE(cd_source.cooldowns, cd_index)

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -85,6 +85,9 @@
 #define EMOTE_AUDIBLE 2
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
+//SKYRAT CHANGES BEGIN
+#define MAX_AMBITION_LEN		1024
+//SKYRAT CHANGES END
 #define MAX_MESSAGE_LEN			2048		//Citadel edit: What's the WORST that could happen?
 #define MAX_FLAVOR_LEN			4096		//double the maximum message length.
 #define MAX_TASTE_LEN			40 //lick... vore... ew...

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -13,6 +13,9 @@
 #define UNSETEMPTY(L) if (L && !length(L)) L = null
 #define LAZYCOPY(L) (L ? L.Copy() : list() )
 #define LAZYREMOVE(L, I) if(L) { L -= I; if(!length(L)) { L = null; } }
+//SKYRAT CHANGES BEGIN
+#define LAZYCUT(L, S, E) if((length(L) >= S) && (E == 0 || length(L) >= (E - 1))) { L.Cut(S, E); if(!length(L)) { L = null; } }
+//SKYRAT CHANGES END
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;
 #define LAZYOR(L, I) if(!L) { L = list(); } L |= I;
 #define LAZYFIND(L, V) L ? L.Find(V) : 0

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -490,6 +490,10 @@
 			currrent_category = A.roundend_category
 			previous_category = A
 		result += A.roundend_report()
+//SKYRAT CHANGES BEGIN
+		for(var/count in 1 to LAZYLEN(A.owner.ambitions))
+			result += "<br><B>Ambition #[count]</B>: [A.owner.ambitions[count]]"
+//SKYRAT CHANGES END
 		result += "<br><br>"
 		CHECK_TICK
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -468,3 +468,8 @@
 
 /datum/config_entry/flag/minimaps_enabled
 	config_entry_value = TRUE
+
+//SKYRAT CHANGES BEGIN
+/datum/config_entry/number/max_ambitions	// Maximum number of ambitions a mind can store.
+	config_entry_value = 5
+//SKYRAT CHANGES END

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -39,6 +39,11 @@
 	/// A weak reference to another datum
 	var/datum/weakref/weak_reference
 
+//SKYRAT CHANGES BEGIN
+	///Lazy associative list of currently active cooldowns.
+	var/list/cooldowns
+//SKYRAT CHANGES END
+
 #ifdef TESTING
 	var/running_find_references
 	var/last_find_references = 0
@@ -201,3 +206,11 @@
 		qdel(D)
 	else
 		return returned
+
+//SKYRAT CHANGES BEGIN
+///Callback called by a timer to end an associative-list-indexed cooldown.
+/proc/end_cooldown(datum/source, index)
+	if(QDELETED(source))
+		return
+	COOLDOWN_END(source, index)
+//SKYRAT CHANGES END

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -208,9 +208,34 @@
 		return returned
 
 //SKYRAT CHANGES BEGIN
-///Callback called by a timer to end an associative-list-indexed cooldown.
+/**
+  * Callback called by a timer to end an associative-list-indexed cooldown.
+  *
+  * Arguments:
+  * * source - datum storing the cooldown
+  * * index - string index storing the cooldown on the cooldowns associative list
+  *
+  * This sends a signal reporting the cooldown end.
+  */
 /proc/end_cooldown(datum/source, index)
 	if(QDELETED(source))
 		return
-	COOLDOWN_END(source, index)
+	SEND_SIGNAL(source, COMSIG_CD_STOP(index))
+	TIMER_COOLDOWN_END(source, index)
+
+
+/**
+  * Proc used by stoppable timers to end a cooldown before the time has ran out.
+  *
+  * Arguments:
+  * * source - datum storing the cooldown
+  * * index - string index storing the cooldown on the cooldowns associative list
+  *
+  * This sends a signal reporting the cooldown end, passing the time left as an argument.
+  */
+/proc/reset_cooldown(datum/source, index)
+	if(QDELETED(source))
+		return
+	SEND_SIGNAL(source, COMSIG_CD_RESET(index), S_TIMER_COOLDOWN_TIMELEFT(source, index))
+	TIMER_COOLDOWN_END(source, index)
 //SKYRAT CHANGES END

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -450,26 +450,51 @@
 				var/datum/objective/objective = antag_datum.objectives[count]
 				output += "<li><B>[count]</B>: [objective.explanation_text]"
 				if(self_mind)
-					output += " <a href='?src=[REF(antag_datum.owner)];req_obj_delete=[REF(objective)]'>Request Remove</a> <a href='?src=[REF(antag_datum.owner)];req_obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Request incompletion" : "Request completion"]</font></a><br>"
+					output += " <a href='?src=[REF(antag_datum.owner)];req_obj_delete=[REF(objective)];target_antag=[REF(antag_datum)]'>Request Remove</a> <a href='?src=[REF(antag_datum.owner)];req_obj_completed=[REF(objective)];target_antag=[REF(antag_datum)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Request incompletion" : "Request completion"]</font></a><br>"
 				if(is_admin)
-					output += " <a href='?src=[REF(antag_datum.owner)];obj_edit=[REF(objective)]'>Edit</a> <a href='?src=[REF(antag_datum.owner)];obj_panel_delete=[REF(objective)]'>Remove</a> <a href='?src=[REF(antag_datum.owner)];obj_panel_complete_toggle=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a><br>"
+					output += " <a href='?src=[REF(antag_datum.owner)];obj_edit=[REF(objective)];target_antag=[REF(antag_datum)]'>Edit</a> <a href='?src=[REF(antag_datum.owner)];obj_panel_delete=[REF(objective)];target_antag=[REF(antag_datum)]'>Remove</a> <a href='?src=[REF(antag_datum.owner)];obj_panel_complete_toggle=[REF(objective)];target_antag=[REF(antag_datum)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a><br>"
 		output += "</ul>"
 		if(is_admin)
 			output += "<a href='?src=[REF(antag_datum.owner)];obj_announce=1;ambition_panel=1'>Announce objectives</a><br>"
-		output += "<br><i><b>Requested Objectives</b></i>:"
+		output += "<br><i><b>Requested Objective Changes</b></i>:"
 		if(self_mind)
 			output += " <a href='?src=[REF(antag_datum.owner)];req_obj_add=1;target_antag=[REF(antag_datum)]'>Request objective</a>"
 		output += "<ul>"
-		if(!length(antag_datum.requested_objectives))
+		if(!length(antag_datum.requested_objective_changes))
 			output += "<li><i><b>NONE</b></i>"
 		else
-			for(var/uid in antag_datum.requested_objectives)
-				var/list/objectives_info = antag_datum.requested_objectives[uid]
-				var/datum/objective/type_cast_objective = objectives_info["type"]
-				var/objective_text = objectives_info["text"]
-				output += "<li><B>Request #[uid]</B>: [initial(type_cast_objective.name)] - [objective_text]"
-				if(is_admin)
-					output += " <a href='?src=[REF(antag_datum.owner)];req_obj_accept=[REF(antag_datum)];req_obj_id=[uid]'>Accept</a> <a href='?src=[REF(antag_datum.owner)];req_obj_edit=[REF(antag_datum)];req_obj_id=[uid]'>Edit</a> <a href='?src=[REF(antag_datum.owner)];req_obj_deny=[REF(antag_datum)];req_obj_id=[uid]'>Deny</a>"
+			for(var/uid in antag_datum.requested_objective_changes)
+				var/list/objectives_info = antag_datum.requested_objective_changes[uid]
+				var/obj_request = objectives_info["request"]
+				switch(obj_request)
+					if(REQUEST_NEW_OBJECTIVE)
+						var/datum/objective/type_cast_objective = objectives_info["target"]
+						var/objective_text = objectives_info["text"]
+						output += "<li><B>Request #[uid]</B>: ADD [initial(type_cast_objective.name)] - [objective_text]"
+						if(is_admin)
+							output += " <a href='?src=[REF(antag_datum.owner)];req_obj_accept=[REF(antag_datum)];req_obj_id=[uid]'>Accept</a> <a href='?src=[REF(antag_datum.owner)];req_obj_edit=[REF(antag_datum)];req_obj_id=[uid]'>Edit</a> <a href='?src=[REF(antag_datum.owner)];req_obj_deny=[REF(antag_datum)];req_obj_id=[uid]'>Deny</a>"
+					if(REQUEST_DEL_OBJECTIVE)
+						var/datum/objective/objective_ref = locate(objectives_info["target"]) in antag_datum.objectives
+						if(QDELETED(objective_ref))
+							stack_trace("Objective request found with deleted reference. UID: [uid] | Antag: [antag_datum] | Mind: [src] | User: [usr]")
+							antag_datum.remove_objective_change(uid)
+							continue
+						output += "<li><B>Request #[uid]</B>: DEL [objective_ref.name] - [objective_ref.explanation_text] - [objectives_info["text"]]"
+						if(is_admin)
+							output += " <a href='?src=[REF(antag_datum.owner)];req_obj_accept=[REF(antag_datum)];req_obj_id=[uid]'>Accept</a> <a href='?src=[REF(antag_datum.owner)];req_obj_deny=[REF(antag_datum)];req_obj_id=[uid]'>Deny</a>"
+					if(REQUEST_WIN_OBJECTIVE, REQUEST_LOSE_OBJECTIVE)
+						var/datum/objective/objective_ref = locate(objectives_info["target"]) in antag_datum.objectives
+						if(QDELETED(objective_ref))
+							stack_trace("Objective request found with deleted reference. UID: [uid] | Antag: [antag_datum] | Mind: [src] | User: [usr]")
+							antag_datum.remove_objective_change(uid)
+							continue
+						output += "<li><B>Request #[uid]</B>: [obj_request == REQUEST_WIN_OBJECTIVE ? "WIN" : "LOSE"] [objective_ref.name] - [objective_ref.explanation_text] - [objectives_info["text"]]"
+						if(is_admin)
+							output += " <a href='?src=[REF(antag_datum.owner)];req_obj_accept=[REF(antag_datum)];req_obj_id=[uid]'>Accept</a> <a href='?src=[REF(antag_datum.owner)];req_obj_deny=[REF(antag_datum)];req_obj_id=[uid]'>Deny</a>"
+					else
+						stack_trace("Objective request found with no request index. UID: [uid] | Antag: [antag_datum] | Mind: [src] | User: [usr]")
+						continue
+
 		output += "</ul><br>"
 	output += "<b>[current.real_name]'s Ambitions:</b>"
 	if(LAZYLEN(ambitions) < CONFIG_GET(number/max_ambitions))
@@ -485,7 +510,7 @@
 
 
 /mob/proc/edit_objectives_and_ambitions()
-	set name = "Edit Objectives and Ambitions"
+	set name = "Objectives and Ambitions"
 	set category = "IC"
 	set desc = "View and edit your character's objectives and ambitions."
 	mind.do_edit_objectives_ambitions()
@@ -498,6 +523,29 @@
 
 
 GLOBAL_VAR_INIT(requested_objective_uid, 0)
+
+
+GLOBAL_LIST(objective_player_choices)
+
+/proc/populate_objective_player_choices()
+	GLOB.objective_player_choices = list()
+	var/list/allowed_types = list(
+		/datum/objective/custom,
+		/datum/objective/assassinate/once,
+		/datum/objective/protect,
+		/datum/objective/escape,
+		/datum/objective/survive,
+		/datum/objective/martyr,
+		/datum/objective/steal,
+		/datum/objective/download,
+		/datum/objective/blackmail_implant //SKYRAT ADDITION
+		)
+
+	for(var/t in allowed_types)
+		var/datum/objective/type_cast = t
+		GLOB.objective_player_choices[initial(type_cast.name)] = t
+
+
 GLOBAL_LIST(objective_choices)
 
 /proc/populate_objective_choices()
@@ -690,14 +738,14 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
-		if(!istype(target_antag))
+		if(QDELETED(target_antag))
 			to_chat(usr, "<span class='warning'>No antagonist found for this objective.</span>")
 			do_edit_objectives_ambitions()
 			return
-		if(!GLOB.objective_choices)
-			populate_objective_choices()
-		var/choe = input("Select desired objective type:", "Objective type") as null|anything in GLOB.objective_choices
-		var/selected_type = GLOB.objective_choices[choe]
+		if(!GLOB.objective_player_choices)
+			populate_objective_player_choices()
+		var/choice = input("Select desired objective type:", "Objective type") as null|anything in GLOB.objective_player_choices
+		var/selected_type = GLOB.objective_player_choices[choice]
 		if(!selected_type)
 			return
 		var/new_objective = stripped_multiline_input(usr,\
@@ -718,11 +766,10 @@ GLOBAL_LIST(objective_choices)
 			return
 		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
 		var/uid = "[GLOB.requested_objective_uid++]"
-		LAZYADD(target_antag.requested_objectives, uid)
-		target_antag.requested_objectives[uid] = list("type" = selected_type, "text" = new_objective)
-		log_admin("[key_name(usr)] has requested a [choe] objective: [new_objective]")
-		message_admins("[ADMIN_TPMONTY(usr)] has requested a [choe] objective. (<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)")
-		to_chat(usr, "<span class='notice'>The admins have been notified of your request!</span>")
+		target_antag.add_objective_change(uid, list("request" = REQUEST_NEW_OBJECTIVE, "target" = selected_type, "text" = new_objective))
+		log_admin("Objectives request [uid] - [key_name(usr)] has requested a [choice] objective: [new_objective]")
+		target_antag.notify_admins_of_request("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has requested a [choice] objective. (<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)</span>")
+		to_chat(usr, "<span class='boldnotice'>The admins have been notified of your request!</span>")
 		do_edit_objectives_ambitions()
 		return
 
@@ -732,29 +779,43 @@ GLOBAL_LIST(objective_choices)
 		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
-		var/datum/objective/objective_to_delete = locate(href_list["req_obj_delete"])
+		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
+		if(QDELETED(target_antag))
+			to_chat(usr, "<span class='warning'>No antagonist found for this objective.</span>")
+			do_edit_objectives_ambitions()
+			return
+		var/objective_reference = href_list["req_obj_delete"]
+		var/datum/objective/objective_to_delete = locate(objective_reference) in target_antag.objectives
 		if(!istype(objective_to_delete) || QDELETED(objective_to_delete))
 			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
 			do_edit_objectives_ambitions()
 			return
-		var/justifation = stripped_multiline_input(usr,
+		var/justification = stripped_multiline_input(usr,
 			"Justify your request for a deleting this objective to the admins.\
 			There's a 10 minutes cooldown between requests, so try to think it through before sending it. Cancelling does not trigger the cooldown.",
 			"Objective Deletion", max_length = MAX_MESSAGE_LEN)
-		if(isnull(justifation))
+		if(isnull(justification))
 			return
 		if(usr != current)
 			return
 		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
-		if(QDELETED(objective_to_delete))
+		if(QDELETED(objective_to_delete) || QDELETED(target_antag))
 			do_edit_objectives_ambitions()
 			return
+		for(var/index in target_antag.requested_objective_changes)
+			var/list/change_request = target_antag.requested_objective_changes[index]
+			if(change_request["target"] != objective_reference)
+				continue
+			to_chat(usr, "<span class='warning'>There is already a change request tied to this objective waiting to be processed. Ahelp or wait for it to be resolved before adding a new one.</span>")
+			return
 		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
-		log_admin("[key_name(usr)] has requested the deletion of the following objective: [objective_to_delete.explanation_text].\nTheir justifation is as follows: [justifation]")
-		message_admins("[ADMIN_TPMONTY(usr)] has requested the deletion of the following objective: [objective_to_delete.explanation_text].\nTheir justifation is as follows: [justifation]\n(<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)")
-		to_chat(usr, "<span class='notice'>The admins have been notified of your request!</span>")
+		var/uid = "[GLOB.requested_objective_uid++]"
+		target_antag.add_objective_change(uid, list("request" = REQUEST_DEL_OBJECTIVE, "target" = objective_reference, "text" = justification))
+		log_admin("Objectives request [uid] - [key_name(usr)] has requested the deletion of the following objective: [objective_to_delete.explanation_text].\nTheir justification is as follows: [justification]")
+		target_antag.notify_admins_of_request("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has requested the deletion of an objective: (<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)</span>")
+		to_chat(usr, "<span class='boldnotice'>The admins have been notified of your request!</span>")
 		do_edit_objectives_ambitions()
 		return
 
@@ -764,29 +825,43 @@ GLOBAL_LIST(objective_choices)
 		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
-		var/datum/objective/objective_to_complete = locate(href_list["req_obj_completed"])
-		if(!istype(objective_to_complete) || QDELETED(objective_to_complete))
-			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
+		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
+		if(QDELETED(target_antag))
+			to_chat(usr, "<span class='warning'>No antagonist found for this objective.</span>")
 			do_edit_objectives_ambitions()
 			return
-		var/justifation = stripped_multiline_input(usr,
-			"Justify your request for the [objective_to_complete.completed ? "completion" : "incompletion"] of this objective to the admins.\
+		var/objective_reference = href_list["req_obj_completed"]
+		var/datum/objective/objective_to_complete = locate(objective_reference) in target_antag.objectives
+		if(!istype(objective_to_complete) || QDELETED(objective_to_complete))
+			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was deleted?</span>")
+			do_edit_objectives_ambitions()
+			return
+		var/justification = stripped_multiline_input(usr,
+			"Justify to the admins your request to mark this objective as [objective_to_complete.completed ? "incomplete" : "completed"].\
 			There's a 10 minutes cooldown between requests, so try to think it through before sending it. Cancelling does not trigger the cooldown.",
-			"Objective [objective_to_complete.completed ? "Completion" : "Incompletion"]", max_length = MAX_MESSAGE_LEN)
-		if(isnull(justifation))
+			"Objective [objective_to_complete.completed ? "Incompletion" : "Completion"]", max_length = MAX_MESSAGE_LEN)
+		if(isnull(justification))
 			return
 		if(usr != current)
 			return
 		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
-		if(QDELETED(objective_to_complete))
+		if(QDELETED(objective_to_complete) || QDELETED(target_antag))
 			do_edit_objectives_ambitions()
 			return
+		for(var/index in target_antag.requested_objective_changes)
+			var/list/change_request = target_antag.requested_objective_changes[index]
+			if(change_request["target"] != objective_reference)
+				continue
+			to_chat(usr, "<span class='warning'>There is already a change request tied to this objective waiting to be processed. Ahelp or wait for it to be resolved before adding a new one.</span>")
+			return
 		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
-		log_admin("[key_name(usr)] has requested the [objective_to_complete.completed ? "completion" : "incompletion"] of the following objective: [objective_to_complete.explanation_text].\nTheir justifation is as follows: [justifation]")
-		message_admins("[ADMIN_TPMONTY(usr)] has requested the [objective_to_complete.completed ? "completion" : "incompletion"] of the following objective: [objective_to_complete.explanation_text].\nTheir justifation is as follows: [justifation]\n(<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)")
-		to_chat(usr, "<span class='notice'>The admins have been notified of your request!</span>")
+		var/uid = "[GLOB.requested_objective_uid++]"
+		target_antag.add_objective_change(uid, list("request" = (objective_to_complete.completed ? REQUEST_LOSE_OBJECTIVE : REQUEST_WIN_OBJECTIVE), "target" = objective_reference, "text" = justification))
+		log_admin("Objectives request [uid] - [key_name(usr)] has requested the [objective_to_complete.completed ? "incompletion" : "completion"] of the following objective: [objective_to_complete.explanation_text].\nTheir justification is as follows: [justification]")
+		target_antag.notify_admins_of_request("<span class='adminhelp'>[ADMIN_TPMONTY(usr)] has requested the [objective_to_complete.completed ? "incompletion" : "completion"] of an objective: (<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)</span>")
+		to_chat(usr, "<span class='boldnotice'>The admins have been notified of your request!</span>")
 		do_edit_objectives_ambitions()
 		return
 
@@ -804,7 +879,7 @@ GLOBAL_LIST(objective_choices)
 		return
 
 	else if (href_list["req_obj_edit"])
-		var/datum/antagonist/antag_datum = locate(href_list["req_obj_edit"])
+		var/datum/antagonist/antag_datum = locate(href_list["req_obj_edit"]) in antag_datums
 		if(QDELETED(antag_datum))
 			do_edit_objectives_ambitions()
 			to_chat(usr, "<span class='warning'>No antag found.</span>")
@@ -814,12 +889,15 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
 			return
 		var/uid = href_list["req_obj_id"]
-		var/list/requested_objective = LAZYACCESS(antag_datum.requested_objectives, uid)
-		if(!requested_objective)
+		var/list/requested_obj_change = LAZYACCESS(antag_datum.requested_objective_changes, uid)
+		if(!requested_obj_change)
 			do_edit_objectives_ambitions()
 			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
 			return
-		
+		if(requested_obj_change["request"] != REQUEST_NEW_OBJECTIVE)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>This is not an editable request. How did you even got here?</span>")
+			return
 		switch(alert(usr, "Do you want to edit the requested objective type or text?", "Edit requested objective", "Type", "Text", "Cancel"))
 			if("Type")
 				if(!check_rights(R_ADMIN))
@@ -828,11 +906,11 @@ GLOBAL_LIST(objective_choices)
 					to_chat(usr, "<span class='warning'>No antag found.</span>")
 					do_edit_objectives_ambitions()
 					return
-				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
-					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+				if(!LAZYACCESS(antag_datum.requested_objective_changes, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 					do_edit_objectives_ambitions()
 					return
-				var/datum/objective/type_cast = requested_objective["type"]
+				var/datum/objective/type_cast = requested_obj_change["target"]
 				var/selected_type = input("Select new requested objective type:", "Requested Objective type", initial(type_cast.name)) as null|anything in GLOB.objective_choices
 				selected_type = GLOB.objective_choices[selected_type]
 				if(!selected_type)
@@ -843,13 +921,13 @@ GLOBAL_LIST(objective_choices)
 					to_chat(usr, "<span class='warning'>No antag found.</span>")
 					do_edit_objectives_ambitions()
 					return
-				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
-					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+				if(!LAZYACCESS(antag_datum.requested_objective_changes, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 					do_edit_objectives_ambitions()
 					return
-				log_admin("[key_name(usr)] has edited the requested objective type for [current], of UID [uid], from [requested_objective["type"]] to [selected_type]")
-				message_admins("[key_name_admin(usr)] has edited the requested objective type for [current], of UID [uid], from [requested_objective["type"]] to [selected_type]")
-				requested_objective["type"] = selected_type
+				log_admin("[key_name(usr)] has edited the requested objective type for [current], of UID [uid], from [requested_obj_change["target"]] to [selected_type]")
+				message_admins("[key_name_admin(usr)] has edited the requested objective type for [current], of UID [uid], from [requested_obj_change["target"]] to [selected_type]")
+				requested_obj_change["target"] = selected_type
 			if("Text")
 				if(!check_rights(R_ADMIN))
 					return
@@ -857,11 +935,11 @@ GLOBAL_LIST(objective_choices)
 					to_chat(usr, "<span class='warning'>No antag found.</span>")
 					do_edit_objectives_ambitions()
 					return
-				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
-					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+				if(!LAZYACCESS(antag_datum.requested_objective_changes, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 					do_edit_objectives_ambitions()
 					return
-				var/new_text = stripped_multiline_input(usr, "Input new requested objective text", "Requested Objective Text", requested_objective["text"], MAX_MESSAGE_LEN)
+				var/new_text = stripped_multiline_input(usr, "Input new requested objective text", "Requested Objective Text", requested_obj_change["text"], MAX_MESSAGE_LEN)
 				if (isnull(new_text))
 					return
 				if(!check_rights(R_ADMIN))
@@ -870,18 +948,18 @@ GLOBAL_LIST(objective_choices)
 					to_chat(usr, "<span class='warning'>No antag found.</span>")
 					do_edit_objectives_ambitions()
 					return
-				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
-					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+				if(!LAZYACCESS(antag_datum.requested_objective_changes, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 					do_edit_objectives_ambitions()
 					return
-				log_admin("[key_name(usr)] has edited the requested objective text for [current], of UID [uid], from [requested_objective["text"]] to [new_text]")
-				message_admins("[key_name_admin(usr)] has edited the requested objective text for [current], of UID [uid], from [requested_objective["text"]] to [new_text]")
-				requested_objective["text"] = new_text
+				log_admin("[key_name(usr)] has edited the requested objective text for [current], of UID [uid], from [requested_obj_change["text"]] to [new_text]")
+				message_admins("[key_name_admin(usr)] has edited the requested objective text for [current], of UID [uid], from [requested_obj_change["text"]] to [new_text]")
+				requested_obj_change["text"] = new_text
 		do_edit_objectives_ambitions()
 		return
 
 	else if (href_list["req_obj_accept"])
-		var/datum/antagonist/antag_datum = locate(href_list["req_obj_accept"])
+		var/datum/antagonist/antag_datum = locate(href_list["req_obj_accept"]) in antag_datums
 		if(QDELETED(antag_datum))
 			do_edit_objectives_ambitions()
 			to_chat(usr, "<span class='warning'>No antag found.</span>")
@@ -891,12 +969,29 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
 			return
 		var/uid = href_list["req_obj_id"]
-		var/list/requested_objective = LAZYACCESS(antag_datum.requested_objectives, uid)
-		if(!requested_objective)
+		var/list/requested_obj_change = LAZYACCESS(antag_datum.requested_objective_changes, uid)
+		if(!requested_obj_change)
 			do_edit_objectives_ambitions()
 			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
 			return
-		if(alert(usr, "Are you sure you want to approve this objective?", "Approve objective", "Yes", "No") != "Yes")
+
+		var/datum/objective/request_target
+		var/request_type = requested_obj_change["request"]
+		switch(request_type)
+			if(REQUEST_NEW_OBJECTIVE)
+				request_target = requested_obj_change["target"]
+				if(!ispath(request_target, /datum/objective))
+					to_chat(usr, "<span class='warning'>Invalid requested objective target path.</span>")
+					return
+			if(REQUEST_DEL_OBJECTIVE, REQUEST_WIN_OBJECTIVE, REQUEST_LOSE_OBJECTIVE)
+				request_target = locate(requested_obj_change["target"]) in antag_datum.objectives
+				if(QDELETED(request_target))
+					to_chat(usr, "<span class='warning'>Invalid requested objective target reference.</span>")
+					return
+			else
+				to_chat(usr, "<span class='warning'>Invalid request type.</span>")
+				return
+		if(alert(usr, "Are you sure you want to approve this objective change?", "Approve objective change", "Yes", "No") != "Yes")
 			return
 		if(!check_rights(R_ADMIN))
 			return
@@ -904,27 +999,53 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>No antag found.</span>")
 			do_edit_objectives_ambitions()
 			return
-		if(!LAZYACCESS(antag_datum.requested_objectives, uid))
-			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+		if(!LAZYACCESS(antag_datum.requested_objective_changes, uid))
+			to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 			do_edit_objectives_ambitions()
 			return
-		var/objective_path = requested_objective["type"]
-		var/datum/objective/new_objective = new objective_path
-		new_objective.owner = src
-		if(istype(new_objective, /datum/objective/custom))
-			new_objective.explanation_text = requested_objective["text"]
-		else
-			new_objective.admin_edit(usr)
-		antag_datum.objectives += new_objective
-		LAZYREMOVE(antag_datum.requested_objectives, uid)
-		message_admins("[key_name_admin(usr)] approved a requested objective from [current]: [new_objective.explanation_text]")
-		log_admin("[key_name(usr)] approved a requested objective from [current]: [new_objective.explanation_text]")
-		to_chat(current, "<span class='boldnotice'>Your objective request has been approved.</span>")
+		switch(request_type) //Last checks
+			if(REQUEST_NEW_OBJECTIVE)
+				if(!ispath(request_target, /datum/objective))
+					stack_trace("Invalid target on objective change request: [request_target]")
+					do_edit_objectives_ambitions()
+					return
+			if(REQUEST_DEL_OBJECTIVE, REQUEST_WIN_OBJECTIVE, REQUEST_LOSE_OBJECTIVE)
+				if(QDELETED(request_target))
+					to_chat(usr, "<span class='warning'>Invalid requested objective target reference.</span>")
+					return
+			else
+				to_chat(usr, "<span class='warning'>Invalid request type.</span>")
+				return
+		antag_datum.remove_objective_change(uid)
+		switch(request_type) //All is clear, let get things done.
+			if(REQUEST_NEW_OBJECTIVE)
+				request_target = new request_target()
+				request_target.owner = src
+				if(istype(request_target, /datum/objective/custom))
+					request_target.explanation_text = requested_obj_change["text"]
+				else
+					request_target.admin_edit(usr)
+				antag_datum.objectives += request_target
+				message_admins("[key_name_admin(usr)] approved a requested objective from [current]: [request_target.explanation_text]")
+				log_admin("[key_name(usr)] approved a requested objective from [current]: [request_target.explanation_text]")
+			if(REQUEST_DEL_OBJECTIVE)
+				message_admins("[key_name_admin(usr)] approved the request to delete an objective from [current]: [request_target.explanation_text]")
+				log_admin("[key_name(usr)] approved the request to delete an objective from [current]: [request_target.explanation_text]")
+				qdel(request_target)
+			if(REQUEST_WIN_OBJECTIVE)
+				message_admins("[key_name_admin(usr)] approved the victory request for an objective from [current]: [request_target.explanation_text]")
+				log_admin("[key_name(usr)] approved the victory request for an objective from [current]: [request_target.explanation_text]")
+				request_target.completed = TRUE
+			if(REQUEST_LOSE_OBJECTIVE)
+				message_admins("[key_name_admin(usr)] approved the defeat request for an objective from [current]: [request_target.explanation_text]")
+				log_admin("[key_name(usr)] approved the defeat request for an objective from [current]: [request_target.explanation_text]")
+				request_target.completed = FALSE
+		to_chat(current, "<span class='boldnotice'>Your objective change request has been approved.</span>")
 		do_edit_objectives_ambitions()
 		return
 
 	else if (href_list["req_obj_deny"])
-		var/datum/antagonist/antag_datum = locate(href_list["req_obj_deny"])
+		var/datum/antagonist/antag_datum = locate(href_list["req_obj_deny"]) in antag_datums
 		if(QDELETED(antag_datum))
 			do_edit_objectives_ambitions()
 			to_chat(usr, "<span class='warning'>No antag found.</span>")
@@ -934,13 +1055,13 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
 			return
 		var/uid = href_list["req_obj_id"]
-		var/list/requested_objective = LAZYACCESS(antag_datum.requested_objectives, uid)
-		if(!requested_objective)
+		var/list/requested_obj_change = LAZYACCESS(antag_datum.requested_objective_changes, uid)
+		if(!requested_obj_change)
 			do_edit_objectives_ambitions()
-			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+			to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 			return
-		var/justifation = stripped_multiline_input(usr, "Justify why you are denying this objective request.", "Deny", memory, MAX_MESSAGE_LEN)
-		if(isnull(justifation))
+		var/justification = stripped_multiline_input(usr, "Justify why you are denying this objective request change.", "Deny", memory, MAX_MESSAGE_LEN)
+		if(isnull(justification))
 			return
 		if(!check_rights(R_ADMIN))
 			return
@@ -948,22 +1069,31 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>No antag found.</span>")
 			do_edit_objectives_ambitions()
 			return
-		if(!LAZYACCESS(antag_datum.requested_objectives, uid))
-			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+		if(!LAZYACCESS(antag_datum.requested_objective_changes, uid))
+			to_chat(usr, "<span class='warning'>Invalid requested objective change reference.</span>")
 			do_edit_objectives_ambitions()
 			return
-		var/datum/objective/type_cast = requested_objective["type"]
+		var/datum/objective/type_cast = requested_obj_change["target"]
 		var/objective_name = initial(type_cast.name)
-		message_admins("[key_name_admin(usr)] denied a requested [objective_name] objective from [current]: [requested_objective["text"]]")
-		log_admin("[key_name(usr)] denied a requested [objective_name] objective from [current]: [requested_objective["text"]]")
-		to_chat(current, "<span class='boldwarning'>Your objective request has been denied for the following reason: [justifation]</span>")
-		LAZYREMOVE(antag_datum.requested_objectives, uid)
+		message_admins("[key_name_admin(usr)] denied a requested [objective_name] objective from [current]: [requested_obj_change["text"]]")
+		log_admin("[key_name(usr)] denied a requested [objective_name] objective from [current]: [requested_obj_change["text"]]")
+		to_chat(current, "<span class='boldwarning'>Your objective request has been denied for the following reason: [justification]</span>")
+		antag_datum.remove_objective_change(uid)
 		do_edit_objectives_ambitions()
 		return
 
 	else if (href_list["obj_panel_complete_toggle"])
-		var/datum/objective/objective_to_toggle = locate(href_list["obj_panel_complete_toggle"])
-		if(!istype(objective_to_toggle) || QDELETED(objective_to_toggle))
+		var/datum/antagonist/antag_datum = locate(href_list["target_antag"]) in antag_datums
+		if(QDELETED(antag_datum))
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			return
+		if(antag_datum.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
+			return
+		var/datum/objective/objective_to_toggle = locate(href_list["obj_panel_complete_toggle"]) in antag_datum.objectives
+		if(QDELETED(objective_to_toggle))
 			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
 			do_edit_objectives_ambitions()
 			return
@@ -980,8 +1110,17 @@ GLOBAL_LIST(objective_choices)
 		return
 
 	else if (href_list["obj_panel_delete"])
-		var/datum/objective/objective_to_delete = locate(href_list["obj_panel_delete"])
-		if(!istype(objective_to_delete) || QDELETED(objective_to_delete))
+		var/datum/antagonist/antag_datum = locate(href_list["target_antag"]) in antag_datums
+		if(QDELETED(antag_datum))
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			return
+		if(antag_datum.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
+			return
+		var/datum/objective/objective_to_delete = locate(href_list["obj_panel_delete"]) in antag_datum.objectives
+		if(QDELETED(objective_to_delete))
 			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
 			do_edit_objectives_ambitions()
 			return
@@ -1002,8 +1141,17 @@ GLOBAL_LIST(objective_choices)
 		return
 
 	else if (href_list["obj_panel_edit"])
-		var/datum/objective/objective_to_edit = locate(href_list["obj_panel_edit"])
-		if(!istype(objective_to_edit) || QDELETED(objective_to_edit))
+		var/datum/antagonist/antag_datum = locate(href_list["target_antag"]) in antag_datums
+		if(QDELETED(antag_datum))
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			return
+		if(antag_datum.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
+			return
+		var/datum/objective/objective_to_edit = locate(href_list["obj_panel_edit"]) in antag_datum.objectives
+		if(QDELETED(objective_to_edit))
 			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
 			do_edit_objectives_ambitions()
 			return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -31,6 +31,7 @@
 
 //SKYRAT CHANGES BEGIN
 #define AMBITION_COOLDOWN_TIME (5 SECONDS)
+#define OBJECTIVES_COOLDOWN_TIME (10 MINUTES)
 //SKYRAT CHANGES END
 
 /datum/mind
@@ -197,7 +198,7 @@
 	. = LAZYLEN(antag_datums)
 	LAZYADD(antag_datums, instanced_datum)
 	if(!.)
-		current.verbs += /mob/proc/edit_ambitions
+		current.verbs += /mob/proc/edit_objectives_and_ambitions
 //SKYRAT CHANGES END
 
 /datum/mind/proc/remove_antag_datum(datum_type)
@@ -213,8 +214,8 @@
 	. = LAZYLEN(antag_datums)
 	LAZYREMOVE(antag_datums, instanced_datum)
 	if(. && !LAZYLEN(antag_datums))
-		current.verbs -= /mob/proc/edit_ambitions
 		ambitions = null
+		current.verbs -= /mob/proc/edit_objectives_and_ambitions
 //SKYRAT CHANGES END
 
 /datum/mind/proc/remove_all_antag_datums() //For the Lazy amongst us.
@@ -430,46 +431,115 @@
 	return output.Join()
 
 
-/datum/mind/proc/show_editable_ambitions()
-	var/list/output = list("<b>[current.real_name]'s Ambitions:</b><br><ul>")
+/datum/mind/proc/show_editable_objectives_and_ambitions()
+	var/is_admin = check_rights(R_ADMIN, FALSE)
+	var/self_mind = usr == current
+	if(!is_admin && !self_mind)
+		return ""
+	var/list/output = list()
+	for(var/a in antag_datums)
+		var/datum/antagonist/antag_datum = a
+		output += "<i><b>Objectives</b></i>:"
+		if(is_admin)
+			output += " <a href='?src=[REF(antag_datum.owner)];obj_add=[REF(antag_datum)];ambition_panel=1'>Add Objective</a>"
+		output += "<ul>"
+		if(!length(antag_datum.objectives))
+			output += "<li><i><b>NONE</b></i>"
+		else
+			for(var/count in 1 to length(antag_datum.objectives))
+				var/datum/objective/objective = antag_datum.objectives[count]
+				output += "<li><B>[count]</B>: [objective.explanation_text]"
+				if(self_mind)
+					output += " <a href='?src=[REF(antag_datum.owner)];req_obj_delete=[REF(objective)]'>Request Remove</a> <a href='?src=[REF(antag_datum.owner)];req_obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Request incompletion" : "Request completion"]</font></a><br>"
+				if(is_admin)
+					output += " <a href='?src=[REF(antag_datum.owner)];obj_edit=[REF(objective)]'>Edit</a> <a href='?src=[REF(antag_datum.owner)];obj_panel_delete=[REF(objective)]'>Remove</a> <a href='?src=[REF(antag_datum.owner)];obj_panel_complete_toggle=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a><br>"
+		output += "</ul>"
+		if(is_admin)
+			output += "<a href='?src=[REF(antag_datum.owner)];obj_announce=1;ambition_panel=1'>Announce objectives</a><br>"
+		output += "<br><i><b>Requested Objectives</b></i>:"
+		if(self_mind)
+			output += " <a href='?src=[REF(antag_datum.owner)];req_obj_add=1;target_antag=[REF(antag_datum)]'>Request objective</a>"
+		output += "<ul>"
+		if(!length(antag_datum.requested_objectives))
+			output += "<li><i><b>NONE</b></i>"
+		else
+			for(var/uid in antag_datum.requested_objectives)
+				var/list/objectives_info = antag_datum.requested_objectives[uid]
+				var/datum/objective/type_cast_objective = objectives_info["type"]
+				var/objective_text = objectives_info["text"]
+				output += "<li><B>Request #[uid]</B>: [initial(type_cast_objective.name)] - [objective_text]"
+				if(is_admin)
+					output += " <a href='?src=[REF(antag_datum.owner)];req_obj_accept=[REF(antag_datum)];req_obj_id=[uid]'>Accept</a> <a href='?src=[REF(antag_datum.owner)];req_obj_edit=[REF(antag_datum)];req_obj_id=[uid]'>Edit</a> <a href='?src=[REF(antag_datum.owner)];req_obj_deny=[REF(antag_datum)];req_obj_id=[uid]'>Deny</a>"
+		output += "</ul><br>"
+	output += "<b>[current.real_name]'s Ambitions:</b>"
+	if(LAZYLEN(ambitions) < CONFIG_GET(number/max_ambitions))
+		output += " <a href='?src=[REF(src)];add_ambition=1'>Add Ambition</a>"
+	output += "<ul>"
 	if(!LAZYLEN(ambitions))
 		output += "<li><i><b>NONE</b></i>"
-		if(LAZYLEN(antag_datums))
-			output +="<li>(<a href='?src=[REF(src)];add_ambition=1'>Add Ambition</a>)"
 	else
 		for(var/count in 1 to LAZYLEN(ambitions))
 			output += "<li><B>Ambition #[count]</B> (<a href='?src=[REF(src)];edit_ambition=[count]'>Edit</a>) (<a href='?src=[REF(src)];remove_ambition=[count]'>Remove</a>):<br>[ambitions[count]]"
-		if(LAZYLEN(ambitions) < 5)
-			output += "<li>(<a href='?src=[REF(src)];add_ambition=1'>Add Ambition</a>)"
-	output += "<li>(<a href='?src=[REF(src)];refresh_ambitions=1'>Refresh</a>)</ul>"
+	output += "</ul><br>(<a href='?src=[REF(src)];refresh_obj_amb=1'>Refresh</a>)"
 	return output.Join()
 
 
-/mob/proc/edit_ambitions()
-	set name = "Ambitions"
+/mob/proc/edit_objectives_and_ambitions()
+	set name = "Edit Objectives and Ambitions"
 	set category = "IC"
-	set desc = "View and edit your character's ambitions."
-	mind.do_edit_ambitions()
+	set desc = "View and edit your character's objectives and ambitions."
+	mind.do_edit_objectives_ambitions()
 
 
-/datum/mind/proc/do_edit_ambitions()
-	var/datum/browser/popup = new(usr, "ambitions", "Ambitions")
-	popup.set_content(show_editable_ambitions())
+/datum/mind/proc/do_edit_objectives_ambitions()
+	var/datum/browser/popup = new(usr, "objectives and ambitions", "Objectives and Ambitions")
+	popup.set_content(show_editable_objectives_and_ambitions())
 	popup.open()
+
+
+GLOBAL_VAR_INIT(requested_objective_uid, 0)
+GLOBAL_LIST(objective_choices)
+
+/proc/populate_objective_choices()
+	GLOB.objective_choices = list()
+	var/list/allowed_types = list(
+		/datum/objective/custom,
+		/datum/objective/assassinate,
+		/datum/objective/assassinate/once,
+		/datum/objective/maroon,
+		/datum/objective/debrain,
+		/datum/objective/protect,
+		/datum/objective/destroy,
+		/datum/objective/hijack,
+		/datum/objective/escape,
+		/datum/objective/survive,
+		/datum/objective/martyr,
+		/datum/objective/steal,
+		/datum/objective/download,
+		/datum/objective/nuclear,
+		/datum/objective/absorb,
+		/datum/objective/blackmail_implant //SKYRAT ADDITION
+		)
+
+	for(var/t in allowed_types)
+		var/datum/objective/type_cast = t
+		GLOB.objective_choices[initial(type_cast.name)] = t
+
 //SKYRAT CHANGES END
 
 /datum/mind/Topic(href, href_list)
 //SKYRAT CHANGES BEGIN
-	if (href_list["refresh_ambitions"])
-		do_edit_ambitions()
+
+	if (href_list["refresh_obj_amb"])
+		do_edit_objectives_ambitions()
 		return
 
 	else if (href_list["add_ambition"])
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
 			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
-				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 10] seconds between changes.</span>")
+				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
 			return
@@ -478,16 +548,16 @@
 		var/max_ambitions = CONFIG_GET(number/max_ambitions)
 		if(LAZYLEN(ambitions) >= max_ambitions)
 			to_chat(usr, "<span class='warning'>There's a limit of [max_ambitions] ambitions. Edit or remove some to accomodate for your new additions.</span>")
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		var/new_ambition = stripped_multiline_input(usr, "Write new ambition", "Ambition", "", MAX_AMBITION_LEN)
 		if(isnull(new_ambition))
 			return
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
 			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
-				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 10] seconds between changes.</span>")
+				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
 			to_chat(usr, "<span class='warning'>The mind holder is no longer a living creature.</span>")
@@ -497,7 +567,7 @@
 			return
 		if(LAZYLEN(ambitions) >= max_ambitions)
 			to_chat(usr, "<span class='warning'>There's a limit of [max_ambitions] ambitions. Edit or remove some to accomodate for your new additions.</span>")
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
 		LAZYADD(ambitions, new_ambition)
@@ -506,15 +576,15 @@
 		else
 			log_game("[key_name(usr)] has created [key_name(current)]'s ambition of index [LAZYLEN(ambitions)].\nNEW AMBITION:\n[new_ambition]")
 			message_admins("[ADMIN_TPMONTY(usr)] has created [ADMIN_TPMONTY(current)]'s ambition of index [LAZYLEN(ambitions)].")
-		do_edit_ambitions()
+		do_edit_objectives_ambitions()
 		return
 
 	else if (href_list["edit_ambition"])
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
 			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
-				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 10] seconds between changes.</span>")
+				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
 			return
@@ -531,11 +601,11 @@
 		var/new_ambition = stripped_multiline_input(usr, "Write new ambition", "Ambition", ambitions[ambition_index], MAX_AMBITION_LEN)
 		if(isnull(new_ambition))
 			return
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
 			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
-				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 10] seconds between changes.</span>")
+				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
 			to_chat(usr, "<span class='warning'>The mind holder is no longer a living creature.</span>")
@@ -545,11 +615,11 @@
 			return
 		if(ambition_index > LAZYLEN(ambitions))
 			to_chat(usr, "<span class='warning'>The ambition we were editing was deleted before we finished. Aborting.</span>")
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		if(old_ambition != ambitions[ambition_index])
 			to_chat(usr, "<span class='warning'>The ambition has changed since we started editing it. Aborting to prevent data loss.</span>")
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
 		ambitions[ambition_index] = new_ambition
@@ -558,15 +628,15 @@
 		else
 			log_game("[key_name(usr)] has edited [key_name(current)]'s ambition of index [ambition_index].\nOLD AMBITION:\n[old_ambition]\nNEW AMBITION:\n[new_ambition]")
 			message_admins("[ADMIN_TPMONTY(usr)] has edited [ADMIN_TPMONTY(current)]'s ambition of index [ambition_index].")
-		do_edit_ambitions()
+		do_edit_objectives_ambitions()
 		return
 
 	else if (href_list["remove_ambition"])
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
 			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
-				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 10] seconds between changes.</span>")
+				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
 			return
@@ -574,7 +644,7 @@
 			return
 		var/ambition_index = text2num(href_list["remove_ambition"])
 		if(ambition_index > LAZYLEN(ambitions))
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		if(!isnum(ambition_index) || ambition_index < 0 || ambition_index % 1)
 			log_admin_private("[key_name(usr)] attempted to remove an ambition with and invalid ambition_index ([ambition_index]) at [AREACOORD(usr.loc)].")
@@ -583,11 +653,11 @@
 		var/old_ambition = ambitions[ambition_index]
 		if(alert(usr, "Are you sure you want to delete this ambition?", "Delete ambition", "Yes", "No") != "Yes")
 			return
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
 			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
-				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 10] seconds between changes.</span>")
+				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
 			to_chat(usr, "<span class='warning'>The mind holder is no longer a living creature. The ambition we were deleting should no longer exist already.</span>")
@@ -597,11 +667,11 @@
 			return
 		if(ambition_index > LAZYLEN(ambitions))
 			to_chat(usr, "<span class='warning'>The ambition we were deleting was deleted before we finished. No need to continue.</span>")
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		if(old_ambition != ambitions[ambition_index])
 			to_chat(usr, "<span class='warning'>The ambition has changed since we started considering its deletion. Aborting to prevent conflicts.</span>")
-			do_edit_ambitions()
+			do_edit_objectives_ambitions()
 			return
 		COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
 		LAZYCUT(ambitions, ambition_index, ambition_index + 1)
@@ -610,9 +680,115 @@
 		else
 			log_game("[key_name(usr)] has deleted [key_name(current)]'s ambition of index [ambition_index].\nDELETED AMBITION:\n[old_ambition]")
 			message_admins("[ADMIN_TPMONTY(usr)] has deleted [ADMIN_TPMONTY(current)]'s ambition of index [ambition_index].")
-		do_edit_ambitions()
+		do_edit_objectives_ambitions()
 		return
 
+	else if (href_list["req_obj_add"])
+		if(usr != current)
+			return
+		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
+			return
+		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
+		if(!istype(target_antag))
+			to_chat(usr, "<span class='warning'>No antagonist found for this objective.</span>")
+			do_edit_objectives_ambitions()
+			return
+		if(!GLOB.objective_choices)
+			populate_objective_choices()
+		var/choe = input("Select desired objective type:", "Objective type") as null|anything in GLOB.objective_choices
+		var/selected_type = GLOB.objective_choices[choe]
+		if(!selected_type)
+			return
+		var/new_objective = stripped_multiline_input(usr,\
+			selected_type == /datum/objective/custom\
+			? "Write the custom objective you'd like to request the admins to grant you.\
+			Remember they can edit or deny your request. There's a 10 minutes cooldown between requests, so try to think it through before sending it. Cancelling does not trigger the cooldown."\
+			: "Justify your request for a new objective to the admins. Add the required clarifations, if you have a specific targets in mind or the likes.\
+			Remember they can edit or deny your request. There's a 10 minutes cooldown between requests, so try to think it through before sending it. Cancelling does not trigger the cooldown.",\
+			"New Objective", max_length = MAX_MESSAGE_LEN)
+		if(isnull(new_objective))
+			return
+		if(usr != current)
+			return
+		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
+			return
+		if(QDELETED(target_antag))
+			return
+		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		var/uid = "[GLOB.requested_objective_uid++]"
+		LAZYADD(target_antag.requested_objectives, uid)
+		target_antag.requested_objectives[uid] = list("type" = selected_type, "text" = new_objective)
+		log_admin("[key_name(usr)] has requested a [choe] objective: [new_objective]")
+		message_admins("[ADMIN_TPMONTY(usr)] has requested a [choe] objective. (<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)")
+		to_chat(usr, "<span class='notice'>The admins have been notified of your request!</span>")
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["req_obj_delete"])
+		if(usr != current)
+			return
+		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
+			return
+		var/datum/objective/objective_to_delete = locate(href_list["req_obj_delete"])
+		if(!istype(objective_to_delete) || QDELETED(objective_to_delete))
+			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
+			do_edit_objectives_ambitions()
+			return
+		var/justifation = stripped_multiline_input(usr,
+			"Justify your request for a deleting this objective to the admins.\
+			There's a 10 minutes cooldown between requests, so try to think it through before sending it. Cancelling does not trigger the cooldown.",
+			"Objective Deletion", max_length = MAX_MESSAGE_LEN)
+		if(isnull(justifation))
+			return
+		if(usr != current)
+			return
+		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
+			return
+		if(QDELETED(objective_to_delete))
+			do_edit_objectives_ambitions()
+			return
+		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		log_admin("[key_name(usr)] has requested the deletion of the following objective: [objective_to_delete.explanation_text].\nTheir justifation is as follows: [justifation]")
+		message_admins("[ADMIN_TPMONTY(usr)] has requested the deletion of the following objective: [objective_to_delete.explanation_text].\nTheir justifation is as follows: [justifation]\n(<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)")
+		to_chat(usr, "<span class='notice'>The admins have been notified of your request!</span>")
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["req_obj_completed"])
+		if(usr != current)
+			return
+		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
+			return
+		var/datum/objective/objective_to_complete = locate(href_list["req_obj_completed"])
+		if(!istype(objective_to_complete) || QDELETED(objective_to_complete))
+			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
+			do_edit_objectives_ambitions()
+			return
+		var/justifation = stripped_multiline_input(usr,
+			"Justify your request for the [objective_to_complete.completed ? "completion" : "incompletion"] of this objective to the admins.\
+			There's a 10 minutes cooldown between requests, so try to think it through before sending it. Cancelling does not trigger the cooldown.",
+			"Objective [objective_to_complete.completed ? "Completion" : "Incompletion"]", max_length = MAX_MESSAGE_LEN)
+		if(isnull(justifation))
+			return
+		if(usr != current)
+			return
+		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
+			return
+		if(QDELETED(objective_to_complete))
+			do_edit_objectives_ambitions()
+			return
+		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		log_admin("[key_name(usr)] has requested the [objective_to_complete.completed ? "completion" : "incompletion"] of the following objective: [objective_to_complete.explanation_text].\nTheir justifation is as follows: [justifation]")
+		message_admins("[ADMIN_TPMONTY(usr)] has requested the [objective_to_complete.completed ? "completion" : "incompletion"] of the following objective: [objective_to_complete.explanation_text].\nTheir justifation is as follows: [justifation]\n(<a href='?_src_=holder;[HrefToken(TRUE)];ObjectiveRequest=[REF(src)]'>RPLY</a>)")
+		to_chat(usr, "<span class='notice'>The admins have been notified of your request!</span>")
+		do_edit_objectives_ambitions()
+		return
 
 	if(!check_rights(R_ADMIN))
 		return
@@ -620,12 +796,237 @@
 	var/self_antagging = usr == current
 
 	if(href_list["edit_ambitions_panel"])
-		do_edit_ambitions()
+		do_edit_objectives_ambitions()
 		return
+
 	else if(href_list["refresh_antag_panel"])
 		traitor_panel()
 		return
+
+	else if (href_list["req_obj_edit"])
+		var/datum/antagonist/antag_datum = locate(href_list["req_obj_edit"])
+		if(QDELETED(antag_datum))
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			return
+		if(antag_datum.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
+			return
+		var/uid = href_list["req_obj_id"]
+		var/list/requested_objective = LAZYACCESS(antag_datum.requested_objectives, uid)
+		if(!requested_objective)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+			return
+		
+		switch(alert(usr, "Do you want to edit the requested objective type or text?", "Edit requested objective", "Type", "Text", "Cancel"))
+			if("Type")
+				if(!check_rights(R_ADMIN))
+					return
+				if(QDELETED(antag_datum))
+					to_chat(usr, "<span class='warning'>No antag found.</span>")
+					do_edit_objectives_ambitions()
+					return
+				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+					do_edit_objectives_ambitions()
+					return
+				var/datum/objective/type_cast = requested_objective["type"]
+				var/selected_type = input("Select new requested objective type:", "Requested Objective type", initial(type_cast.name)) as null|anything in GLOB.objective_choices
+				selected_type = GLOB.objective_choices[selected_type]
+				if(!selected_type)
+					return
+				if(!check_rights(R_ADMIN))
+					return
+				if(QDELETED(antag_datum))
+					to_chat(usr, "<span class='warning'>No antag found.</span>")
+					do_edit_objectives_ambitions()
+					return
+				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+					do_edit_objectives_ambitions()
+					return
+				log_admin("[key_name(usr)] has edited the requested objective type for [current], of UID [uid], from [requested_objective["type"]] to [selected_type]")
+				message_admins("[key_name_admin(usr)] has edited the requested objective type for [current], of UID [uid], from [requested_objective["type"]] to [selected_type]")
+				requested_objective["type"] = selected_type
+			if("Text")
+				if(!check_rights(R_ADMIN))
+					return
+				if(QDELETED(antag_datum))
+					to_chat(usr, "<span class='warning'>No antag found.</span>")
+					do_edit_objectives_ambitions()
+					return
+				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+					do_edit_objectives_ambitions()
+					return
+				var/new_text = stripped_multiline_input(usr, "Input new requested objective text", "Requested Objective Text", requested_objective["text"], MAX_MESSAGE_LEN)
+				if (isnull(new_text))
+					return
+				if(!check_rights(R_ADMIN))
+					return
+				if(QDELETED(antag_datum))
+					to_chat(usr, "<span class='warning'>No antag found.</span>")
+					do_edit_objectives_ambitions()
+					return
+				if(!LAZYACCESS(antag_datum.requested_objectives, uid))
+					to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+					do_edit_objectives_ambitions()
+					return
+				log_admin("[key_name(usr)] has edited the requested objective text for [current], of UID [uid], from [requested_objective["text"]] to [new_text]")
+				message_admins("[key_name_admin(usr)] has edited the requested objective text for [current], of UID [uid], from [requested_objective["text"]] to [new_text]")
+				requested_objective["text"] = new_text
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["req_obj_accept"])
+		var/datum/antagonist/antag_datum = locate(href_list["req_obj_accept"])
+		if(QDELETED(antag_datum))
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			return
+		if(antag_datum.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
+			return
+		var/uid = href_list["req_obj_id"]
+		var/list/requested_objective = LAZYACCESS(antag_datum.requested_objectives, uid)
+		if(!requested_objective)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+			return
+		if(alert(usr, "Are you sure you want to approve this objective?", "Approve objective", "Yes", "No") != "Yes")
+			return
+		if(!check_rights(R_ADMIN))
+			return
+		if(QDELETED(antag_datum))
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			do_edit_objectives_ambitions()
+			return
+		if(!LAZYACCESS(antag_datum.requested_objectives, uid))
+			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+			do_edit_objectives_ambitions()
+			return
+		var/objective_path = requested_objective["type"]
+		var/datum/objective/new_objective = new objective_path
+		new_objective.owner = src
+		if(istype(new_objective, /datum/objective/custom))
+			new_objective.explanation_text = requested_objective["text"]
+		else
+			new_objective.admin_edit(usr)
+		antag_datum.objectives += new_objective
+		LAZYREMOVE(antag_datum.requested_objectives, uid)
+		message_admins("[key_name_admin(usr)] approved a requested objective from [current]: [new_objective.explanation_text]")
+		log_admin("[key_name(usr)] approved a requested objective from [current]: [new_objective.explanation_text]")
+		to_chat(current, "<span class='boldnotice'>Your objective request has been approved.</span>")
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["req_obj_deny"])
+		var/datum/antagonist/antag_datum = locate(href_list["req_obj_deny"])
+		if(QDELETED(antag_datum))
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			return
+		if(antag_datum.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid antag reference.</span>")
+			return
+		var/uid = href_list["req_obj_id"]
+		var/list/requested_objective = LAZYACCESS(antag_datum.requested_objectives, uid)
+		if(!requested_objective)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+			return
+		var/justifation = stripped_multiline_input(usr, "Justify why you are denying this objective request.", "Deny", memory, MAX_MESSAGE_LEN)
+		if(isnull(justifation))
+			return
+		if(!check_rights(R_ADMIN))
+			return
+		if(QDELETED(antag_datum))
+			to_chat(usr, "<span class='warning'>No antag found.</span>")
+			do_edit_objectives_ambitions()
+			return
+		if(!LAZYACCESS(antag_datum.requested_objectives, uid))
+			to_chat(usr, "<span class='warning'>Invalid requested objective reference.</span>")
+			do_edit_objectives_ambitions()
+			return
+		var/datum/objective/type_cast = requested_objective["type"]
+		var/objective_name = initial(type_cast.name)
+		message_admins("[key_name_admin(usr)] denied a requested [objective_name] objective from [current]: [requested_objective["text"]]")
+		log_admin("[key_name(usr)] denied a requested [objective_name] objective from [current]: [requested_objective["text"]]")
+		to_chat(current, "<span class='boldwarning'>Your objective request has been denied for the following reason: [justifation]</span>")
+		LAZYREMOVE(antag_datum.requested_objectives, uid)
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["obj_panel_complete_toggle"])
+		var/datum/objective/objective_to_toggle = locate(href_list["obj_panel_complete_toggle"])
+		if(!istype(objective_to_toggle) || QDELETED(objective_to_toggle))
+			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
+			do_edit_objectives_ambitions()
+			return
+		if(objective_to_toggle.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid objective reference.</span>")
+			return
+		objective_to_toggle.completed = !objective_to_toggle.completed
+		message_admins("[key_name_admin(usr)] toggled the win state for [current]'s objective: [objective_to_toggle.explanation_text]")
+		log_admin("[key_name(usr)] toggled the win state for [current]'s objective: [objective_to_toggle.explanation_text]")
+		if(alert(usr, "Would you like to alert the player of the change?", "Deny objective", "Yes", "No") == "Yes")
+			to_chat(current, "[objective_to_toggle.completed ? "<span class='boldnotice'>" : "<span class='boldwarning'>"]Your objective status has changed!</span>")
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["obj_panel_delete"])
+		var/datum/objective/objective_to_delete = locate(href_list["obj_panel_delete"])
+		if(!istype(objective_to_delete) || QDELETED(objective_to_delete))
+			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
+			do_edit_objectives_ambitions()
+			return
+		if(objective_to_delete.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid objective reference.</span>")
+			return
+		if(alert(usr, "Are you sure you want to delete this objective?", "Delete objective", "Yes", "No") != "Yes")
+			return
+		if(!check_rights(R_ADMIN))
+			return
+		if(QDELETED(objective_to_delete))
+			return
+		message_admins("[key_name_admin(usr)] removed an objective from [current]: [objective_to_delete.explanation_text]")
+		log_admin("[key_name(usr)] removed an objective from [current]: [objective_to_delete.explanation_text]")
+		qdel(objective_to_delete)
+		do_edit_objectives_ambitions()
+		return
+
+	else if (href_list["obj_panel_edit"])
+		var/datum/objective/objective_to_edit = locate(href_list["obj_panel_edit"])
+		if(!istype(objective_to_edit) || QDELETED(objective_to_edit))
+			to_chat(usr, "<span class='warning'>No objective found. Perhaps it was already deleted?</span>")
+			do_edit_objectives_ambitions()
+			return
+		if(objective_to_edit.owner != src)
+			do_edit_objectives_ambitions()
+			to_chat(usr, "<span class='warning'>Invalid objective reference.</span>")
+			return
+		var/explanation_before = objective_to_edit.explanation_text
+		objective_to_edit.admin_edit(usr)
+		if(QDELETED(objective_to_edit))
+			return
+		message_admins("[key_name_admin(usr)] edited an objective from [current]:\
+		Before: [explanation_before]\
+		After: [objective_to_edit.explanation_text]")
+		log_admin("[key_name(usr)] edited an objective from [current]:\
+		Before: [explanation_before]\
+		After: [objective_to_edit.explanation_text]")
+		do_edit_objectives_ambitions()
+		return
+
+
 //SKYRAT CHANGES END
+
 	if(href_list["add_antag"])
 		add_antag_wrapper(text2path(href_list["add_antag"]),usr)
 	if(href_list["remove_antag"])
@@ -685,39 +1086,17 @@
 						else
 							target_antag = target
 
-		var/static/list/choices
-		if(!choices)
-			choices = list()
+//SKYRAT CHANGES BEGIN
+		if(!GLOB.objective_choices)
+			populate_objective_choices()
 
-			var/list/allowed_types = list(
-				/datum/objective/assassinate,
-				/datum/objective/assassinate/once,
-				/datum/objective/maroon,
-				/datum/objective/debrain,
-				/datum/objective/protect,
-				/datum/objective/destroy,
-				/datum/objective/hijack,
-				/datum/objective/escape,
-				/datum/objective/survive,
-				/datum/objective/martyr,
-				/datum/objective/steal,
-				/datum/objective/download,
-				/datum/objective/nuclear,
-				/datum/objective/absorb,
-				/datum/objective/blackmail_implant, //SKYRAT EDIT
-				/datum/objective/custom
-			)
+		if(old_objective && GLOB.objective_choices[old_objective.name])
+			def_value = old_objective.name
 
-			for(var/T in allowed_types)
-				var/datum/objective/X = T
-				choices[initial(X.name)] = T
+		var/selected_type = input("Select objective type:", "Objective type", def_value) as null|anything in GLOB.objective_choices
+		selected_type = GLOB.objective_choices[selected_type]
+//SKYRAT CHANGES END
 
-		if(old_objective)
-			if(old_objective.name in choices)
-				def_value = old_objective.name
-
-		var/selected_type = input("Select objective type:", "Objective type", def_value) as null|anything in choices
-		selected_type = choices[selected_type]
 		if (!selected_type)
 			return
 
@@ -744,6 +1123,12 @@
 				target_antag.objectives.Insert(objective_pos, new_objective)
 			message_admins("[key_name_admin(usr)] edited [current]'s objective to [new_objective.explanation_text]")
 			log_admin("[key_name(usr)] edited [current]'s objective to [new_objective.explanation_text]")
+
+//SKYRAT CHANGES BEGIN
+		if(href_list["ambition_panel"])
+			do_edit_objectives_ambitions()
+			return
+//SKYRAT CHANGES END
 
 	else if(href_list["traitor_class"])
 		var/static/list/choices
@@ -829,6 +1214,11 @@
 
 	else if (href_list["obj_announce"])
 		announce_objectives()
+//SKYRAT CHANGES BEGIN
+		if(href_list["ambition_panel"])
+			do_edit_objectives_ambitions()
+			return
+//SKYRAT CHANGES END
 
 	//Something in here might have changed your mob
 	if(self_antagging && (!usr || !usr.client) && current.client)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -573,6 +573,17 @@ GLOBAL_LIST(objective_choices)
 		var/datum/objective/type_cast = t
 		GLOB.objective_choices[initial(type_cast.name)] = t
 
+
+/datum/mind/proc/on_objectives_request_cd_end(datum/source)
+	UnregisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES))
+	if(!antag_datums)
+		return
+	to_chat(current, "<span class='boldnotice'>The cooldown for objective change requests is over, you can make new ones now.</span>")
+	for(var/a in antag_datums)
+		var/datum/antagonist/antag_datum = a
+		if(!antag_datum.requested_objective_changes)
+			continue
+		to_chat(current, "<span class='boldnotice'>You seem to have unanswered change requests. The next one you do will bwoink the admins.</span>")
 //SKYRAT CHANGES END
 
 /datum/mind/Topic(href, href_list)
@@ -586,7 +597,7 @@ GLOBAL_LIST(objective_choices)
 		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
-			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
 				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
@@ -604,7 +615,7 @@ GLOBAL_LIST(objective_choices)
 		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
-			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
 				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
@@ -617,7 +628,8 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>There's a limit of [max_ambitions] ambitions. Edit or remove some to accomodate for your new additions.</span>")
 			do_edit_objectives_ambitions()
 			return
-		COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
+		TIMER_COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
+		RegisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES), .proc/on_objectives_request_cd_end)
 		LAZYADD(ambitions, new_ambition)
 		if(usr == current)
 			log_game("[key_name(usr)] has created their ambition of index [LAZYLEN(ambitions)].\nNEW AMBITION:\n[new_ambition]")
@@ -631,7 +643,7 @@ GLOBAL_LIST(objective_choices)
 		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
-			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
 				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
@@ -652,7 +664,7 @@ GLOBAL_LIST(objective_choices)
 		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
-			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
 				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
@@ -669,7 +681,8 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>The ambition has changed since we started editing it. Aborting to prevent data loss.</span>")
 			do_edit_objectives_ambitions()
 			return
-		COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
+		TIMER_COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
+		RegisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES), .proc/on_objectives_request_cd_end)
 		ambitions[ambition_index] = new_ambition
 		if(usr == current)
 			log_game("[key_name(usr)] has edited their ambition of index [ambition_index].\nOLD AMBITION:\n[old_ambition]\nNEW AMBITION:\n[new_ambition]")
@@ -683,7 +696,7 @@ GLOBAL_LIST(objective_choices)
 		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
-			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
 				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
@@ -704,7 +717,7 @@ GLOBAL_LIST(objective_choices)
 		if(!check_rights(R_ADMIN, FALSE))
 			if(usr != current)
 				return
-			if(COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
+			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_AMBITION))
 				to_chat(usr, "<span class='warning'>You must wait [AMBITION_COOLDOWN_TIME * 0.1] seconds between changes.</span>")
 				return
 		if(!isliving(current))
@@ -721,7 +734,8 @@ GLOBAL_LIST(objective_choices)
 			to_chat(usr, "<span class='warning'>The ambition has changed since we started considering its deletion. Aborting to prevent conflicts.</span>")
 			do_edit_objectives_ambitions()
 			return
-		COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
+		TIMER_COOLDOWN_START(src, COOLDOWN_AMBITION, AMBITION_COOLDOWN_TIME)
+		RegisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES), .proc/on_objectives_request_cd_end)
 		LAZYCUT(ambitions, ambition_index, ambition_index + 1)
 		if(usr == current)
 			log_game("[key_name(usr)] has deleted their ambition of index [ambition_index].\nDELETED AMBITION:\n[old_ambition]")
@@ -734,7 +748,7 @@ GLOBAL_LIST(objective_choices)
 	else if (href_list["req_obj_add"])
 		if(usr != current)
 			return
-		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
@@ -759,12 +773,13 @@ GLOBAL_LIST(objective_choices)
 			return
 		if(usr != current)
 			return
-		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		if(QDELETED(target_antag))
 			return
-		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		TIMER_COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		RegisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES), .proc/on_objectives_request_cd_end)
 		var/uid = "[GLOB.requested_objective_uid++]"
 		target_antag.add_objective_change(uid, list("request" = REQUEST_NEW_OBJECTIVE, "target" = selected_type, "text" = new_objective))
 		log_admin("Objectives request [uid] - [key_name(usr)] has requested a [choice] objective: [new_objective]")
@@ -776,7 +791,7 @@ GLOBAL_LIST(objective_choices)
 	else if (href_list["req_obj_delete"])
 		if(usr != current)
 			return
-		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
@@ -798,7 +813,7 @@ GLOBAL_LIST(objective_choices)
 			return
 		if(usr != current)
 			return
-		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		if(QDELETED(objective_to_delete) || QDELETED(target_antag))
@@ -810,7 +825,8 @@ GLOBAL_LIST(objective_choices)
 				continue
 			to_chat(usr, "<span class='warning'>There is already a change request tied to this objective waiting to be processed. Ahelp or wait for it to be resolved before adding a new one.</span>")
 			return
-		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		TIMER_COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		RegisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES), .proc/on_objectives_request_cd_end)
 		var/uid = "[GLOB.requested_objective_uid++]"
 		target_antag.add_objective_change(uid, list("request" = REQUEST_DEL_OBJECTIVE, "target" = objective_reference, "text" = justification))
 		log_admin("Objectives request [uid] - [key_name(usr)] has requested the deletion of the following objective: [objective_to_delete.explanation_text].\nTheir justification is as follows: [justification]")
@@ -822,7 +838,7 @@ GLOBAL_LIST(objective_choices)
 	else if (href_list["req_obj_completed"])
 		if(usr != current)
 			return
-		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		var/datum/antagonist/target_antag = locate(href_list["target_antag"]) in antag_datums
@@ -844,7 +860,7 @@ GLOBAL_LIST(objective_choices)
 			return
 		if(usr != current)
 			return
-		if(COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
+		if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_OBJECTIVES))
 			to_chat(usr, "<span class='warning'>You must wait [round(OBJECTIVES_COOLDOWN_TIME / 600, 0.1)] minutes between requests.</span>")
 			return
 		if(QDELETED(objective_to_complete) || QDELETED(target_antag))
@@ -856,7 +872,8 @@ GLOBAL_LIST(objective_choices)
 				continue
 			to_chat(usr, "<span class='warning'>There is already a change request tied to this objective waiting to be processed. Ahelp or wait for it to be resolved before adding a new one.</span>")
 			return
-		COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		TIMER_COOLDOWN_START(src, COOLDOWN_OBJECTIVES, OBJECTIVES_COOLDOWN_TIME)
+		RegisterSignal(src, COMSIG_CD_STOP(COOLDOWN_OBJECTIVES), .proc/on_objectives_request_cd_end)
 		var/uid = "[GLOB.requested_objective_uid++]"
 		target_antag.add_objective_change(uid, list("request" = (objective_to_complete.completed ? REQUEST_LOSE_OBJECTIVE : REQUEST_WIN_OBJECTIVE), "target" = objective_reference, "text" = justification))
 		log_admin("Objectives request [uid] - [key_name(usr)] has requested the [objective_to_complete.completed ? "incompletion" : "completion"] of the following objective: [objective_to_complete.explanation_text].\nTheir justification is as follows: [justification]")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -25,7 +25,10 @@
 		to_chat(usr, "You seem to be selecting a mob that doesn't exist anymore.")
 		return
 
-	var/body = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Options for [M.key]</title></head>"
+//SKYRAT CHANGES BEGIN
+	var/list/body = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Options for [M.key]</title></head>")
+//SKYRAT CHANGES END
+
 	body += "<body>Options panel for <b>[M]</b>"
 	if(M.client)
 		body += " played by <b>[M.client]</b> "
@@ -126,6 +129,10 @@
 	body += "<A href='?_src_=holder;[HrefToken()];narrateto=[REF(M)]'>Narrate to</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>Subtle message</A> | "
 	body += "<A href='?_src_=holder;[HrefToken()];languagemenu=[REF(M)]'>Language Menu</A>"
+//SKYRAT CHANGES BEGIN
+	if(M.mind)
+		body += " | <A href='?_src_=holder;[HrefToken()];ObjectiveRequest=[REF(M.mind)]'>Objective-Ambition Menu</A>"
+//SKYRAT CHANGES END
 
 	if (M.client)
 		if(!isnewplayer(M))
@@ -207,7 +214,12 @@
 	body += "<br>"
 	body += "</body></html>"
 
-	usr << browse(body, "window=adminplayeropts-[REF(M)];size=550x515")
+//SKYRAT CHANGES BEGIN
+	var/datum/browser/popup = new(usr, "adminplayeropts-[REF(M)]", "Player Panel", nwidth = 550, nheight = 515)
+	popup.set_content(body.Join())
+	popup.open()
+//SKYRAT CHANGES END
+
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Player Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -97,10 +97,14 @@ GLOBAL_VAR(antag_prototypes)
 		alert("This mind doesn't have a mob, or is deleted! For some reason!", "Edit Memory")
 		return
 
-	var/out = "<B>[name]</B>[(current && (current.real_name!=name))?" (as [current.real_name])":""]<br>"
-	out += "Mind currently owned by key: [key] [active?"(synced)":"(not synced)"]<br>"
-	out += "Assigned role: [assigned_role]. <a href='?src=[REF(src)];role_edit=1'>Edit</a><br>"
-	out += "Faction and special role: <b><font color='red'>[special_role]</font></b><br>"
+//SKYRAT CHANGES BEGIN
+	var/list/out = list(
+		"<B>[name]</B>[(current && (current.real_name!=name))?" (as [current.real_name])":""]<br>\
+		Mind currently owned by key: [key] [active?"(synced)":"(not synced)"]<br>\
+		Assigned role: [assigned_role]. <a href='?src=[REF(src)];role_edit=1'>Edit</a><br>\
+		Faction and special role: <b><font color='red'>[special_role]</font></b><br>"
+		)
+//SKYRAT CHANGES END
 
 	var/special_statuses = get_special_statuses()
 	if(length(special_statuses))
@@ -203,15 +207,25 @@ GLOBAL_VAR(antag_prototypes)
 		uplink_info += "." //hiel grammar
 
 		out += uplink_info + "<br>"
+//SKYRAT CHANGES BEGIN
+	//Ambitions
+	out += "<b>[current.real_name]'s Ambitions:</b> <a href='?src=[REF(src)];edit_ambitions_panel=1'>Edit Ambitions</a><br><ul>"
+	if(!LAZYLEN(ambitions))
+		out += "<li><i><b>NONE</b></i><li>"
+	else
+		for(var/count in 1 to LAZYLEN(ambitions))
+			out += "<li><B>Ambition #[count]</B>:<br>[ambitions[count]]"
+	out += "</ul>"
 	//Common Memory
-	var/common_memory = "<span>Common Memory:</span>"
-	common_memory += memory
-	common_memory += "<a href='?src=[REF(src)];memory_edit=1'>Edit Memory</a>"
-	out += common_memory + "<br>"
+	out += "<br><span>Common Memory:</span>"
+	out += memory
+	out += "<a href='?src=[REF(src)];memory_edit=1'>Edit Memory</a><br>"
 	//Other stuff
 	out += get_common_admin_commands()
+	out += "<br><a href='?src=[REF(src)];refresh_antag_panel=1'>Refresh</a>"
 
 	var/datum/browser/panel = new(usr, "traitorpanel", "", 600, 600)
-	panel.set_content(out)
+	panel.set_content(out.Join())
+//SKYRAT CHANGES END
 	panel.open()
 	return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2333,6 +2333,18 @@
 		var/mob/M = locate(href_list["HeadsetMessage"])
 		usr.client.admin_headset_message(M)
 
+//SKYRAT CHANGES BEGIN
+	else if(href_list["ObjectiveRequest"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/datum/mind/requesting_mind = locate(href_list["ObjectiveRequest"])
+		if(!istype(requesting_mind) || QDELETED(requesting_mind))
+			to_chat(usr, "<span class='warning'>This mind reference is no longer valid. It has probably since been destroyed.</span>")
+			return
+		requesting_mind.do_edit_objectives_ambitions()
+		return
+//SKYRAT CHANGES END
+
 	else if(href_list["reject_custom_name"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -23,6 +23,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/show_name_in_check_antagonists = FALSE //Will append antagonist name in admin listings - use for categories that share more than one antag type
 	var/list/blacklisted_quirks = list(/datum/quirk/nonviolent,/datum/quirk/mute) // Quirks that will be removed upon gaining this antag. Pacifist and mute are default.
 	var/threat = 0 // Amount of threat this antag poses, for dynamic mode
+// SKYRAT CHANGES BEGIN
+	/// Lazy list for antagonists to request the admins objectives.
+	var/list/requested_objectives
+// SKYRAT CHANGES END
+
 
 	var/list/skill_modifiers
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -281,17 +281,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	..()
 
 
-///Sends a message to the admins notifying them of a change request. Is a bit more insistent if there's pending requests.
-/datum/antagonist/proc/notify_admins_of_request(notification_message)
-	if(LAZYLEN(requested_objective_changes) > 1) //Not the first unprocessed request, be a bit more insistent.
-		for(var/a in GLOB.admins)
-			var/client/admin_client = a
-			if(admin_client.prefs.toggles & SOUND_ADMINHELP)
-				SEND_SOUND(admin_client, sound('sound/effects/adminhelp.ogg'))
-			window_flash(admin_client)
-	message_admins(notification_message)
-
-
 ///Clears change requests from deleted objectives to avoid broken references.
 /datum/antagonist/proc/clean_request_from_del_objective(datum/objective/source, force)
 	var/objective_reference = REF(source)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -32,8 +32,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /datum/antagonist/Destroy()
 	GLOB.antagonists -= src
-	if(owner)
-		LAZYREMOVE(owner.antag_datums, src)
+//SKYRAT CHANGES BEGIN
+	owner?.do_remove_antag_datum(src)
+//SKYRAT CHANGES END
 	owner = null
 	return ..()
 
@@ -109,7 +110,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 	remove_innate_effects()
 	clear_antag_moodies()
 	if(owner)
-		LAZYREMOVE(owner.antag_datums, src)
+//SKYRAT CHANGES BEGIN
+		owner.do_remove_antag_datum(src)
+//SKYRAT CHANGES END
 		for(var/A in skill_modifiers)
 			owner.remove_skill_modifier(GET_SKILL_MOD_ID(A, type))
 		if(!silent && owner.current)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/threat = 0 // Amount of threat this antag poses, for dynamic mode
 // SKYRAT CHANGES BEGIN
 	/// Lazy list for antagonists to request the admins objectives.
-	var/list/requested_objectives
+	var/list/requested_objective_changes
 // SKYRAT CHANGES END
 
 
@@ -279,3 +279,45 @@ GLOBAL_LIST_EMPTY(antagonists)
 	else
 		return
 	..()
+
+
+///Sends a message to the admins notifying them of a change request. Is a bit more insistent if there's pending requests.
+/datum/antagonist/proc/notify_admins_of_request(notification_message)
+	if(LAZYLEN(requested_objective_changes) > 1) //Not the first unprocessed request, be a bit more insistent.
+		for(var/a in GLOB.admins)
+			var/client/admin_client = a
+			if(admin_client.prefs.toggles & SOUND_ADMINHELP)
+				SEND_SOUND(admin_client, sound('sound/effects/adminhelp.ogg'))
+			window_flash(admin_client)
+	message_admins(notification_message)
+
+
+///Clears change requests from deleted objectives to avoid broken references.
+/datum/antagonist/proc/clean_request_from_del_objective(datum/objective/source, force)
+	var/objective_reference = REF(source)
+	for(var/uid in requested_objective_changes)
+		var/list/change_request = requested_objective_changes[uid]
+		if(change_request["target"] != objective_reference)
+			continue
+		LAZYREMOVE(requested_objective_changes, uid)
+
+
+/datum/antagonist/proc/add_objective_change(uid, list/additions)
+	LAZYADD(requested_objective_changes, uid)
+	var/datum/objective/request_target = additions["target"]
+	if(!ispath(request_target))
+		request_target = locate(request_target) in objectives
+		if(istype(request_target))
+			RegisterSignal(request_target, COMSIG_PARENT_QDELETING, .proc/clean_request_from_del_objective)
+	requested_objective_changes[uid] = additions
+
+
+/datum/antagonist/proc/remove_objective_change(uid)
+	if(!LAZYACCESS(requested_objective_changes, uid))
+		return
+	var/datum/objective/request_target = requested_objective_changes[uid]["target"]
+	if(!ispath(request_target))
+		request_target = locate(request_target) in objectives
+		if(istype(request_target))
+			UnregisterSignal(request_target, COMSIG_PARENT_QDELETING)
+	LAZYREMOVE(requested_objective_changes, uid)

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -65,7 +65,9 @@
 	user.copy_languages(target, LANGUAGE_ABSORB)
 
 	if(target.mind && user.mind)//if the victim and user have minds
-		target.mind.show_memory(user, 0) //I can read your mind, kekeke. Output all their notes.
+//SKYRAT CHANGES BEGIN
+		to_chat(user, "<i>[target.mind.show_memory()]</i>") //I can read your mind, kekeke. Output all their notes.
+//SKYRAT CHANGES END
 
 		//Some of target's recent speech, so the changeling can attempt to imitate them better.
 		//Recent as opposed to all because rounds tend to have a LOT of text.

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -47,7 +47,10 @@
 	cult_team = new_team
 
 /datum/antagonist/cult/proc/add_objectives()
-	objectives |= cult_team?.objectives
+//SKYRAT CHANGES BEGIN
+	if(cult_team)
+		objectives |= cult_team.objectives
+//SKYRAT CHANGES END
 
 /datum/antagonist/cult/Destroy()
 	QDEL_NULL(communion)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -2,7 +2,10 @@
 	..()
 	//Mind updates
 	sync_mind()
-	mind.show_memory(src, 0)
+//SKYRAT CHANGES BEGIN
+	if(mind.memory || mind.antag_datums)
+		to_chat(src, "<i>[mind.show_memory()]</i>")
+//SKYRAT CHANGES END
 
 	//Round specific stuff
 	if(SSticker.mode)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -439,7 +439,11 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 	set category = "IC"
 	set desc = "View your character's notes memory."
 	if(mind)
-		mind.show_memory(src)
+//SKYRAT CHANGES BEGIN
+		var/datum/browser/popup = new(src, "memory", "Memory and Notes")
+		popup.set_content(mind.show_memory())
+		popup.open()
+//SKYRAT CHANGES END
 	else
 		to_chat(src, "You don't have a mind datum for some reason, so you can't look at your notes, if you had any.")
 

--- a/modular_skyrat/code/game/gamemodes/objective.dm
+++ b/modular_skyrat/code/game/gamemodes/objective.dm
@@ -40,7 +40,7 @@
 	return target
 
 /datum/objective/blackmail_implant
-	name = "blcakmail implant"
+	name = "blackmail implant"
 	var/target_role_type=0
 	martyr_compatible = 1
 	var/special_equipment = list(/obj/item/implanter/blackmail)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -39,6 +39,7 @@
 #include "code\__DEFINES\configuration.dm"
 #include "code\__DEFINES\construction.dm"
 #include "code\__DEFINES\contracts.dm"
+#include "code\__DEFINES\cooldowns.dm"
 #include "code\__DEFINES\cult.dm"
 #include "code\__DEFINES\diseases.dm"
 #include "code\__DEFINES\DNA.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

* Adds an ambitions system for antags. It stores a series of player-set information with the purpose of describing what they hope to achieve for the round, to provide better context to their actions and gimmicks at the round end.
* Admins can see and edit the antag's ambitions through the objectives-ambitions panel.
* All additions, edits and deletes are logged. Players have a small 5 seconds cooldown between edits to prevent spam, admins don't.
* The max number of ambitions is set to 5 by default, but it's a config and thus can be changed either during the game or on the configs.txt
* Added a safe lazylist cut macro for convenience.
* Adds some cooldown systems for convenience.
* Adds a pair of admin macros to give them the choice of teleporting to the incident reported.
* Did minor cleanup on the code.
* Fixes a typo on the blackmail objective.

* On the same verb/panel, added an interface for players to request modifications, removals or additions of their objectives. The cooldown for using it is 10 minutes, which is pretty steep but it was what was requested of me.
* Admins can access this interface through the Player Panel, which is now in nice dark-mode, instead of blinding white.
* Players get notified when the cooldown has ended, and if they have pending requests that the next one will bwoink the admins.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Requested by Rayford/Iknil/Irsil.

## Changelog
:cl:
add: Antags gain the Objectives and Ambitions verb (in the IC tab), which allows them to set custom ambitions that will be shown at the end of the round's report to give better context to their actions, plus allows them to request the removal, addition or modification of their objectives to the admins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
