### PR TITLE
Removes the recipe for Strange Reagent

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -201,11 +201,11 @@
 	results = list(/datum/reagent/medicine/epinephrine = 6)
 	required_reagents = list(/datum/reagent/phenol = 1, /datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1, /datum/reagent/hydrogen = 1)
 
-/datum/chemical_reaction/strange_reagent
+/*/datum/chemical_reaction/strange_reagent //Skyrat change - Removed the strange reagent recipe as its unhealthy for the game
 	name = "Strange Reagent"
 	id = /datum/reagent/medicine/strange_reagent
 	results = list(/datum/reagent/medicine/strange_reagent = 3)
-	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)
+	required_reagents = list(/datum/reagent/medicine/omnizine = 1, /datum/reagent/water/holywater = 1, /datum/reagent/toxin/mutagen = 1)*/
 
 /datum/chemical_reaction/mannitol
 	name = "Mannitol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, just the recipe. You'll still be able to get SR from a very lucky strange seed 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Strange reagent is usually the go-to for reviving people, or even cloning them combined with the surgeries, as it usually is faster and preserves person's implant etc.. Putting a very iconic pieces of medical equipment such as the defibs and cloner into the dark corner is bad. Dying hard should penalize you more, requiring the need of cloning in some cases, or the effort to preserve a freshly died corpse and get them defibbed, instead of just whipping some magical piss/ doing a quick surgery to just revive someone. #make death matter

It's actually gotten so bad you may be mocked for not using SR

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the strange reagent recipe. You can still get the chem through unconventional means
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
