### PR TITLE
[Fix] Sprite size speed penalty formula

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -678,7 +678,7 @@
 	holder.update_transform()
 	var/danger = CONFIG_GET(number/threshold_body_size_slowdown)
 	if(features["body_size"] < danger)
-		var/slowdown = 1 + round(danger/features["body_size"], 0.1) * CONFIG_GET(number/body_size_slowdown_multiplier)
+		var/slowdown = (1 - round(features["body_size"] / danger, 0.1)) * CONFIG_GET(number/body_size_slowdown_multiplier)
 		holder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/small_stride, TRUE, slowdown)
 	else if(old_size < danger)
 		holder.remove_movespeed_modifier(/datum/movespeed_modifier/small_stride)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1594,7 +1594,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 			else
 				dat += "<b><font color='[font_color]'>[language_name]:</font></b> [initial(L.desc)]"
 				dat += "<a href='?_src_=prefs;preference=language;task=update;language=[has_language ? nullify : language_name]'>[has_language ? "Remove" : "Choose"]</a><br>"
-	else 
+	else
 		dat += "<center><b>The language subsystem hasn't fully loaded yet! Please wait a bit and try again.</b></center><br>"
 	dat += "<hr>"
 	dat += "<center><a href='?_src_=prefs;preference=language;task=close'>Done</a></center>"
@@ -1905,7 +1905,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
 						features["flavor_text"] = html_decode(msg)
-				
+
 				if("silicon_flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", features["silicon_flavor_text"], MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
@@ -1916,7 +1916,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 					var/msg = stripped_multiline_input(usr, "Set your OOC Notes", "OOC Notes", skyrat_ooc_notes, MAX_FLAVOR_LEN, TRUE)
 					if(msg)
 						skyrat_ooc_notes = html_decode(msg)
-				
+
 				if("bloodtype")
 					var/msg = input(usr, "Choose your blood type", "Blood Type", "") as anything in (pref_species.bloodtypes + "Default")
 					if(msg)
@@ -2654,14 +2654,16 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 					var/min = CONFIG_GET(number/body_size_min)
 					var/max = CONFIG_GET(number/body_size_max)
 					var/danger = CONFIG_GET(number/threshold_body_size_slowdown)
-					var/new_body_size = input(user, "Choose your desired sprite size:\n([min*100]%-[max*100]%), Warning: May make your character look distorted[danger > min ? ", and an exponential slowdown will occur for those smaller than [danger*100]%!" : "!"]", "Character Preference", features["body_size"]*100) as num|null
+					var/new_body_size = input(user, "Choose your desired sprite size: ([min*100]%-[max*100]%)\nWarning: This may make your character look distorted[danger > min ? "! Additionally, a proportional movement speed penalty will be applied to characters smaller than [danger*100]%." : "!"]", "Character Preference", features["body_size"]*100) as num|null
 					if (new_body_size)
 						new_body_size = clamp(new_body_size * 0.01, min, max)
 						var/dorfy
-						if(danger > new_body_size)
-							dorfy = alert(user, "The chosen size appears to be smaller than the threshold of [danger*100]%, which will lead to an added exponential slowdown. Are you sure about that?", "Dwarfism Alert", "Yes", "Move it to the threshold", "No")
-							if(!dorfy || dorfy == "Move it above the threshold")
-								new_body_size = danger
+						if(new_body_size < danger)
+							dorfy = alert(user, "You have chosen a size below the slowdown threshold of [danger*100]%. For balancing purposes, the further you go below this percentage, the slower your character will be. Do you wish to keep this size?", "Speed Penalty Alert", "Yes", "Move it to the threshold", "No")
+						if(dorfy == "No")
+							return
+						if(dorfy == "Move it to the threshold")
+							new_body_size = danger
 						if(dorfy != "No")
 							features["body_size"] = new_body_size
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -66,6 +66,8 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 
 	/// Custom Keybindings
 	var/list/key_bindings = list()
+	/// List with a key string associated to a list of keybindings. Unlike key_bindings, this one operates on raw key, allowing for binding a key that triggers regardless of if a modifier is depressed as long as the raw key is sent.
+	var/list/modless_key_bindings = list()
 
 
 	var/tgui_fancy = TRUE
@@ -432,9 +434,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 				if(!length(features["flavor_text"]))
 					dat += "\[...\]<BR>" //skyrat - adds <br> //come to brazil or brazil comes to you
 				else
-					dat += "[features["flavor_text"]]<BR>" //skyrat - adds <br>
+					dat += "[html_encode(features["flavor_text"])]<BR>" //skyrat - adds <br> and uses html_encode
 			else
-				dat += "[TextPreview(features["flavor_text"])]...<BR>"
+				dat += "[TextPreview(html_encode(features["flavor_text"]))]...<BR>" //skyrat edit, uses html_encode
 			//SKYRAT EDIT
 			dat += 	"Records :"
 			dat += 	"<a href='?_src_=prefs;preference=general_records;task=input'>General</a>"
@@ -1211,11 +1213,16 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 			Input mode is the closest thing to the old input system.<br>\
 			<b>IMPORTANT:</b> While in input mode's non hotkey setting (tab toggled), Ctrl + KEY will send KEY to the keybind system as the key itself, not as Ctrl + KEY. This means Ctrl + T/W/A/S/D/all your familiar stuff still works, but you \
 			won't be able to access any regular Ctrl binds.<br>"
+			dat += "<br><b>Modifier-Independent binding</b> - This is a singular bind that works regardless of if Ctrl/Shift/Alt are held down. For example, if combat mode is bound to C in modifier-independent binds, it'll trigger regardless of if you are \
+			holding down shift for sprint. <b>Each keybind can only have one independent binding, and each key can only have one keybind independently bound to it.</b>"
 			// Create an inverted list of keybindings -> key
 			var/list/user_binds = list()
+			var/list/user_modless_binds = list()
 			for (var/key in key_bindings)
 				for(var/kb_name in key_bindings[key])
 					user_binds[kb_name] += list(key)
+			for (var/key in modless_key_bindings)
+				user_modless_binds[modless_key_bindings[key]] = key
 
 			var/list/kb_categories = list()
 			// Group keybinds by category
@@ -1223,21 +1230,29 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 				var/datum/keybinding/kb = GLOB.keybindings_by_name[name]
 				kb_categories[kb.category] += list(kb)
 
-			dat += "<style>label { display: inline-block; width: 200px; }</style><body>"
+			dat += {"
+			<style>
+			span.bindname { display: inline-block; position: absolute; width: 20% ; left: 5px; padding: 5px; } \
+			span.bindings { display: inline-block; position: relative; width: auto; left: 20%; width: auto; right: 20%; padding: 5px; } \
+			span.independent { display: inline-block; position: absolute; width: 20%; right: 5px; padding: 5px; } \
+			</style><body>
+			"}
 
 			for (var/category in kb_categories)
 				dat += "<h3>[category]</h3>"
 				for (var/i in kb_categories[category])
 					var/datum/keybinding/kb = i
+					var/current_independent_binding = user_modless_binds[kb.name] || "Unbound"
 					if(!length(user_binds[kb.name]))
-						dat += "<label>[kb.full_name]</label> <a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=["Unbound"]'>Unbound</a>"
+						dat += "<span class='bindname'>[kb.full_name]</span><span class='bindings'><a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=["Unbound"]'>Unbound</a>"
 						var/list/default_keys = hotkeys ? kb.hotkey_keys : kb.classic_keys
 						if(LAZYLEN(default_keys))
 							dat += "| Default: [default_keys.Join(", ")]"
+						dat += "</span><span class='independent'>Independent Binding: <a href='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[current_independent_binding];independent=1'>[current_independent_binding]</a></span>"
 						dat += "<br>"
 					else
 						var/bound_key = user_binds[kb.name][1]
-						dat += "<label>[kb.full_name]</label> <a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[bound_key]'>[bound_key]</a>"
+						dat += "<span class='bindname'l>[kb.full_name]</span><span class='bindings'><a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[bound_key]'>[bound_key]</a>"
 						for(var/bound_key_index in 2 to length(user_binds[kb.name]))
 							bound_key = user_binds[kb.name][bound_key_index]
 							dat += " | <a href ='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[bound_key]'>[bound_key]</a>"
@@ -1246,6 +1261,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 						var/list/default_keys = hotkeys ? kb.classic_keys : kb.hotkey_keys
 						if(LAZYLEN(default_keys))
 							dat += "| Default: [default_keys.Join(", ")]"
+						dat += "</span><span class='independent'>Independent Binding: <a href='?_src_=prefs;preference=keybindings_capture;keybinding=[kb.name];old_key=[current_independent_binding];independent=1'>[current_independent_binding]</a></span>"
 						dat += "<br>"
 
 			dat += "<br><br>"
@@ -1271,7 +1287,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 #undef APPEARANCE_CATEGORY_COLUMN
 #undef MAX_MUTANT_ROWS
 
-/datum/preferences/proc/CaptureKeybinding(mob/user, datum/keybinding/kb, var/old_key)
+/datum/preferences/proc/CaptureKeybinding(mob/user, datum/keybinding/kb, old_key, independent = FALSE)
 	var/HTML = {"
 	<div id='focus' style="outline: 0;" tabindex=0>Keybinding: [kb.full_name]<br>[kb.description]<br><br><b>Press any key to change<br>Press ESC to clear</b></div>
 	<script>
@@ -1283,7 +1299,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 		var shift = e.shiftKey ? 1 : 0;
 		var numpad = (95 < e.keyCode && e.keyCode < 112) ? 1 : 0;
 		var escPressed = e.keyCode == 27 ? 1 : 0;
-		var url = 'byond://?_src_=prefs;preference=keybindings_set;keybinding=[kb.name];old_key=[old_key];clear_key='+escPressed+';key='+e.key+';alt='+alt+';ctrl='+ctrl+';shift='+shift+';numpad='+numpad+';key_code='+e.keyCode;
+		var url = 'byond://?_src_=prefs;preference=keybindings_set;keybinding=[kb.name];old_key=[old_key];[independent?"independent=1":""];clear_key='+escPressed+';key='+e.key+';alt='+alt+';ctrl='+ctrl+';shift='+shift+';numpad='+numpad+';key_code='+e.keyCode;
 		window.location=url;
 		deedDone = true;
 	}
@@ -1902,9 +1918,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FLAVOR_LEN, TRUE)
+					var/msg = input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"]) as message|null //Skyrat edit, removed stripped_multiline_input()
 					if(!isnull(msg))
-						features["flavor_text"] = html_decode(msg)
+						features["flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE) //Skyrat edit, removed html_decode()
 
 				if("silicon_flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", features["silicon_flavor_text"], MAX_FLAVOR_LEN, TRUE)
@@ -2773,8 +2789,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 
 				if("keybindings_capture")
 					var/datum/keybinding/kb = GLOB.keybindings_by_name[href_list["keybinding"]]
-					var/old_key = href_list["old_key"]
-					CaptureKeybinding(user, kb, old_key)
+					CaptureKeybinding(user, kb, href_list["old_key"], text2num(href_list["independent"]))
 					return
 
 				if("keybindings_set")
@@ -2784,13 +2799,18 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 						ShowChoices(user)
 						return
 
+					var/independent = href_list["independent"]
+
 					var/clear_key = text2num(href_list["clear_key"])
 					var/old_key = href_list["old_key"]
 					if(clear_key)
-						if(key_bindings[old_key])
-							key_bindings[old_key] -= kb_name
-							if(!length(key_bindings[old_key]))
-								key_bindings -= old_key
+						if(independent)
+							modless_key_bindings -= old_key
+						else
+							if(key_bindings[old_key])
+								key_bindings[old_key] -= kb_name
+								if(!length(key_bindings[old_key]))
+									key_bindings -= old_key
 						user << browse(null, "window=capturekeypress")
 						save_preferences()
 						ShowChoices(user)
@@ -2816,15 +2836,18 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 							full_key = "[AltMod][CtrlMod][new_key]"
 						else
 							full_key = "[AltMod][CtrlMod][ShiftMod][numpad][new_key]"
-					if(key_bindings[old_key])
-						key_bindings[old_key] -= kb_name
-						if(!length(key_bindings[old_key]))
-							key_bindings -= old_key
-					key_bindings[full_key] += list(kb_name)
-					key_bindings[full_key] = sortList(key_bindings[full_key])
-
-					user << browse(null, "window=capturekeypress")
+					if(independent)
+						modless_key_bindings -= old_key
+						modless_key_bindings[full_key] = kb_name
+					else
+						if(key_bindings[old_key])
+							key_bindings[old_key] -= kb_name
+							if(!length(key_bindings[old_key]))
+								key_bindings -= old_key
+						key_bindings[full_key] += list(kb_name)
+						key_bindings[full_key] = sortList(key_bindings[full_key])
 					user.client.update_movement_keys()
+					user << browse(null, "window=capturekeypress")
 					save_preferences()
 
 				if("keybindings_reset")
@@ -2834,6 +2857,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 						return
 					hotkeys = (choice == "Hotkey")
 					key_bindings = (hotkeys) ? deepCopyList(GLOB.hotkey_keybinding_list_by_key) : deepCopyList(GLOB.classic_keybinding_list_by_key)
+					modless_key_bindings = list()
 					user.client.update_movement_keys()
 
 				if("chat_on_map")

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -46,7 +46,7 @@ MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 1
 ##MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal/slime 0
 MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 
-## PROJECTILES 
+## PROJECTILES
 
 ## 1 is the default projectile speed, so 1.5 would be 50% faster.
 PROJECTILE_SPEED_MODIFIER 1
@@ -466,7 +466,7 @@ ROUNDSTART_RACES dwarf
 #ROUNDSTART_RACES silver
 #ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
-#ROUNDSTART_RACES synth
+ROUNDSTART_RACES synth
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton
@@ -495,7 +495,7 @@ ROUNDSTART_RACES moth
 ##-------------------------------------------------------------------------------------------
 
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
-#JOIN_WITH_MUTANT_HUMANS
+JOIN_WITH_MUTANT_HUMANS
 
 ##Overflow job. Default is assistant
 OVERFLOW_JOB Assistant
@@ -666,17 +666,18 @@ PENIS_MIN_INCHES_PREFS 1
 PENIS_MAX_INCHES_PREFS 20
 
 ## Body size configs, the feature will be disabled if both min and max have the same value.
-BODY_SIZE_MIN 1
-BODY_SIZE_MAX 1
+BODY_SIZE_MIN 0.60
+BODY_SIZE_MAX 1.25
 
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.
-## To disable, just make sure the value is lower than 'body_size_min'
+## To completely disable this slowdown function, set the value below to 0.
 THRESHOLD_BODY_SIZE_SLOWDOWN 0.85
 
 ## Multiplier used in the smaller strides slowdown calculation.
+## This is a linear function that smoothly intensifies as the player size decreases below the above threshold.
 ## Doesn't apply to floating or crawling mobs.
-BODY_SIZE_SLOWDOWN_MULTIPLIER 0.25
+BODY_SIZE_SLOWDOWN_MULTIPLIER 3.0
 
 ## Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 ALLOW_CUSTOM_SKINTONES

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -466,7 +466,7 @@ ROUNDSTART_RACES dwarf
 #ROUNDSTART_RACES silver
 #ROUNDSTART_RACES uranium
 #ROUNDSTART_RACES abductor
-ROUNDSTART_RACES synth
+#ROUNDSTART_RACES synth
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton
@@ -495,7 +495,7 @@ ROUNDSTART_RACES moth
 ##-------------------------------------------------------------------------------------------
 
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game
-JOIN_WITH_MUTANT_HUMANS
+#JOIN_WITH_MUTANT_HUMANS
 
 ##Overflow job. Default is assistant
 OVERFLOW_JOB Assistant
@@ -667,7 +667,7 @@ PENIS_MAX_INCHES_PREFS 20
 
 ## Body size configs, the feature will be disabled if both min and max have the same value.
 BODY_SIZE_MIN 0.60
-BODY_SIZE_MAX 1.25
+BODY_SIZE_MAX 1.50
 
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**This is not a balance change.** This PR fixes a broken formula that does not do what it says it does, and changes it to something that can be more easily changed for balance as staff sees fit.

The current equation used is `1 + [slowdown threshold (85%)] / [body size] * [slowdown multiplier (.25)]`. This means that any size between 150% - 86% receives no speed changes, but as soon as you hit 85%, your speed is more or less halved. Furthermore, there is no noticeable difference in speed between 85% - 60%, making it more advantageous to choose the smallest size if you're already at the threshold. This slowdown is definitely not exponential, despite what it says. No amount of config value adjustments can fix this broken formula, hence why this PR was made.

See the screen captures below for proof (For reference, all clips are exactly 7 seconds long):
86% size (no slowdown) - https://i.gyazo.com/cc1a99fb414b7cf7ebb1a0e89fee1f79.mp4
85% size  (massive slowdown) - https://i.gyazo.com/49a6d7b800fdb99edb01d7d60d238d2f.mp4
60% size  (barely any difference) - https://i.gyazo.com/8fa486f265b531cdae899b45e96a7276.mp4

The new equation is `(1 - [body size] / [slowdown threshold (85%)]) * [slowdown multiplier (3)]`. There is no slowdown applied until you're below the threshold, and then a speed penalty is gradually applied, which increases the smaller the character gets, up to a maximum of the slowdown multiplier. **The `BODY_SIZE_SLOWDOWN_MULTIPLIER` needs to be changed in the `game_options.txt` config file**, assuming merging this does not change it. The current value of .25 will not work well with this new equation; in my testing, 3 is a good value to have it at, but staff are free to balance it however they please.

I also reworded some text to make things more clear for the player, fixed a button that didn't work, and did some cleanup.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes a poorly-written formula that failed to accomplish its intended goal, and makes it easier for server owners to balance the speed penalty for small sprites. Also fixes some smaller bugs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed the slowdown formula for small character sprites; no more jarring slowdown at threshold and you now actually get slower as you go further below the threshold.
fix: Fixed the "Move it to the threshold" button; it now does what it says.
tweak: Reworded some text to be clearer.
config: Changed the default BODY_SIZE_SLOWDOWN_MULTIPLIER from 0.25 to 3 in the config to adjust for the new formula. Let the appropriate staff know if small characters should be slower or faster; only they can change this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
