### PR TITLE
[s] Fixes a pair of DoS vectors.

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -133,3 +133,6 @@
 	var/parallax_movedir = 0
 	var/parallax_layers_max = 3
 	var/parallax_animate_timer
+
+	//world.time of when the crew manifest can be accessed
+	var/crew_manifest_delay

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -176,9 +176,6 @@
 			SSticker.queue_delay = 4
 			qdel(src)
 
-	if(!ready && href_list["preference"])
-		if(client)
-			client.prefs.process_link(src, href_list)
 	else if(!href_list["late_join"])
 		new_player_panel()
 
@@ -598,6 +595,12 @@
 		qdel(src)
 
 /mob/dead/new_player/proc/ViewManifest()
+	if(!client)
+		return
+	if(world.time < client.crew_manifest_delay)
+		return
+	client.crew_manifest_delay = world.time + (1 SECONDS)
+
 	var/dat = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'></head><body>"
 	dat += "<h4>Crew Manifest</h4>"
 	dat += GLOB.data_core.get_manifest(OOC = 1)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -719,6 +719,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "View Crew Manifest"
 	set category = "Ghost"
 
+	if(!client)
+		return
+	if(world.time < client.crew_manifest_delay)
+		return
+	client.crew_manifest_delay = world.time + (1 SECONDS)
+
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
 	dat += GLOB.data_core.get_manifest()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -395,6 +395,12 @@
 		return aicamera.selectpicture(user)
 
 /mob/living/silicon/proc/ai_roster()
+	if(!client)
+		return
+	if(world.time < client.crew_manifest_delay)
+		return
+	client.crew_manifest_delay = world.time + (1 SECONDS)
+
 	var/dat = "<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Crew Roster</title></head><body><b>Crew Roster:</b><br><br>"
 
 	dat += GLOB.data_core.get_manifest()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6356337/84463766-b99a4100-ac40-11ea-8cf8-d2c078b7b7d6.png)

Mirrored from Citadel-Station-13/Citadel-Station-13#12511 . This is an exact copy of the PR there, so this PR may be redundant, but should be able to be safely merged prior to mirrorbot mirroring since the contents are exactly the same (the mirrorbot will just create a blank PR in weird cases where a PR's contents are already present). Whether or not this will fix the DoS attacks you guys are actively dealing with is unknown, since I do not have access to your guys' discord to walk online admins/maintainers through proper debugging on live while an attack is happening, and the href logs I was provided don't seem to be enough to go off of to confirm for sure whether or not either of these are what was being exploited (and I currently don't have runtime logs of a round reported to have crashed, either), but shotgun debugging from the distance is sometimes worth a shot.

I will not publicly explain exactly what's going on in this PR, but maintainers/headcoders are free to DM me or ping me in coderbus for a quick rundown of how the exploit patched by this PR ticks. This patch likely is not very urgent since what I currently know implies that this patch may be unrelated to the current DoS attacks you guys are experiencing, but hey, day 0 mitigations are nice to have regardless.