### PR TITLE
Round End Tatos

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -189,7 +189,7 @@
 	display_report(popcount)
 
 	CHECK_TICK
-
+	/* Skyrat change, removed.
 	// Add AntagHUD to everyone, see who was really evil the whole time!
 	for(var/datum/atom_hud/antag/H in GLOB.huds)
 		for(var/m in GLOB.player_list)
@@ -197,7 +197,7 @@
 			H.add_hud_to(M)
 
 	CHECK_TICK
-
+	*/
 	//Set news report and mode result
 	mode.set_round_result()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the icons above antag heads that happens at round end.

## Why It's Good For The Game

Can continue the RP, requested.

## Changelog
:cl: Afya
del: Antag icons no longer appear over antags at round end.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
