### PR TITLE
Makes maint energy more sane

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -156,17 +156,11 @@
 	// Skyrat change
 	if(user.a_intent != INTENT_HARM)
 		to_chat(user, "<span class='notice'>You push at the wall...</span>") 
+		user.changeNext_move(CLICK_CD_MELEE)
 		if(do_after(user, 4 SECONDS, target = src))
-			user.changeNext_move(CLICK_CD_MELEE)
 			to_chat(user, "<span class='notice'>...but nothing happens!</span>")
 			playsound(src, 'sound/weapons/genhit.ogg', 25, 1)
 			add_fingerprint(user)
-	else
-		if(isliving(user))
-			var/mob/living/ooser = user
-			if(ooser.has_status_effect(/datum/status_effect/kyle))
-				if(hardness > 20)
-					return attack_hulk(ooser, TRUE)
 	//
 
 /turf/closed/wall/attackby(obj/item/W, mob/user, params)

--- a/modular_skyrat/code/_DEFINES/status_effects.dm
+++ b/modular_skyrat/code/_DEFINES/status_effects.dm
@@ -1,3 +1,2 @@
 #define STATUS_EFFECT_CRUSHERMARK_HARM /datum/status_effect/crusher_mark/harm
 #define STATUS_EFFECT_HOLOBURN /datum/status_effect/holoburn //the weird burn effect of the holorifle
-#define STATUS_EFFECT_KYLE /datum/status_effect/kyle //maint energy blood red effect

--- a/modular_skyrat/code/datums/status_effects/buffs.dm
+++ b/modular_skyrat/code/datums/status_effects/buffs.dm
@@ -60,29 +60,3 @@
 	desc = "You are one with the dark. You'll get more and more invisible over time, as long as you stay immobile. The invisibility effect is reset whenever you interact with something."
 	icon = 'modular_skyrat/icons/mob/screen_alert.dmi'
 	icon_state = "stealth"
-
-//maint energy blood red effect
-/datum/status_effect/kyle
-	id = "kyle"
-	duration = -1
-	tick_interval = 0
-	alert_type = null
-	examine_text = "<span class='danger'><b>They look restless.</b></span>"
-	var/extra_punchlow = 5
-	var/extra_punchhigh = 12
-
-/datum/status_effect/kyle/on_apply()
-	. = ..()
-	if(ishuman(owner))
-		//there is no physiology for this, so i had to force my hand
-		var/mob/living/carbon/human/kyle = owner
-		kyle.dna.species.punchdamagelow += extra_punchlow
-		kyle.dna.species.punchdamagehigh += extra_punchhigh
-
-/datum/status_effect/kyle/on_remove()
-	. = ..()
-	if(ishuman(owner))
-		//there is no physiology for this, so i had to force my hand
-		var/mob/living/carbon/human/kyle = owner
-		kyle.dna.species.punchdamagelow -= extra_punchlow
-		kyle.dna.species.punchdamagehigh -= extra_punchhigh

--- a/modular_skyrat/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/modular_skyrat/code/modules/food_and_drinks/drinks/drinks.dm
@@ -67,7 +67,7 @@
 	icon_state = "maintenergy_bloodred"
 	crushed_icon = 'modular_skyrat/icons/obj/janitor.dmi'
 	crushed_state = "maintenergy_bloodred_trash"
-	list_reagents = list(/datum/reagent/consumable/maint_energy/raid/blood_red = 50)
+	list_reagents = list(/datum/reagent/consumable/maint_energy/blood_red = 50)
 	foodtype = SUGAR
 
 /obj/item/storage/box/syndie_kit/sixpack

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -9,8 +9,6 @@
 	pH = 5 //slightly acidic
 	glass_name = "glass of Maintenance Energy"
 	glass_desc = "Unleash the tide."
-	var/list/healed_roles = list("Assistant")
-	var/heal_amount = 0.25
 
 /datum/reagent/consumable/maint_energy/on_mob_add(mob/living/L, amount)
 	. = ..()
@@ -20,12 +18,7 @@
 	. = ..()
 	M.Jitter(20)
 	M.drowsyness = max(M.drowsyness - 0.5, 0)
-	if(M.mind)
-		if((M.mind.assigned_role in healed_roles) || (M.mind.special_role in healed_roles))
-			M.adjustBruteLoss(-heal_amount, 0)
-			M.adjustFireLoss(-heal_amount, 0)
-			M.adjustToxLoss(-heal_amount, 0)
-			M.adjustOxyLoss(-heal_amount, 0)
+	M.AdjustSleeping(-50)
 
 /datum/reagent/consumable/maint_energy/zero_fusion
 	name = "Maintenance Energy Zero Fusion"
@@ -36,16 +29,6 @@
 	glass_name = "glass of Maintenance Energy Zero Fusion"
 	glass_desc = "Unleash the singulo."
 
-/datum/reagent/consumable/maint_energy/zero_fusion/on_mob_life(mob/living/carbon/M)
-	. = ..()
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.age >= 30)
-			M.adjustBruteLoss(-(2 * heal_amount), 0)
-			M.adjustFireLoss(-(2 * heal_amount), 0)
-			M.adjustToxLoss(-(2 * heal_amount), 0)
-			M.adjustOxyLoss(-(2 * heal_amount), 0)
-
 /datum/reagent/consumable/maint_energy/tritium_flood
 	name = "Maintenance Energy Tritium Flood"
 	description = "The flavor of atmosia, inside your mouth."
@@ -55,7 +38,6 @@
 	taste_description = "radioactive lemon"
 	glass_name = "glass of Maintenance Energy Tritium Flood"
 	glass_desc = "Unleash the tesla."
-	healed_roles = list("Station Engineer", "Atmospheric Technician")
 
 /datum/reagent/consumable/maint_energy/plasma_fire
 	name = "Maintenance Energy Plasma Fire"
@@ -65,7 +47,6 @@
 	taste_description = "burning mango"
 	glass_name = "glass of Maintenance Energy Plasma Fire"
 	glass_desc = "Unleash the supermatter."
-	healed_roles = list("Station Engineer", "Atmospheric Technician")
 
 /datum/reagent/consumable/maint_energy/raid
 	name = "Maintenance Energy Raid"
@@ -75,30 +56,6 @@
 	taste_description = "cherries"
 	glass_name = "glass of Maintenance Energy Raid"
 	glass_desc = "Unleash the Death Squad."
-	healed_roles = list("Captain", "Head of Security", "Head of Personnel", "Blueshield",\
-						"Security Officer", "Detective", "Brig Physician", "Warden")
-	var/extraresist = 0
-	var/stunmod = 0
-	var/storedstunmod = 0
-	var/storedresistance = 0
-
-/datum/reagent/consumable/maint_energy/raid/on_mob_add(mob/living/L, amount)
-	. = ..()
-	var/mob/living/carbon/human/C = L
-	if(istype(C))
-		storedresistance = C.physiology.damage_resistance
-		C.physiology.damage_resistance += extraresist
-		storedstunmod = C.physiology.stun_mod
-		C.physiology.stun_mod += stunmod
-
-/datum/reagent/consumable/maint_energy/raid/on_mob_delete(mob/living/L)
-	. = ..()
-	var/mob/living/carbon/human/C = L
-	if(istype(C))
-		C.physiology.damage_resistance = storedresistance
-		storedresistance = 0
-		C.physiology.stun_mod = storedstunmod
-		storedstunmod = 0
 
 /datum/reagent/consumable/maint_energy/megaflavor
 	name = "Maintenance Energy Megaflavor"
@@ -108,9 +65,8 @@
 	taste_description = "bubblegum"
 	glass_name = "glass of Maintenance Energy Megaflavor"
 	glass_desc = "Only drink capable of turning you into a Blood-Drunk Miner."
-	healed_roles = list("Quartermaster", "Cargo Technician", "Shaft Miner")
 
-/datum/reagent/consumable/maint_energy/raid/blood_red
+/datum/reagent/consumable/maint_energy/blood_red
 	name = "Maintenance Energy Blood Red"
 	description = "Favored by operatives all around the frontier."
 	nutriment_factor = 0.357 * REAGENTS_METABOLISM
@@ -122,15 +78,12 @@
 				All crew are instructed to obey all instructions given by heads of staff. \
 				Any violations of these orders can be punished by death. \
 				This is not a drill.</b></span>"
-	extraresist = 0
-	stunmod = -0.5
-	healed_roles = list(ROLE_SYNDICATE, ROLE_TRAITOR)
-	heal_amount = 0.6
-	var/stamina_heal_amount = 1
-	var/stamina_buffer_heal_amount = 0.5
 
-/datum/reagent/consumable/maint_energy/raid/blood_red/on_mob_add(mob/living/L, amount)
+/datum/reagent/consumable/maint_energy/blood_red/on_mob_add(mob/living/L, amount)
 	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.physiology.stun_mod *= 0.5 //doesn't matter since stamina combat
 	if(prob(33))
 		var/code = (num2text(rand(0,9)) + num2text(rand(0,9)) + num2text(rand(0,9)))
 		var/designation = pick("Alfa","Bravo","Charlie","Delta","Echo","Foxtrot","Zero", "Niner")
@@ -138,15 +91,21 @@
 		playsound(L, 'sound/ambience/antag/tatoralert.ogg', 100)
 	to_chat(L, "<span class='userdanger'>The [src] makes you invincible.</span>")
 
-/datum/reagent/consumable/maint_energy/raid/blood_red/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/maint_energy/blood_red/on_mob_life(mob/living/carbon/M)
 	. = ..()
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.adjustStaminaLoss(-stamina_heal_amount)
-		H.adjustStaminaLossBuffered(-stamina_buffer_heal_amount)
+		H.adjustStaminaLoss(-1)
+		H.adjustStaminaLossBuffered(-0.5)
 		H.sprint_buffer = min(H.sprint_buffer_max, H.sprint_buffer + (H.sprint_buffer_regen_ds*2))
-		H.AdjustSleeping(-50)
+	M.adjustBruteLoss(-0.6, 0)
+	M.adjustFireLoss(-0.6, 0)
+	M.adjustToxLoss(-0.6, 0)
+	M.adjustOxyLoss(-0.6, 0)
 
-/datum/reagent/consumable/maint_energy/raid/blood_red/on_mob_delete(mob/living/L)
+/datum/reagent/consumable/maint_energy/blood_red/on_mob_delete(mob/living/L)
 	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.physiology.stun_mod *= 2
 	to_chat(L, "<span class='danger'>You feel weak again...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
No longer heals and instead wakes you up.
The syndicate variant remains the same 

Also removes the unused code with the kyle status effect ffs clean up your shit

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's dumb for it to heal you, especially it being a vendor item, now does what you'd expect an energy drink to do

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked maint energy to be an energy drink and not some miraculous healing potion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
