### PR TITLE
Puts Nanite replication protocolls back in as a normal node. Removes BEPIS technode unlock for that.

### DIFF
--- a/code/modules/research/techweb/nodes/bepis_nodes.dm
+++ b/code/modules/research/techweb/nodes/bepis_nodes.dm
@@ -50,16 +50,6 @@
 	hidden = TRUE
 	experimental = TRUE
 
-/datum/techweb_node/nanite_replication_protocols
-	id = "nanite_replication_protocols"
-	display_name = "Nanite Replication Protocols"
-	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
-	prereq_ids = list("nanite_smart")
-	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	hidden = TRUE
-	experimental = TRUE
-
 /datum/techweb_node/interrogation
 	id = "interrogation"
 	display_name = "Enhanced Interrogation Technology"

--- a/code/modules/research/techweb/nodes/nanites_nodes.dm
+++ b/code/modules/research/techweb/nodes/nanites_nodes.dm
@@ -67,15 +67,13 @@
 	design_ids = list("explosive_nanites","pyro_nanites","meltdown_nanites","viral_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	
-/datum/techweb_node/nanite_replication_protocols
+/datum/techweb_node/nanite_replication_protocols //Skyrats change start
 	id = "nanite_replication_protocols"
 	display_name = "Nanite Replication Protocols"
 	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
 	prereq_ids = list("nanite_smart")
 	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	hidden = TRUE
-	experimental = TRUE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) //Skyrats change end
 
 /datum/techweb_node/nanite_hazard
 	id = "nanite_hazard"

--- a/code/modules/research/techweb/nodes/nanites_nodes.dm
+++ b/code/modules/research/techweb/nodes/nanites_nodes.dm
@@ -81,4 +81,4 @@
 	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
 	prereq_ids = list("nanite_smart")
 	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) //Skyrats change end
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 12500) //Skyrats change end

--- a/code/modules/research/techweb/nodes/nanites_nodes.dm
+++ b/code/modules/research/techweb/nodes/nanites_nodes.dm
@@ -18,6 +18,14 @@
 	design_ids = list("purging_nanites", "research_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
+/datum/techweb_node/nanite_replication_protocols //Skyrats change start
+	id = "nanite_replication_protocols"
+	display_name = "Nanite Replication Protocols"
+	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
+	prereq_ids = list("nanite_smart")
+	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) //Skyrats change end
+
 /datum/techweb_node/nanite_mesh
 	id = "nanite_mesh"
 	display_name = "Mesh Nanite Programming"
@@ -67,14 +75,6 @@
 	design_ids = list("explosive_nanites","pyro_nanites","meltdown_nanites","viral_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	
-/datum/techweb_node/nanite_replication_protocols //Skyrats change start
-	id = "nanite_replication_protocols"
-	display_name = "Nanite Replication Protocols"
-	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
-	prereq_ids = list("nanite_smart")
-	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) //Skyrats change end
-
 /datum/techweb_node/nanite_hazard
 	id = "nanite_hazard"
 	display_name = "Hazard Nanite Programs"

--- a/code/modules/research/techweb/nodes/nanites_nodes.dm
+++ b/code/modules/research/techweb/nodes/nanites_nodes.dm
@@ -66,6 +66,16 @@
 	prereq_ids = list("nanite_harmonic", "syndicate_basic")
 	design_ids = list("explosive_nanites","pyro_nanites","meltdown_nanites","viral_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	
+/datum/techweb_node/nanite_replication_protocols
+	id = "nanite_replication_protocols"
+	display_name = "Nanite Replication Protocols"
+	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
+	prereq_ids = list("nanite_smart")
+	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	hidden = TRUE
+	experimental = TRUE
 
 /datum/techweb_node/nanite_hazard
 	id = "nanite_hazard"

--- a/code/modules/research/techweb/nodes/nanites_nodes.dm
+++ b/code/modules/research/techweb/nodes/nanites_nodes.dm
@@ -18,14 +18,6 @@
 	design_ids = list("purging_nanites", "research_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
-/datum/techweb_node/nanite_replication_protocols //Skyrats change start
-	id = "nanite_replication_protocols"
-	display_name = "Nanite Replication Protocols"
-	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
-	prereq_ids = list("nanite_smart")
-	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) //Skyrats change end
-
 /datum/techweb_node/nanite_mesh
 	id = "nanite_mesh"
 	display_name = "Mesh Nanite Programming"
@@ -82,3 +74,11 @@
 	prereq_ids = list("nanite_harmonic", "alientech")
 	design_ids = list("spreading_nanites","mindcontrol_nanites","mitosis_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	
+/datum/techweb_node/nanite_replication_protocols //Skyrats change start
+	id = "nanite_replication_protocols"
+	display_name = "Nanite Replication Protocols"
+	description = "Advanced behaviours that allow nanites to exploit certain circumstances to replicate faster."
+	prereq_ids = list("nanite_smart")
+	design_ids = list("kickstart_nanites","factory_nanites","tinker_nanites","offline_nanites","synergy_nanites")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) //Skyrats change end


### PR DESCRIPTION
Previously available relatively late (or if some guy reasearched nanites first and survived the lynching) now locked behind literal gambling and a waste of time.

## About The Pull Request

Removes one nanite technode from BEPIS. Moves the nanite technode back to regular RND. Considered raising the point cost a little.  Will do if asked.

## Why It's Good For The Game

BEPIS is a massive mistake. RNG paywalls that might give you nothing or 'amazing' stuff like gloves that cause 40 damage if you miss a grapple. How fun.

## Changelog
:cl:
tweak: BEPIS RNG fest now doesnt have nanite stuff in it anymore. Its dilluted enough as it is.
balance: Nanite replication protocoll research cost upped to 12500.
/:cl:

