### PR TITLE
Fixes modular modifications of loadout

### DIFF
--- a/modular_skyrat/code/modules/client/loadout/backpack.dm
+++ b/modular_skyrat/code/modules/client/loadout/backpack.dm
@@ -2,7 +2,3 @@
 	name = "Handheld Mirror"
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/hhmirror
-
-/datum/gear/crowbar
-	restricted_roles = NOPRISON_ROLES
-	restricted_desc = "All, barring Prisoners"

--- a/modular_skyrat/code/modules/client/loadout/uniform.dm
+++ b/modular_skyrat/code/modules/client/loadout/uniform.dm
@@ -74,10 +74,10 @@
 	name = "EntCorp uniform, medsci, cmd"
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/trek/command/orv/medsci
-	restricted_roles = MEDSCI_ROLES
+	restricted_roles = list("Research Director", "Chief Medical Officer")
 
 /datum/gear/orvcmd_ops
 	name = "EntCorp uniform, ops, cmd"
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/trek/command/orv/engsec
-	restricted_roles = OPRS_ROLES
+	restricted_roles = list("Head of Security", "Chief Engineer")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply removes loadout crowbar modification (the one that disallowed prisoners to get it), since upstream removed the original. Also corrects restrictions for command orvilike.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Crowbar no longer exist in the loadout anyway, **_but also to not have this happening:_** 
![image](https://user-images.githubusercontent.com/36963049/84643998-3bbb8b80-af07-11ea-9a65-b74368a9e140.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Anonymous
fix: Removes modular modifications of crowbar loadout since upstream removed original. This will remove blank category.
fix: EntCorp defined command uniform is now properly available to command only.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
