### PR TITLE
Terror Spiders are now also organic and a bug

### DIFF
--- a/modular_skyrat/code/modules/mob/living/simple_animal/terror_spiders/terror_spiders.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/terror_spiders/terror_spiders.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	name = "terror spider"
 	desc = "The generic parent of all other terror spider types. If you see this in-game, it is a bug."
 	faction = list(ROLE_TERROR_SPIDER)
-
+	mob_biotypes = MOB_ORGANIC|MOB_BUG
 	// Icons
 	icon = 'modular_skyrat/icons/mob/terrorspider.dmi'
 	icon_state = "terror_red"


### PR DESCRIPTION

## About The Pull Request
Makes spiders of horror weak to pestspray

## Why It's Good For The Game

Consistency 

## Changelog
:cl:
add: terror spiders are weak to bug based chems like normal spiders...
/:cl: