### PR TITLE
Makes ATVs not purchasable through cargo

### DIFF
--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -11,10 +11,10 @@
 
 /datum/supply_pack/emergency/vehicle
 	name = "Biker Gang Kit" //TUNNEL SNAKES OWN THIS TOWN
-	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains an unbranded All Terrain Vehicle, two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!"
+	desc = "TUNNEL SNAKES OWN THIS TOWN. Contains two cans of spraypaint, and a complete gang outfit -- consists of black gloves, a menacing skull bandanna, and a SWEET leather overcoat!" //skyrat edit
 	cost = 2500
 	contraband = TRUE
-	contains = list(/obj/vehicle/ridden/atv,
+	contains = list(///obj/vehicle/ridden/atv, //skyrat edit fuck you
 					/obj/item/key,
 					/obj/item/toy/crayon/spraycan,
 					/obj/item/toy/crayon/spraycan,

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -69,7 +69,7 @@
 /datum/supply_pack/service/snowmobile
 	name = "Snowmobile kit"
 	desc = "trapped on a frigid wasteland? need to get around fast? purchase a refurbished snowmobile, with a FREE 10 microsecond warranty!"
-	cost = 1500 // 1000 points cheaper than ATV
+	cost = 1000000 // 1000 points cheaper than ATV
 	contains = list(/obj/vehicle/ridden/atv/snowmobile = 1,
 			/obj/item/key = 1,
 			/obj/item/clothing/mask/gas/explorer = 1)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/25989101/84102390-b1df6000-a9e6-11ea-90c6-faf72fd5fee6.png)

![image](https://user-images.githubusercontent.com/25989101/84102399-bc015e80-a9e6-11ea-88a1-0a3a7a2c60e5.png)

![image](https://user-images.githubusercontent.com/25989101/84102454-e4895880-a9e6-11ea-8bb9-9d6f33c257b5.png)

## Why It's Good For The Game

It's not. If the entire game was designed around Feasel i'd have to babyproof every corner of it. There is not a single moment in which i see Feasel talking about the game like a normal person and not a fucking **SS13 speedrunner 100% all megafauna hellburn engine 1000000000 cargo credits**.

## Changelog
:cl:
balance: Cargo can no longer buy ATVs.
/:cl: