### PR TITLE
Rebalances two Abductor Glands

### DIFF
--- a/code/modules/antagonists/abductor/equipment/glands/transform.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/transform.dm
@@ -1,15 +1,9 @@
 /obj/item/organ/heart/gland/transform
-	true_name = "anthropmorphic transmorphosizer"
+	true_name = "Psychic Domination Device" //Cheap RA2 Ref, Skyrats change.
 	cooldown_low = 900
 	cooldown_high = 1800
-	uses = -1
+	uses = 0
 	human_only = TRUE
 	icon_state = "species"
 	mind_control_uses = 7
-	mind_control_duration = 300
-
-/obj/item/organ/heart/gland/transform/activate()
-	to_chat(owner, "<span class='notice'>You feel unlike yourself.</span>")
-	randomize_human(owner)
-	var/species = pick(list(/datum/species/human, /datum/species/lizard, /datum/species/insect, /datum/species/fly))
-	owner.set_species(species)
+	mind_control_duration = 3000 //skyrats change end

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -7,12 +7,9 @@
 	mind_control_uses = 3
 	mind_control_duration = 1800
 
-/obj/item/organ/heart/gland/trauma/activate()
+/obj/item/organ/heart/gland/trauma/activate()	//Skyrats change start
 	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
-	if(prob(33))
+	if(prob(50))
 		owner.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_SURGERY))
 	else
-		if(prob(20))
-			owner.gain_trauma_type(BRAIN_TRAUMA_SEVERE, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_SURGERY))
-		else
-			owner.gain_trauma_type(BRAIN_TRAUMA_MILD, rand(TRAUMA_RESILIENCE_BASIC, TRAUMA_RESILIENCE_SURGERY))
+		owner.gain_trauma_type(BRAIN_TRAUMA_MILD, (TRAUMA_RESILIENCE_BASIC)) //skyrats change end


### PR DESCRIPTION
## About The Pull Request

Rebalances two questionable abductor glands.

## Why It's Good For The Game

Species gland is basicly not fixable whatsoever, not even with genetics help and due to the massive ammount of customization options results in rather hideous randomized appearences which makes it instant "I cryo" material. Species gland was reworked into "Psychic Domination Device" gland. It gives the longest mind control with the highest number of uses for abductors. No other benefits or drawbacks. No quirks. Was gonna go first with "Mental Omega" gland but nobody would probably catch the reference.

Trauma gland got the severe trauma roll chance removed and the surgery requirement for minor traumas removed aswell.

## Changelog
:cl:
add: Psychic Domination Gland
del: Species Transformation Gland
balance: Trauma Gland less bothersome for the receiving end, has a higher chance to roll special trauma which are gimmicky and not nearly as bothersome as severe traumas.
/:cl:


