### PR TITLE
Removes LRP content

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -603,12 +603,12 @@
 	name = "The Owl"
 	desc = "The Owl would do his best to protect the station. Will you?"
 	icon_state = "poster33_legit"
-
+/* skyrat edit - memes b gone
 /obj/structure/sign/poster/official/no_erp
 	name = "No ERP"
 	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Nanotrasen stations."
 	icon_state = "poster34_legit"
-
+*/
 /obj/structure/sign/poster/official/wtf_is_co2
 	name = "Carbon Dioxide"
 	desc = "This informational poster teaches the viewer what carbon dioxide is."

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -1,3 +1,4 @@
+/* skyrat edit - memes b gone
 /obj/item/suspiciousphone
 	name = "suspicious phone"
 	desc = "This device raises pink levels to unknown highs."
@@ -227,3 +228,4 @@
 	playsound(src, "explosion", 80, TRUE)
 	dump.forceMove(get_turf(src))
 	qdel(src) //The target's purpose is complete. It can rest easy now
+*/

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/box/syndicate
 
 /obj/item/storage/box/syndicate/PopulateContents()
-	switch (pickweight(list("bloodyspai" = 3, "stealth" = 2, "bond" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "baseball" = 1, "implant" = 1, "hacker" = 3, "darklord" = 1, "sniper" = 1, "metaops" = 1, "ninja" = 1)))
+	switch (pickweight(list("bloodyspai" = 3, "stealth" = 2, "bond" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "sniper" = 1, "metaops" = 1, "ninja" = 1))) //skyrat edit - no more memes
 		if("bloodyspai") // 30 tc now this is more right
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
 			new /obj/item/clothing/mask/chameleon(src) // Goes with above
@@ -61,7 +61,7 @@
 			new /obj/item/grenade/syndieminibomb(src)
 			new /obj/item/clothing/glasses/phantomthief/syndicate(src)
 			new /obj/item/reagent_containers/syringe/stimulants(src)
-
+		
 		if("baseball") // 42~ tc
 			new /obj/item/melee/baseball_bat/ablative/syndi(src) //Lets say 12 tc, lesser sleeping carp
 			new /obj/item/clothing/glasses/sunglasses/garb(src) //Lets say 2 tc

--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -276,6 +276,7 @@
 					var/spillage = input(src, "Would your fluids spill outside?", "Choose overflowing option", "Yes") as null|anything in list("Yes", "No")
 					if(spillage && in_range(src, partner))
 						mob_climax_partner(picked_organ, partner, spillage == "Yes" ? TRUE : FALSE)
+		/* skyrat edit - memes b gone
 		if("Fill container")
 			//We'll need hands and no restraints.
 			if(!available_rosie_palms(FALSE, /obj/item/reagent_containers))
@@ -288,6 +289,7 @@
 				var/obj/item/reagent_containers/fluid_container = pick_climax_container()
 				if(fluid_container && available_rosie_palms(TRUE, /obj/item/reagent_containers))
 					mob_fill_container(picked_organ, fluid_container)
+		*/
 
 	mb_cd_timer = world.time + mb_cd_length
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -145,7 +145,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		H.adjustBruteLoss(160)
 	if(L && (L.density || prob(10)))
 		L.ex_act(EXPLODE_HEAVY)
-
+/* skyrat edit - no more memes
 obj/effect/immovablerod/attack_hand(mob/living/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/U = user
@@ -165,3 +165,4 @@ obj/effect/immovablerod/attack_hand(mob/living/user)
 				new /obj/structure/festivus/anchored(drop_location())
 				new /obj/effect/anomaly/flux(drop_location())
 				qdel(src)
+*/

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -174,6 +174,16 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	reagents_add = list(/datum/reagent/sulfur = 0.1, /datum/reagent/carbon = 0.1, /datum/reagent/nitrogen = 0.07, /datum/reagent/potassium = 0.05)
 
+//skyrat edit - no more memes
+/obj/item/seeds/gatfruit/Initialize(mapload, nogenes)
+	..()
+	qdel(src)
+
+/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit/Initialize(mapload, obj/item/seeds/new_seed)
+	..()
+	qdel(src)
+//
+
 /obj/item/reagent_containers/food/snacks/grown/shell/gatfruit
 	seed = /obj/item/seeds/gatfruit
 	name = "gatfruit"

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -74,8 +74,13 @@
 		if("lampism")
 			B.name = "Fluorescent Incandescence"
 		if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks", "meme", "memes")
+		/* skyrat edit - memes b gone
 			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // starts off [censored for github] as fuck
+		*/
+		// skyrat edit - memes b gone
+			log_admin("[key_name(H)] has chosen a LRP religion name. [ADMIN_SMITE(H)]")
+		//
 		if("monkeyism","apism","gorillism","primatism")
 			B.name = pick("Going Bananas", "Bananas Out For Harambe")
 		if("mormonism")

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -47,6 +47,8 @@
 	..()
 	if(visualsOnly)
 		return
+	/* skyrat edit - memes b gone
 	var/datum/martial_art/cqc/under_siege/justacook = new
 	justacook.teach(H)
+	*/
 

--- a/code/modules/uplink/uplink_items/uplink_badass.dm
+++ b/code/modules/uplink/uplink_items/uplink_badass.dm
@@ -23,7 +23,7 @@
 	desc = "Ask the crew to \"inspect\" their nuclear disk and weapons system, and then when they decline, pull out a fully automatic rifle and gun down the Captain. \
 			Radio headset does not include encryption key. No gun included."
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
-
+/* skyrat edit - no more memes
 /datum/uplink_item/badass/costumes/clown
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
@@ -34,7 +34,7 @@
 	desc = "A very high impact toolbox. Excels at destroying stationary structures."
 	item = /obj/item/storage/toolbox/plastitanium
 	cost = 2		//18 damage on mobs, 50 on objects, 4.5 stam/hit
-
+*/
 /datum/uplink_item/badass/balloon
 	name = "Syndicate Balloon"
 	desc = "For showing that you are THE BOSS: A useless red balloon with the Syndicate logo on it. \
@@ -69,7 +69,7 @@
 	item = /obj/item/storage/fancy/cigarettes/cigpack_syndicate
 	cost = 2
 	illegal_tech = FALSE
-
+/* skyrat edit - no more memes
 /datum/uplink_item/badass/tactical_naptime
 	name = "Sleepy Time Pajama Bundle"
 	desc = "Even soldiers need to get a good nights rest. Comes with some cozy as heck sleeping wear, a blankie to keep yourself warm in deep space, a hot mug of cocoa for you and your fuzzy friend."
@@ -78,3 +78,4 @@
 	limited_stock = 1
 	cant_discount = TRUE
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+*/

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -42,7 +42,7 @@
 	cost = 14
 	surplus = 25
 	include_modes = list(/datum/game_mode/nuclear)
-
+/* skyrat edit - no more memes
 /datum/uplink_item/dangerous/pie_cannon
 	name = "Banana Cream Pie Cannon"
 	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"
@@ -69,7 +69,7 @@
 	cost = 3
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
-
+*/
 /datum/uplink_item/dangerous/bioterror
 	name = "Biohazardous Chemical Sprayer"
 	desc = "A handheld chemical sprayer that allows a wide dispersal of selected chemicals. Especially tailored by the Tiger \
@@ -161,7 +161,7 @@
 	cost = 12
 	surplus = 30
 	include_modes = list(/datum/game_mode/nuclear)
-
+/* skyrat edit - no more memes
 /datum/uplink_item/dangerous/rapid
 	name = "Bands of the North Star"
 	desc = "These armbands let the user punch people very fast and with the lethality of a legendary martial artist. \
@@ -170,7 +170,7 @@
 	item = /obj/item/clothing/gloves/fingerless/pugilist/rapid
 	cost = 30
 	include_modes = list(/datum/game_mode/nuclear)
-
+*/
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \

--- a/code/modules/uplink/uplink_items/uplink_explosives.dm
+++ b/code/modules/uplink/uplink_items/uplink_explosives.dm
@@ -16,7 +16,7 @@
 	cost = 5
 	surplus = 35
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-
+/* skyrat edit - no more memes
 /datum/uplink_item/explosives/bombanana
 	name = "Bombanana"
 	desc = "A banana with an explosive taste! discard the peel quickly, as it will explode with the force of a syndicate minibomb \
@@ -25,7 +25,7 @@
 	cost = 4 //it is a bit cheaper than a minibomb because you have to take off your helmet to eat it, which is how you arm it
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
-
+*/
 /datum/uplink_item/explosives/buzzkill
 	name = "Buzzkill Grenade Box"
 	desc = "A box with three grenades that release a swarm of angry bees upon activation. These bees indiscriminately attack friend or foe \
@@ -58,7 +58,7 @@
 	item = /obj/item/storage/backpack/duffelbag/syndie/x4
 	cost = 4 //
 	cant_discount = TRUE
-
+/* skyrat edit - no more memes
 /datum/uplink_item/explosives/clown_bomb_clownops
 	name = "Clown Bomb"
 	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
@@ -70,7 +70,7 @@
 	cost = 15
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
-
+*/
 /datum/uplink_item/explosives/detomatix
 	name = "Detomatix PDA Cartridge"
 	desc = "When inserted into a personal digital assistant, this cartridge gives you four opportunities to \

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -13,14 +13,15 @@
 	item = /obj/item/clothing/under/color/grey/glorf
 	cost = 20
 	restricted_roles = list("Assistant")
-
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"
 	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"
 	cost = 10
 	item = /obj/item/pneumatic_cannon/pie/selfcharge
 	restricted_roles = list("Clown")
-
+*/
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/blastcannon
 	name = "Blast Cannon"
 	desc = "A highly specialized weapon, the Blast Cannon is actually relatively simple. It contains an attachment for a tank transfer valve mounted to an angled pipe specially constructed \
@@ -30,7 +31,7 @@
 	item = /obj/item/gun/blastcannon
 	cost = 14							//High cost because of the potential for extreme damage in the hands of a skilled gas masked scientist.
 	restricted_roles = list("Research Director", "Scientist")
-
+*/
 /datum/uplink_item/role_restricted/alientech
 	name = "Alien Research Disk"
 	desc = "A technology disk holding a terabyte of highly confidential abductor technology. \
@@ -38,7 +39,7 @@
 	item = /obj/item/disk/tech_disk/abductor
 	cost = 12
 	restricted_roles = list("Research Director", "Scientist", "Roboticist")
-
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"
 	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \
@@ -50,6 +51,7 @@
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	restricted_roles = list("Clown")
+*/
 
 /*
 /datum/uplink_item/role_restricted/clowncar
@@ -72,7 +74,7 @@
 	cost = 2
 	restricted_roles = list("Curator")
 	limited_stock = 1 //please don't spam deadchat
-
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/his_grace
 	name = "His Grace"
 	desc = "An incredibly dangerous weapon recovered from a station overcome by the grey tide. Once activated, He will thirst for blood and must be used to kill to sate that thirst. \
@@ -83,7 +85,7 @@
 	cost = 20
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
-
+*/
 /datum/uplink_item/role_restricted/clockwork_slab
 	name = "Clockwork Slab"
 	desc = "A reverse engineered clockwork slab. Is this really a good idea?."
@@ -101,7 +103,7 @@
 	player_minimum = 20
 	refundable = TRUE
 	//restricted_roles = list("Chaplain") skyrat change - fuck the chaplain i want to build my shoko asara cult
-
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/explosive_hot_potato
 	name = "Exploding Hot Potato"
 	desc = "A potato rigged with explosives. On activation, a special mechanism is activated that prevents it from being dropped. \
@@ -109,7 +111,7 @@
 	item = /obj/item/hot_potato/syndicate
 	cost = 4
 	restricted_roles = list("Cook", "Botanist", "Clown", "Mime")
-
+*/
 /datum/uplink_item/role_restricted/strange_seeds_10pack
 	name = "Pack of strange seeds"
 	desc = "Mysterious seeds as strange as their name implies. Spooky. These come in bulk"
@@ -157,7 +159,7 @@
 	cost = 5 //you need two for full damage, so total of 10 for maximum damage
 	limited_stock = 2 //you can't use more than two!
 	restricted_roles = list("Shaft Miner")
-
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/kitchen_gun
 	name = "Kitchen Gun (TM)"
 	desc = "A revolutionary .45 caliber cleaning solution! Say goodbye to daily stains and dirty surfaces with Kitchen Gun (TM)! \
@@ -173,7 +175,7 @@
 	cost = 1
 	restricted_roles = list("Cook", "Janitor")
 	item = /obj/item/ammo_box/magazine/m45/kitchengun
-
+*/
 /datum/uplink_item/role_restricted/magillitis_serum
 	name = "Magillitis Serum Autoinjector"
 	desc = "A single-use autoinjector which contains an experimental serum that causes rapid muscular growth in Hominidae. \
@@ -204,7 +206,7 @@
 	cost = 5
 	item = /obj/item/reverse_bear_trap
 	restricted_roles = list("Clown")
-
+/* skyrat edit - no more memes
 /datum/uplink_item/role_restricted/reverse_revolver
 	name = "Reverse Revolver"
 	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \
@@ -219,7 +221,7 @@
 	cost = 14
 	item = /obj/item/clothing/shoes/clown_shoes/taeclowndo
 	restricted_roles = list("Clown")
-
+*/
 /datum/uplink_item/role_restricted/emitter_cannon
 	name = "Emitter Cannon"
 	desc = "A small emitter fitted into a gun case, do to size constraints and safety it can only shoot about ten times when fully charged."

--- a/code/modules/uplink/uplink_items/uplink_species.dm
+++ b/code/modules/uplink/uplink_items/uplink_species.dm
@@ -1,4 +1,5 @@
 //this entire file is a skyrat addition.
+/* skyrat edit - no more memes
 /datum/uplink_item/race_restricted/syndilamp
 	name = "Extra-Bright Lantern"
 	desc = "We heard that moths such as yourself really like lamps, so we decided to grant you early access to a prototype \
@@ -6,3 +7,4 @@
 	cost = 2
 	item = /obj/item/flashlight/lantern/syndicate
 	restricted_species = list("moth")
+*/

--- a/code/modules/uplink/uplink_items/uplink_support.dm
+++ b/code/modules/uplink/uplink_items/uplink_support.dm
@@ -60,14 +60,14 @@
 			for hit-and-run style attacks. Features an incendiary carbine, flash bang launcher, teleporter, ion thrusters and a Tesla energy array."
 	item = /obj/mecha/combat/gygax/dark/loaded
 	cost = 80
-
+/* skyrat edit - no more memes
 /datum/uplink_item/support/honker
 	name = "Dark H.O.N.K."
 	desc = "A clown combat mech equipped with bombanana peel and tearstache grenade launchers, as well as the ubiquitous HoNkER BlAsT 5000."
 	item = /obj/mecha/combat/honker/dark/loaded
 	cost = 80
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
-
+*/
 /datum/uplink_item/support/mauler
 	name = "Mauler Exosuit"
 	desc = "A massive and incredibly deadly military-grade exosuit. Features long-range targeting, thrust vectoring \

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/designatedspeciesscreamfile.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/designatedspeciesscreamfile.dm
@@ -13,10 +13,10 @@
 
 /datum/species/lizard
 	screamsounds = list('modular_citadel/sound/voice/scream_lizard.ogg')
-
+/* no more memes
 /datum/species/skeleton
 	screamsounds = list('modular_citadel/sound/voice/scream_skeleton.ogg')
-
+*/
 /datum/species/fly
 	screamsounds = list('modular_citadel/sound/voice/scream_moth.ogg')
 


### PR DESCRIPTION
## About The Pull Request

This PR kills a lot of LRP content that i could find. There is a lot more to be axed however, and your suggestions of things to axe are always welcome.

Current list of memes removed:
- Crab 17
- Chaplain LRP meme bibles
- No ERP poster
- Chef CQC
- Cumming into reagent containers such as glasses
- Revolver plant that can be gotten via xenobio
- Baseball antag kit
- Lord singulo antag kit
- His grace
- Skeleton rattle me bones
- A bunch of clown traitor items
- Moth traitor lamp
- Research director rod suplex

## Why It's Good For The Game

Crashing this code... with no survivors.

## Changelog
:cl:
del: Removed meme content.
/:cl: