### PR TITLE
Makes automatic guns actually automatic

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -142,10 +142,6 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
-	//skyrat edit
-	if(on_cooldown())
-		return
-	//
 	to_chat(user, "<span class='danger'>*click*</span>")
 	playsound(src, "gun_dry_fire", 30, 1)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -142,7 +142,12 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
+	//skyrat edit
+	if(on_cooldown())
+		return FALSE
+	//
 	to_chat(user, "<span class='danger'>*click*</span>")
+	last_fire = world.time
 	playsound(src, "gun_dry_fire", 30, 1)
 
 /obj/item/gun/proc/shoot_live_shot(mob/living/user, pointblank = FALSE, mob/pbtarget, message = 1, stam_cost = 0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1,5 +1,10 @@
 
 #define DUALWIELD_PENALTY_EXTRA_MULTIPLIER 1.4
+//woops skyrat defines
+#define SEMIAUTO	1
+#define ROUNDBURST	2
+#define FULLAUTO	3
+//
 
 /obj/item/gun
 	name = "gun"
@@ -223,6 +228,10 @@
 
 	if(user)
 		bonus_spread = getinaccuracy(user, bonus_spread, stamloss) //CIT CHANGE - adds bonus spread while not aiming
+	//skyrat edit full auto
+	if(user)
+		bonus_spread += calculate_extra_inaccuracy(user, bonus_spread, stamloss)
+	//
 	if(ishuman(user) && user.a_intent == INTENT_HARM && weapon_weight <= WEAPON_LIGHT)
 		var/mob/living/carbon/human/H = user
 		for(var/obj/item/gun/G in H.held_items)
@@ -246,6 +255,11 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM) && chambered?.harmful) // If the user has the pacifist trait, then they won't be able to fire [src] if the round chambered inside of [src] is lethal.
 		to_chat(user, "<span class='notice'> [src] is lethally chambered! You don't want to risk harming anyone...</span>")
 		return FALSE
+
+//skyrat edit
+/obj/item/gun/proc/calculate_extra_inaccuracy()
+	return 0
+//
 
 /obj/item/gun/proc/handle_pins(mob/living/user)
 	if(no_pin_required)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -137,6 +137,10 @@
 	return TRUE
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
+	//skyrat edit
+	if(on_cooldown())
+		return
+	//
 	to_chat(user, "<span class='danger'>*click*</span>")
 	playsound(src, "gun_dry_fire", 30, 1)
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -123,7 +123,7 @@
 		process_afterattack(over_object, L, TRUE)
 
 /obj/item/gun/ballistic/automatic/on_cooldown()
-	return busy_action || firing || (last_fire + fire_delay > world.time) || ((select == FULLAUTO) && last_fire + burst_shot_delay >= world.time)
+	return busy_action || firing || (last_fire + fire_delay > world.time) || ((select == FULLAUTO) && (last_fire + burst_shot_delay >= world.time))
 //
 
 /obj/item/gun/ballistic/automatic/c20r

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -123,12 +123,6 @@
 /obj/item/gun/ballistic/automatic/calculate_extra_inaccuracy(mob/living/user, bonus_spread, stamloss)
 	if(select == FULLAUTO)
 		return getinaccuracy(user, bonus_spread, stamloss)
-
-/obj/item/gun/ballistic/automatic/shoot_with_empty_chamber(mob/living/user)
-	if((select == FULLAUTO) && on_cooldown())
-		return FALSE
-	else
-		return ..()
 //
 
 /obj/item/gun/ballistic/automatic/c20r

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -143,9 +143,6 @@
 /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	pin = /obj/item/firing_pin
 
-/obj/item/gun/ballistic/automatic/c20r/unrestricted/fullauto
-	can_fullauto = TRUE
-
 /obj/item/gun/ballistic/automatic/c20r/Initialize()
 	. = ..()
 	update_icon()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -4,7 +4,7 @@
 	//woops skyrat edit
 	canMouseDown = TRUE
 	var/select = SEMIAUTO
-	var/can_fullauto = FALSE
+	var/can_fullauto = TRUE
 	//
 	var/automatic_burst_overlay = TRUE
 	can_suppress = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -123,6 +123,12 @@
 /obj/item/gun/ballistic/automatic/calculate_extra_inaccuracy(mob/living/user, bonus_spread, stamloss)
 	if(select == FULLAUTO)
 		return getinaccuracy(user, bonus_spread, stamloss)
+
+/obj/item/gun/ballistic/automatic/shoot_with_empty_chamber(mob/living/user)
+	if((select == FULLAUTO) && on_cooldown())
+		return FALSE
+	else
+		return ..()
 //
 
 /obj/item/gun/ballistic/automatic/c20r

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -121,7 +121,7 @@
 	return busy_action || firing || (last_fire + fire_delay > world.time) || ((select == FULLAUTO) && (last_fire + burst_shot_delay >= world.time))
 
 /obj/item/gun/ballistic/automatic/calculate_extra_inaccuracy(mob/living/user, bonus_spread, stamloss)
-	if(select = FULLAUTO)
+	if(select == FULLAUTO)
 		return getinaccuracy(user, bonus_spread, stamloss)
 //
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -5,6 +5,7 @@
 	canMouseDown = TRUE
 	var/select = SEMIAUTO
 	var/can_fullauto = TRUE
+	var/done_empty = 0
 	//
 	var/automatic_burst_overlay = TRUE
 	can_suppress = TRUE
@@ -123,6 +124,15 @@
 /obj/item/gun/ballistic/automatic/calculate_extra_inaccuracy(mob/living/user, bonus_spread, stamloss)
 	if(select == FULLAUTO)
 		return getinaccuracy(user, bonus_spread, stamloss)
+
+/obj/item/gun/ballistic/automatic/shoot_with_empty_chamber(mob/living/user)
+	if(done_empty >= world.time)
+		return FALSE
+	else
+		done_empty = world.time + 2 SECONDS
+		return ..()
+
+/obj/item/gun/ballistic/automatic/
 //
 
 /obj/item/gun/ballistic/automatic/c20r

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1,15 +1,10 @@
-//woops skyrat defines
-#define SEMIAUTO	1
-#define ROUNDBURST	2
-#define FULLAUTO	3
-
 /obj/item/gun/ballistic/automatic
 	w_class = WEIGHT_CLASS_NORMAL
 	var/alarmed = 0
 	//woops skyrat edit
-	var/select = SEMIAUTO
-	var/can_fullauto = TRUE
 	canMouseDown = TRUE
+	var/select = SEMIAUTO
+	var/can_fullauto = FALSE
 	//
 	var/automatic_burst_overlay = TRUE
 	can_suppress = TRUE
@@ -124,6 +119,10 @@
 
 /obj/item/gun/ballistic/automatic/on_cooldown()
 	return busy_action || firing || (last_fire + fire_delay > world.time) || ((select == FULLAUTO) && (last_fire + burst_shot_delay >= world.time))
+
+/obj/item/gun/ballistic/automatic/calculate_extra_inaccuracy(mob/living/user, bonus_spread, stamloss)
+	if(select = FULLAUTO)
+		return getinaccuracy(user, bonus_spread, stamloss)
 //
 
 /obj/item/gun/ballistic/automatic/c20r

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -129,7 +129,8 @@
 	if(done_empty >= world.time)
 		return FALSE
 	else
-		done_empty = world.time + 2 SECONDS
+		if(select == FULLAUTO)
+			done_empty = world.time + 2 SECONDS
 		return ..()
 
 /obj/item/gun/ballistic/automatic/


### PR DESCRIPTION
## About The Pull Request

title

every gun with burst select can now use full auto. on full auto, dragging your gun to someone will shoot at them repeatedly in accordance to the burst shot delay. to avoid magdumps, full auto will only fire at mobs.

**note:** due to byond memery, you have do spaz out your mouse on the mob target for full auto to actually work.

**note 2:** this might need some balancing

**note 3:** Empty chamber spam has been fixed.

heres a video of it in action
https://cdn.discordapp.com/attachments/640744619302453316/721651225501630504/2020-06-14_06-02-34.mp4

## Why It's Good For The Game

haha smg go brrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr

## Changelog
:cl:
add: Most burst fire guns can now go full auto.
/:cl:
