### PR TITLE
Spiders that are of horror may count as a spider

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -660,6 +660,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	spider_panic = typecacheof(list(
 					/mob/living/simple_animal/banana_spider,
 					/mob/living/simple_animal/hostile/poison/giant_spider,
+					/mob/living/simple_animal/hostile/poison/terror_spider, //Skyrat addition, spiders are now spiders to a flyswatter
 	))
 
 /obj/item/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)


### PR DESCRIPTION

## About The Pull Request
Makes spiders of horror weak to flyswatters

## Why It's Good For The Game

Consistency 

## Changelog
:cl:
add: terror spiders are weak to flyswatters like normal spiders...
/:cl: