### PR TITLE
Mutation and clone damage fix for IPCs

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -551,13 +551,13 @@
 		return TRUE
 
 /mob/living/carbon/proc/randmut(list/candidates, difficulty = 2)
-	if(!has_dna())
+	if(!has_dna() || !can_mutate()) //Skyrat edit
 		return
 	var/mutation = pick(candidates)
 	. = dna.add_mutation(mutation)
 
 /mob/living/carbon/proc/easy_randmut(quality = POSITIVE + NEGATIVE + MINOR_NEGATIVE, scrambled = TRUE, sequence = TRUE, exclude_monkey = TRUE)
-	if(!has_dna())
+	if(!has_dna() || !can_mutate()) //Skyrat edit
 		return
 	var/list/mutations = list()
 	if(quality & POSITIVE)
@@ -583,7 +583,7 @@
 
 
 /mob/living/carbon/proc/randmuti()
-	if(!has_dna())
+	if(!has_dna() || !can_mutate()) //Skyrat edit
 		return
 	var/num = rand(1, DNA_UNI_IDENTITY_BLOCKS)
 	var/newdna = setblock(dna.uni_identity, num, random_string(DNA_BLOCK_SIZE, GLOB.hex_characters))

--- a/modular_skyrat/code/_DEFINES/traits.dm
+++ b/modular_skyrat/code/_DEFINES/traits.dm
@@ -1,2 +1,3 @@
 #define TRAIT_SYNTH				"synthetic"		// robotic boy
 #define TRAIT_TOXIMMUNE			"toxin_immune"
+#define TRAIT_CLONEIMMUNE		"clone_immune" //This is for clone damage

--- a/modular_skyrat/code/datums/dna.dm
+++ b/modular_skyrat/code/datums/dna.dm
@@ -1,0 +1,5 @@
+/mob/proc/can_mutate()
+	return FALSE
+
+/mob/living/carbon/can_mutate()
+	return !(NO_DNA_COPY in dna.species.species_traits)

--- a/modular_skyrat/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/damage_procs.dm
@@ -2,3 +2,8 @@
 	if(HAS_TRAIT(src, TRAIT_TOXIMMUNE)) //Prevents toxin damage, but not healing
 		amount = min(amount, 0)
 	return ..()
+
+/mob/living/carbon/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE)
+	if(HAS_TRAIT(src, TRAIT_CLONEIMMUNE)) //Prevents bleed damage, but not healing
+		amount = min(amount, 0)
+	return ..()

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -1,7 +1,7 @@
 /datum/species/ipc
 	species_traits = list(MUTCOLORS_PARTSONLY,NOEYES,NOTRANSSTING,NOZOMBIE,REVIVESBYHEALING,NOHUSK,ROBOTIC_LIMBS,NO_DNA_COPY,HAIR)
 	mutant_bodyparts = list("ipc_screen" = "Blank", "ipc_antenna" = "None", ipc_chassis = "Morpheus Cyberkinetics(Greyscale)")
-	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH, TRAIT_LIMBATTACHMENT, TRAIT_TOXIMMUNE)
+	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH, TRAIT_LIMBATTACHMENT, TRAIT_TOXIMMUNE, TRAIT_CLONEIMMUNE)
 	coldmod = 0.5
 	burnmod = 1.1
 	heatmod = 1.2

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthliz.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthliz.dm
@@ -27,7 +27,7 @@
 	mutantliver = /obj/item/organ/liver/robot_ipc
 	//exotic_blood = /datum/reagent/oil
 	exotic_bloodtype = "S"
-	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH, TRAIT_LIMBATTACHMENT, TRAIT_TOXIMMUNE)
+	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH, TRAIT_LIMBATTACHMENT, TRAIT_TOXIMMUNE, TRAIT_CLONEIMMUNE)
 	languagewhitelist = list("Encoded Audio Language")
 
 /datum/species/synthliz/on_species_gain(mob/living/carbon/C) // Let's make that IPC actually robotic.

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -4,7 +4,7 @@
 	say_mod = "states" //inherited from a user's fake species
 	sexes = 0 //it gets it's sexes by the fake species
 	species_traits = list(NOTRANSSTING,NOZOMBIE,REVIVESBYHEALING,NOHUSK,ROBOTIC_LIMBS,NO_DNA_COPY) //all of these + whatever we inherit from the real species. I know you sick fucks want to fuck synths so yes you get genitals. Degenerates.
-	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_TOXIMMUNE, TRAIT_EASYDISMEMBER, TRAIT_EASYLIMBDISABLE)
+	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_TOXIMMUNE, TRAIT_EASYDISMEMBER, TRAIT_EASYLIMBDISABLE, TRAIT_CLONEIMMUNE)
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
 	dangerous_existence = 0 //not dangerous anymore i guess
 	blacklisted = 0 //not blacklisted anymore
@@ -15,7 +15,7 @@
 	icon_limbs = 'modular_skyrat/icons/mob/synth_parts.dmi'
 	//mutant_bodyparts = list("legs" = "Digitigrade", "taur" = "None") //this probably isn't gonna work. Note: it didn't work.
 	initial_species_traits = list(NOTRANSSTING,NOZOMBIE,REVIVESBYHEALING,NOHUSK,ROBOTIC_LIMBS,NO_DNA_COPY) //for getting these values back for assume_disguise()
-	initial_inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_TOXIMMUNE, TRAIT_EASYDISMEMBER, TRAIT_EASYLIMBDISABLE) //blah blah i explained above
+	initial_inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_TOXIMMUNE, TRAIT_EASYDISMEMBER, TRAIT_EASYLIMBDISABLE, TRAIT_CLONEIMMUNE) //blah blah i explained above
 	disguise_fail_health = 45 //When their health gets to this level their synthflesh partially falls off
 	fake_species = null //a species to do most of our work for us, unless we're damaged
 	var/isdisguised = FALSE //boolean to help us with disguising proper

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3463,6 +3463,7 @@
 #include "modular_skyrat\code\controllers\subsystem\recycling.dm"
 #include "modular_skyrat\code\datums\action.dm"
 #include "modular_skyrat\code\datums\ai_laws.dm"
+#include "modular_skyrat\code\datums\dna.dm"
 #include "modular_skyrat\code\datums\ert.dm"
 #include "modular_skyrat\code\datums\event_menu.dm"
 #include "modular_skyrat\code\datums\saymode.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes mutations respect NO_DNA_COPY, as that trait basically prevents tampering with the DNA. 
Synths and IPC now get TRAIT_CLONEIMMUNE which prevents them from getting any clone damage

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugfix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed IPCs and synths with clone damage and mutations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
