### PR TITLE
Disables Overthrow

### DIFF
--- a/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/modular_skyrat/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -59,6 +59,7 @@
 //                                      //
 //////////////////////////////////////////
 
+/*
 /datum/dynamic_ruleset/roundstart/overthrow
 	name = "Overthrow"
 	config_tag = "overthrow"
@@ -91,3 +92,4 @@
 		var/datum/antagonist/overthrow/O = agent.add_antag_datum(/datum/antagonist/overthrow) // create_team called on_gain will create the team
 		O.equip_initial_overthrow_agent()
 	return TRUE
+	*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Overthrow is a:
Buggy Mess
Rolls too Often (9/10 rounds it will be overthrow)
Results in many tickets from both sides
Causes bloodpressure issues among the crew
Is unenjoyable for security, and most of the time, the mutineers themselves

Overthrow also Encourages:
Permanent killing/exiles
LRP behaviour
A lack of RP and more mechanical pursuits
The objectives literally forcing you to subvert the AI every shift, resulting in chaos

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Overthrow man bad for the reasons listed above.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: overthrow has been deleted(commented) from the code, will no longer roll on dynamic but still can be manually forced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
