### PR TITLE
Respawned players are no longer eligible for antag rep or latejoin antag

### DIFF
--- a/code/__DEFINES/modular_skyrat/lists.dm
+++ b/code/__DEFINES/modular_skyrat/lists.dm
@@ -1,1 +1,1 @@
-GLOBAL_LIST_EMPTY(antag_rolled_ckeys)
+GLOBAL_LIST_EMPTY(respawned_ckeys)

--- a/code/__DEFINES/modular_skyrat/lists.dm
+++ b/code/__DEFINES/modular_skyrat/lists.dm
@@ -1,0 +1,1 @@
+GLOBAL_LIST_EMPTY(antag_rolled_ckeys)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -462,7 +462,7 @@ SUBSYSTEM_DEF(job)
 				M = H
 
 		//Skyrat changes
-		if(!(GLOB.respawned_ckeys[M.client.ckey]))
+		if(!(GLOB.respawned_ckeys[M.client?.ckey]))
 			SSpersistence.antag_rep_change[M.client.ckey] += job.GetAntagRep()
 		//End of skyrat changes
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -461,7 +461,10 @@ SUBSYSTEM_DEF(job)
 			else
 				M = H
 
-		SSpersistence.antag_rep_change[M.client.ckey] += job.GetAntagRep()
+		//Skyrat changes
+		if(!(GLOB.antag_rolled_ckeys[M.client.ckey]))
+			SSpersistence.antag_rep_change[M.client.ckey] += job.GetAntagRep()
+		//End of skyrat changes
 
 /*		if(M.client.holder)
 			if(CONFIG_GET(flag/auto_deadmin_players) || (M.client.prefs?.toggles & DEADMIN_ALWAYS))

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -462,7 +462,7 @@ SUBSYSTEM_DEF(job)
 				M = H
 
 		//Skyrat changes
-		if(!(GLOB.antag_rolled_ckeys[M.client.ckey]))
+		if(!(GLOB.respawned_ckeys[M.client.ckey]))
 			SSpersistence.antag_rep_change[M.client.ckey] += job.GetAntagRep()
 		//End of skyrat changes
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -186,6 +186,7 @@
 /// Give your candidates or assignees equipment and antag datum here.
 /datum/dynamic_ruleset/proc/execute()
 	for(var/datum/mind/M in assigned)
+		GLOB.antag_rolled_ckeys[M.ckey] = TRUE //Skyrat change
 		M.add_antag_datum(antag_datum)
 	return TRUE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -186,7 +186,6 @@
 /// Give your candidates or assignees equipment and antag datum here.
 /datum/dynamic_ruleset/proc/execute()
 	for(var/datum/mind/M in assigned)
-		GLOB.antag_rolled_ckeys[M.ckey] = TRUE //Skyrat change
 		M.add_antag_datum(antag_datum)
 	return TRUE
 
@@ -273,7 +272,6 @@
 			if(!(antag_flag in P.client.prefs.be_special) || jobban_isbanned(P.ckey, antag_flag))
 				candidates.Remove(P)
 				continue
-		GLOB.antag_rolled_ckeys[P.ckey] = TRUE //Skyrat change
 
 /// Do your checks if the ruleset is ready to be executed here.
 /// Should ignore certain checks if forced is TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -273,6 +273,7 @@
 			if(!(antag_flag in P.client.prefs.be_special) || jobban_isbanned(P.ckey, antag_flag))
 				candidates.Remove(P)
 				continue
+		GLOB.antag_rolled_ckeys[P.ckey] = TRUE //Skyrat change
 
 /// Do your checks if the ruleset is ready to be executed here.
 /// Should ignore certain checks if forced is TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -27,10 +27,9 @@
 			candidates.Remove(P)
 			continue
 		//Skyrat changes
-		if (GLOB.antag_rolled_ckeys[P.ckey])
+		if (GLOB.respawned_ckeys[P.ckey])
 			candidates.Remove(P)
 			continue
-		GLOB.antag_rolled_ckeys[P.ckey] = TRUE
 		//Skyrat changes end
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -30,6 +30,7 @@
 		if (GLOB.antag_rolled_ckeys[P.ckey])
 			candidates.Remove(P)
 			continue
+		GLOB.antag_rolled_ckeys[P.ckey] = TRUE
 		//Skyrat changes end
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)
@@ -52,7 +53,6 @@
 	assigned += M.mind
 	M.mind.special_role = antag_flag
 	M.mind.add_antag_datum(antag_datum)
-	GLOB.antag_rolled_ckeys[M.ckey] = TRUE //Skyrat change
 	log_admin("[M.name] was made into a [name] by dynamic.")
 	message_admins("[M.name] was made into a [name] by dynamic.")
 	return TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -26,6 +26,11 @@
 		if ((exclusive_roles.len > 0) && !(P.mind.assigned_role in exclusive_roles)) // Is the rule exclusive to their job?
 			candidates.Remove(P)
 			continue
+		//Skyrat changes
+		if (GLOB.antag_rolled_ckeys[P.ckey])
+			candidates.Remove(P)
+			continue
+		//Skyrat changes end
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)
 	if (!forced)
@@ -47,6 +52,7 @@
 	assigned += M.mind
 	M.mind.special_role = antag_flag
 	M.mind.add_antag_datum(antag_datum)
+	GLOB.antag_rolled_ckeys[M.ckey] = TRUE //Skyrat change
 	log_admin("[M.name] was made into a [name] by dynamic.")
 	message_admins("[M.name] was made into a [name] by dynamic.")
 	return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -461,6 +461,7 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
 		return
 
+	GLOB.respawned_ckeys[M.ckey] = TRUE //Skyrat change
 	log_game("[key_name(usr)] used abandon mob.")
 
 	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -461,7 +461,7 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
 		return
 
-	GLOB.respawned_ckeys[M.ckey] = TRUE //Skyrat change
+	GLOB.respawned_ckeys[src.ckey] = TRUE //Skyrat change
 	log_game("[key_name(usr)] used abandon mob.")
 
 	to_chat(usr, "<span class='boldnotice'>Please roleplay correctly!</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -129,6 +129,7 @@
 #include "code\__DEFINES\material\worth.dm"
 #include "code\__DEFINES\misc\return_values.dm"
 #include "code\__DEFINES\mobs\slowdowns.dm"
+#include "code\__DEFINES\modular_skyrat\lists.dm"
 #include "code\__DEFINES\modular_skyrat\runechat_defines.dm"
 #include "code\__DEFINES\research\stock_parts.dm"
 #include "code\__DEFINES\skills\defines.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
They are still eligible for midround antags.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People knowingly or unknowingly abused the system by switching characters a lot in hopes of getting antag

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Respawned players are no longer eligible for antag rep or latejoin antag, they can still midround antag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
