### PR TITLE
parrot improvement

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -809,7 +809,7 @@
 
 /mob/living/simple_animal/parrot/Moved(oldLoc, dir)
 	. = ..()
-	if(. && !stat && client && parrot_state == PARROT_PERCH)
+	if(. && !stat && client && parrot_state == PARROT_PERCH && !buckled) //skyrat change - makes it so that the parrot won't switch to a living icon_state when perching and buckled ie no more flying parrot when perching on a person
 		parrot_state = PARROT_WANDER
 		icon_state = icon_living
 		pixel_x = initial(pixel_x)


### PR DESCRIPTION
## About The Pull Request

makes it so that the parrot doesn't switch to flying icon when perched on a person's shoulder

## Why It's Good For The Game

improvement

## Changelog
:cl:
tweak: makes it so that the parrot doesn't switch to flying icon when perched on a person's shoulder
/:cl:
