### PR TITLE
Flavor text can no longer inject html

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -24,16 +24,21 @@
  * Text sanitization
  */
 
+//SKYRAT CHANGES BEGIN - Unicode support addition.
 //Simply removes < and > and limits the length of the message
-/proc/strip_html_simple(t,limit=MAX_MESSAGE_LEN)
-	var/list/strip_chars = list("<",">")
-	t = copytext(t,1,limit)
+/proc/strip_html_simple(t, limit = MAX_MESSAGE_LEN, unicode = FALSE)
+	var/static/list/strip_chars
+	if(!strip_chars)
+		strip_chars = list("<", ">")
+	t = unicode ? copytext_char(t, 1, limit) : copytext(t, 1, limit)
 	for(var/char in strip_chars)
+		var/char_len = length(char)
 		var/index = findtext(t, char)
 		while(index)
-			t = copytext(t, 1, index) + copytext(t, index+1)
+			t = copytext(t, 1, index) + copytext(t, index + char_len)
 			index = findtext(t, char)
 	return t
+//SKYRAT CHANGES END
 
 //Removes a few problematic characters
 /proc/sanitize_simple(t,list/repl_chars = list("\n"="#","\t"="#"))

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	var/lower_name = lowertext(flavor_name)
 	var/new_text = input(user, "Set the [lower_name] displayed on 'examine'. [addendum]", flavor_name, texts_by_atom[usr]) as message|null //Skyrat edit, removed stripped_multiline_input()
 	if(!isnull(new_text) && (user in texts_by_atom))
-		texts_by_atom[user] = strip_html_simple(new_text, MAX_FLAVOR_LEN) //Skyrat edit, removed html_decode()
+		texts_by_atom[user] = strip_html_simple(new_text, MAX_FLAVOR_LEN, TRUE) //Skyrat edit, removed html_decode()
 		to_chat(src, "Your [lower_name] has been updated.")
 		return TRUE
 	return FALSE

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	if(examine_no_preview)
 		examine_list += "<span class='notice'><a href='?src=[REF(src)];show_flavor=[REF(target)]'>\[[flavor_name]\]</a></span>"
 		return
-	var/msg = replacetext(text, "\n", " ")
+	var/msg = replacetext(html_encode(text), "\n", " ") //Skyrat edit, added html_encode()
 	if(length_char(msg) <= 40)
 		examine_list += "<span class='notice'>[msg]</span>"
 	else
@@ -117,9 +117,9 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		return FALSE
 
 	var/lower_name = lowertext(flavor_name)
-	var/new_text = stripped_multiline_input(user, "Set the [lower_name] displayed on 'examine'. [addendum]", flavor_name, texts_by_atom[usr], max_len, TRUE)
+	var/new_text = input(user, "Set the [lower_name] displayed on 'examine'. [addendum]", flavor_name, texts_by_atom[usr]) as message|null //Skyrat edit, removed stripped_multiline_input()
 	if(!isnull(new_text) && (user in texts_by_atom))
-		texts_by_atom[user] = html_decode(new_text)
+		texts_by_atom[user] = strip_html_simple(new_text, MAX_FLAVOR_LEN) //Skyrat edit, removed html_decode()
 		to_chat(src, "Your [lower_name] has been updated.")
 		return TRUE
 	return FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -434,9 +434,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 				if(!length(features["flavor_text"]))
 					dat += "\[...\]<BR>" //skyrat - adds <br> //come to brazil or brazil comes to you
 				else
-					dat += "[features["flavor_text"]]<BR>" //skyrat - adds <br>
+					dat += "[html_encode(features["flavor_text"])]<BR>" //skyrat - adds <br> and uses html_encode
 			else
-				dat += "[TextPreview(features["flavor_text"])]...<BR>"
+				dat += "[TextPreview(html_encode(features["flavor_text"]))]...<BR>" //skyrat edit, uses html_encode
 			//SKYRAT EDIT
 			dat += 	"Records :"
 			dat += 	"<a href='?_src_=prefs;preference=general_records;task=input'>General</a>"
@@ -1918,9 +1918,9 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FLAVOR_LEN, TRUE)
+					var/msg = input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"]) as message|null //Skyrat edit, removed stripped_multiline_input()
 					if(!isnull(msg))
-						features["flavor_text"] = html_decode(msg)
+						features["flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN) //Skyrat edit, removed html_decode()
 
 				if("silicon_flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", features["silicon_flavor_text"], MAX_FLAVOR_LEN, TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1920,7 +1920,7 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 				if("flavor_text")
 					var/msg = input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"]) as message|null //Skyrat edit, removed stripped_multiline_input()
 					if(!isnull(msg))
-						features["flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN) //Skyrat edit, removed html_decode()
+						features["flavor_text"] = strip_html_simple(msg, MAX_FLAVOR_LEN, TRUE) //Skyrat edit, removed html_decode()
 
 				if("silicon_flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", features["silicon_flavor_text"], MAX_FLAVOR_LEN, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The `html_encode()` sanitization must be done on output, else it breaks the `'`, `"` and other characters.
This additionally forbids the use of `>` and `<` through `strip_html_simple()` which is given some small tweaks for better unicode support.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Safety

## Changelog
:cl:
tweak: Flavor text can no longer inject html.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
