### PR TITLE
Makes bubblegum hallucinations have 0 mouse opacity - This is a GC fix

### DIFF
--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegumhard.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegumhard.dm
@@ -445,6 +445,7 @@ obj/item/gps/internal/bubblegum/hard
 	deathmessage = "Explodes into a pool of blood!"
 	deathsound = 'sound/effects/splat.ogg'
 	true_spawn = FALSE
+	mouse_opacity = 0 //This is so clients wont hover and store them, causing them to fail GC
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hard/hallucination/Initialize()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With 0 opacity clients will no longer store them in mouseObject, causing them to fail GC

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
performance good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
