### PR TITLE
[READY] Adds a combat knife to the motherbase shipment.

### DIFF
--- a/modular_skyrat/code/modules/uplink/uplink_bundles.dm
+++ b/modular_skyrat/code/modules/uplink/uplink_bundles.dm
@@ -76,6 +76,7 @@
 	new /obj/item/limbsurgeon/martialarm(src)
 	new /obj/item/headsetupgrader(src)
 	new /obj/item/encryptionkey/syndicate(src)
+	new /obj/item/kitchen/knife/combat/survival(src)
 
 /obj/item/limbsurgeon //autosurgeon is shit and does not support limbs, i had to do it to 'em
 	name = "limb autosurgeon"


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. Specifically kitchen/knife/combat/survival.

## Why It's Good For The Game

As motherbase was recently upped to 20TC from its previous 12, it would make more sense to make it more alike to it's inspiration. A knife isn't that much more powerful than your fists anyway. It's mostly for roleplay.

## Changelog
:cl:
add: Added a combat knife to the motherbase shipment.
/:cl: