### PR TITLE
Alternate title disclaimer

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -484,6 +484,11 @@ SUBSYSTEM_DEF(job)
 			to_chat(M, "<b>[job.custom_spawn_text]</b>")
 		if(CONFIG_GET(number/minimal_access_threshold))
 			to_chat(M, "<span class='notice'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></span>")
+		//skyrat edit
+		if(display_rank != rank)
+		to_chat(M, "<span class='warning'>Remember that alternate titles are for the most part for flavor and roleplay. \
+					<b>Do not use your alt title as an excuse to forego your duties as a [rank].</b></span>"
+		//
 	if(ishuman(H))
 		var/mob/living/carbon/human/wageslave = H
 		to_chat(M, "<b><span class = 'big'>Your account ID is [wageslave.account_id].</span></b>")


### PR DESCRIPTION
## About The Pull Request

A disclaimer for people who join with a job alt title, informing them to not take their title at face value.
"Remember that alternate titles are, for the most part, for flavor and roleplay. **Do not use your alt title as an excuse to forego your duties as a [normal job name].**"

## Why It's Good For The Game

no more explorers saying they don't need to mine

## Changelog
:cl:
add: Joining with an alt title now has a disclaimer.
/:cl:
