### PR TITLE
Sometimes, reasonable spacemen must do unreasonable things - Adds a Killdozer Day holiday

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -22,6 +22,10 @@
 #define CHRISTMAS				"Christmas"
 #define FESTIVE_SEASON			"Festive Season"
 
+//skyrat holidays
+#define KILLDOZER_DAY			"Killdozer Day"
+//
+
 /*
 
 Days of the week to make it easier to reference them.

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -545,6 +545,8 @@
 	var/displayed_rank = rank
 	if(character.client && character.client.prefs && character.client.prefs.alt_titles_preferences[rank])
 		displayed_rank = character.client.prefs.alt_titles_preferences[rank]
+	if((rank == "Roboticist") && SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
+		display_rank = "Welder"
 	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
 	announcer.announce("ARRIVAL", character.real_name, displayed_rank, list()) //make the list empty to make it announce it in common
 	//End of skyrat changes

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -546,7 +546,7 @@
 	if(character.client && character.client.prefs && character.client.prefs.alt_titles_preferences[rank])
 		displayed_rank = character.client.prefs.alt_titles_preferences[rank]
 	if((rank == "Roboticist") && SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
-		display_rank = "Welder"
+		displayed_rank = "Welder"
 	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
 	announcer.announce("ARRIVAL", character.real_name, displayed_rank, list()) //make the list empty to make it announce it in common
 	//End of skyrat changes

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -473,6 +473,8 @@ SUBSYSTEM_DEF(job)
 	var/display_rank = rank
 	if(M.client && M.client.prefs && M.client.prefs.alt_titles_preferences[rank])
 		display_rank = M.client.prefs.alt_titles_preferences[rank]
+	if((rank == "Roboticist") && SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
+		display_rank = "Welder"
 	//End of skyrat changes
 	to_chat(M, "<b>You are the [display_rank].</b>") //Skyrat change
 	if(job)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -213,6 +213,8 @@
 		var/shown_assignment = assignment
 		if(C && C.prefs && C.prefs.alt_titles_preferences[assignment])
 			shown_assignment = C.prefs.alt_titles_preferences[assignment]
+		if((assignment == "Roboticist") && SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
+			shown_assignment = "Welder"
 		//End of skyrat changes
 
 		var/static/record_id_num = 1001

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -553,3 +553,14 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 	SSevents.holidays = list(HALLOWEEN = new /datum/holiday/halloween)
 	generate_selectable_species(FALSE)
 	SSevents.holidays = oldlist
+
+//skyrat holidays
+/datum/holiday/killdozer
+	name = KILLDOZER_DAY
+	begin_day = 1
+	begin_month = JUNE
+	end_day = 2
+
+/datum/holiday/killdozer/getStationPrefix()
+	return pick("Free", "American", "Independent", "Libertarian", "USA", "Marvin", "Welder", "Reasonable", "Furious", "Stateless", "Freedom", "Bulldozer", "Killdozer")
+//

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -265,7 +265,7 @@
 			C.assignment = J.title
 		if(SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
 			if(istype(J, /datum/job/roboticist))
-				assignment = "Welder"
+				C.assignment = "Welder"
 		//End of skyrat change
 		C.update_label()
 		for(var/A in SSeconomy.bank_accounts)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -263,6 +263,9 @@
 			C.assignment = preference_source.prefs.alt_titles_preferences[J.title]
 		else
 			C.assignment = J.title
+		if(SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
+			if(istype(J, /datum/job/roboticist))
+				assignment = "Welder"
 		//End of skyrat change
 		C.update_label()
 		for(var/A in SSeconomy.bank_accounts)

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -63,6 +63,14 @@
 	id = "SCIENCE"
 	organization = "Nanotrasen"
 
+//skyrat edit
+/datum/techweb/science/New()
+	. = ..()
+	if(SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
+		var/datum/techweb_node/illegal_mechs/Node = new()
+		research_node(Node, TRUE)
+//
+
 /datum/techweb/bepis	//Should contain only 1 BEPIS tech selected at random.
 	id = "EXPERIMENTAL"
 	organization = "Nanotrasen R&D"

--- a/modular_skyrat/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -61,6 +61,11 @@
 
 /datum/job/roboticist
 	alt_titles = list("Biomechanical Engineer", "Mechatronic Engineer")
+
+/datum/job/roboticist/New()
+	. = ..()
+	if(SSevents.holidays && SSevents.holidays[KILLDOZER_DAY])
+		alt_titles += "Welder"
 	
 /datum/job/geneticist
 	alt_titles = list("Biochemist")


### PR DESCRIPTION
## About The Pull Request

Title.
On Killdozer day the illegal mech technode is unlocked on roundstart, and all roboticists receive a "Welder" alt-title when joining

## Why It's Good For The Game

🇺🇸 🍔 Freedom 🍔 🇺🇸 

A day to remember the ever important rule of never trusting your government, arguably more american than the 4th of july.

## Changelog
:cl:
add: Added killdozer day as a holiday on june 4th
/:cl:
