### PR TITLE
This kills the bad officer - Disabler nerf

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -90,8 +90,10 @@
 		var/mob/living/carbon/C = target
 		if(C.getStaminaLoss() >= (C.maxHealth * 0.75))
 			damage = 0
+			name = "weakened [name]"
 		else if((C.getStaminaLoss() + damage) >= (C.maxHealth * 0.75)) //fuck you nerd
 			damage *= 0.65
+			name = "weakened [name]"
 //
 
 /obj/item/projectile/beam/pulse

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -81,6 +81,19 @@
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
 
+//skyrat edit - disablers can't do more than 75 stamina damage.
+//They serve as an effective slowdown weapon, but to truly down
+//someone you gotta pick the USP or baton.
+/obj/item/projectile/beam/disabler/on_hit(atom/target, blocked)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		if(C.staminaloss >= 75)
+			damage = 0
+		else if((C.staminaloss + damage) >= 75) //fuck you nerd
+			damage *= 0.5
+//
+
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -88,10 +88,10 @@
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
-		if(C.staminaloss >= 75)
+		if(C.getStaminaLoss() >= (C.maxHealth * 0.75))
 			damage = 0
-		else if((C.staminaloss + damage) >= 75) //fuck you nerd
-			damage *= 0.5
+		else if((C.getStaminaLoss() + damage) >= (C.maxHealth * 0.75)) //fuck you nerd
+			damage *= 0.65
 //
 
 /obj/item/projectile/beam/pulse

--- a/modular_skyrat/code/modules/projectiles/projectile/pistol.dm
+++ b/modular_skyrat/code/modules/projectiles/projectile/pistol.dm
@@ -3,5 +3,5 @@
 /obj/item/projectile/bullet/c9mm/rubber
 	name = "9mm rubber bullet"
 	desc = "Vacate, citizen."
-	damage = 0
+	damage = 2.5 //it should deal a small amount of damage
 	stamina = 28 //same damage as disabler but actually able to down someone

--- a/modular_skyrat/code/modules/projectiles/projectile/pistol.dm
+++ b/modular_skyrat/code/modules/projectiles/projectile/pistol.dm
@@ -4,4 +4,4 @@
 	name = "9mm rubber bullet"
 	desc = "Vacate, citizen."
 	damage = 0
-	stamina = 30 //2 more damage when compared to the disabler, to compensate for the armor being taken in account
+	stamina = 28 //same damage as disabler but actually able to down someone

--- a/modular_skyrat/code/modules/projectiles/projectile/pistol.dm
+++ b/modular_skyrat/code/modules/projectiles/projectile/pistol.dm
@@ -4,4 +4,4 @@
 	name = "9mm rubber bullet"
 	desc = "Vacate, citizen."
 	damage = 0
-	stamina = 25
+	stamina = 30 //2 more damage when compared to the disabler, to compensate for the armor being taken in account


### PR DESCRIPTION
## About The Pull Request

Title. This basically nerfs disablers a slowdown weapon. They are not able to deal stamina damage to someone who has 75 or more stamina damage. Essentially, this makes the USP and batons have an actual use, and punishes you for spamming disablers through windows.

Also, buffed stamina damage of the USP rubber bullets to match the disabler(from 25 to 28).

## Why It's Good For The Game

Why is a rubber loaded pistol worse than a disabler

## Changelog
:cl:
balance: Rubber 9mm shots now deal 2.5 brute damage. Just a mosquito sting.
balance: Rubber 9mm now deals a biiiit more stamina damage.
balance: Killed the disabler meta. Disablers now only work up to a certain point, past 75 stamina damage will require you to use rubber bullets or the baton to down the target.
/:cl:
