### PR TITLE
Removes MouseMove as its very performance draining.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -405,3 +405,7 @@
 //skyrat funnies
 #define COMSIG_LIVING_FLASH_ACT "living_flash_act"				///from base of [/mob/living/proc/flash_act] //moth
 #define COMSIG_EVENTPREF_UPDATE "observer_eventpref_update"
+
+//Mob stuff
+#define COMSIG_MOB_CLIENT_MOUSEUP "mob_client_mouseup" ///from base of [client/MouseUp()] (datum/source, object, location, control, params)
+#define COMSIG_MOB_CLIENT_MOUSEDOWN "mob_client_mousedown" ///from base of [client/MouseDown()] (datum/source, object, location, control, params)

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -25,6 +25,10 @@
 
 
 /client/MouseDown(object, location, control, params)
+	//Skyrat changes
+	if(mob)
+		SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_MOUSEDOWN, object, location, control, params)
+	//End of skyrat changes
 	if (mouse_down_icon)
 		mouse_pointer_icon = mouse_down_icon
 	var/delay = mob.CanMobAutoclick(object, location, params)
@@ -39,6 +43,10 @@
 		active_mousedown_item.onMouseDown(object, location, params, mob)
 
 /client/MouseUp(object, location, control, params)
+	//Skyrat changes
+	if(mob)
+		SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_MOUSEUP, object, location, control, params)
+	//End of skyrat changes
 	if (mouse_up_icon)
 		mouse_pointer_icon = mouse_up_icon
 	selected_target[1] = null
@@ -87,14 +95,14 @@
 	. = 1
 
 //Please don't roast me too hard
-/client/MouseMove(object,location,control,params)
+/*/client/MouseMove(object,location,control,params) //Skyrat change - lag begone!
 	mouseParams = params
 	mouseLocation = location
 	//mouseObject = object //Skyrat change
 	mouseControlObject = control
 	if(mob)
 		SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_MOUSEMOVE, object, location, control, params)
-	..()
+	..()*/
 
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
 	var/list/L = params2list(params)

--- a/code/datums/components/combat_mode.dm
+++ b/code/datums/components/combat_mode.dm
@@ -9,6 +9,7 @@
 	var/lastmousedir
 	var/obj/screen/combattoggle/hud_icon
 	var/hud_loc
+	var/click_time = 0 //Skyrat change
 
 /datum/component/combat_mode/Initialize(hud_loc = ui_combat_toggle)
 	if(!isliving(parent))
@@ -88,9 +89,12 @@
 			to_chat(source, self_message)
 		if(playsound)
 			source.playsound_local(source, 'sound/misc/ui_toggle.ogg', 50, FALSE, pressure_affected = FALSE) //Sound from interbay!
-	RegisterSignal(source, COMSIG_MOB_CLIENT_MOUSEMOVE, .proc/onMouseMove)
+	//RegisterSignal(source, COMSIG_MOB_CLIENT_MOUSEMOVE, .proc/onMouseMove) //Skyrat change
 	RegisterSignal(source, COMSIG_MOVABLE_MOVED, .proc/on_move)
-	RegisterSignal(source, COMSIG_MOB_CLIENT_MOVE, .proc/on_client_move)
+	RegisterSignal(source, COMSIG_MOVABLE_BUMP, .proc/on_bump) //Skyrat change
+	RegisterSignal(source, COMSIG_MOB_CLIENT_MOUSEDOWN, .proc/onMouseUpDown) //Skyrat change
+	RegisterSignal(source, COMSIG_MOB_CLIENT_MOUSEUP, .proc/onMouseUpDown) //Skyrat change
+	//RegisterSignal(source, COMSIG_MOB_CLIENT_MOVE, .proc/on_client_move) //Skyrat change - no backwards delay
 	if(hud_icon)
 		hud_icon.combat_on = TRUE
 		hud_icon.update_icon()
@@ -115,7 +119,7 @@
 			to_chat(source, self_message)
 		if(playsound)
 			source.playsound_local(source, 'sound/misc/ui_toggleoff.ogg', 50, FALSE, pressure_affected = FALSE) //Slightly modified version of the toggleon sound!
-	UnregisterSignal(source, list(COMSIG_MOB_CLIENT_MOUSEMOVE, COMSIG_MOVABLE_MOVED, COMSIG_MOB_CLIENT_MOVE))
+	UnregisterSignal(source, list(COMSIG_MOVABLE_MOVED, COMSIG_MOB_CLIENT_MOUSEDOWN, COMSIG_MOB_CLIENT_MOUSEUP, COMSIG_MOVABLE_BUMP)) //Skyrat change
 	if(hud_icon)
 		hud_icon.combat_on = FALSE
 		hud_icon.update_icon()
@@ -123,20 +127,20 @@
 ///Changes the user direction to (try) keep match the pointer.
 /datum/component/combat_mode/proc/on_move(atom/movable/source, dir, atom/oldloc, forced)
 	var/mob/living/L = source
-	if(mode_flags & COMBAT_MODE_ACTIVE && L.client && lastmousedir && lastmousedir != dir)
+	if(mode_flags & COMBAT_MODE_ACTIVE && L.client && world.time < click_time && L.dir != lastmousedir) //Skyrat change
 		L.setDir(lastmousedir, ismousemovement = TRUE)
 
-/// Added movement delay if moving backward.
+/*/// Added movement delay if moving backward. //Skyrat change - unusued
 /datum/component/combat_mode/proc/on_client_move(mob/source, client/client, direction, n, oldloc, added_delay)
 	if(oldloc != n && direction == REVERSE_DIR(source.dir))
-		client.move_delay += added_delay*0.5
+		client.move_delay += added_delay*0.5*/
 
-///Changes the user direction to (try) match the pointer.
+/*///Changes the user direction to (try) match the pointer. Skyrat change - unused
 /datum/component/combat_mode/proc/onMouseMove(mob/source, object, location, control, params)
 	if(source.client.show_popup_menus)
 		return
 	source.face_atom(object, TRUE)
-	lastmousedir = source.dir
+	lastmousedir = source.dir*/
 
 /// Toggles whether the user is intentionally in combat mode. THIS should be the proc you generally use! Has built in visual/to other player feedback, as well as an audible cue to ourselves.
 /datum/component/combat_mode/proc/user_toggle_intentional_combat_mode(mob/living/source)
@@ -215,3 +219,15 @@
 			flashy = mutable_appearance('icons/mob/screen_gen.dmi', "togglefull_flash")
 		flashy.color = user.client.prefs.hud_toggle_color
 		. += flashy //TODO - beg lummox jr for the ability to force mutable appearances or images to be created rendering from their first frame of animation rather than being based entirely around the client's frame count
+
+//Skyrat changes down here
+/datum/component/combat_mode/proc/onMouseUpDown(mob/living/source, object, location, control, params)
+	if(source.client.show_popup_menus)
+		return
+	source.face_atom(location, TRUE)
+	lastmousedir = source.dir
+	click_time = world.time + 30
+
+/datum/component/combat_mode/proc/on_bump(mob/living/source, bumped)
+	on_move(source)
+//End of skyrat changes

--- a/code/datums/components/combat_mode.dm
+++ b/code/datums/components/combat_mode.dm
@@ -127,7 +127,7 @@
 ///Changes the user direction to (try) keep match the pointer.
 /datum/component/combat_mode/proc/on_move(atom/movable/source, dir, atom/oldloc, forced)
 	var/mob/living/L = source
-	if(mode_flags & COMBAT_MODE_ACTIVE && L.client && world.time < click_time && L.dir != lastmousedir) //Skyrat change
+	if(mode_flags & COMBAT_MODE_ACTIVE && L.client && lastmousedir && world.time < click_time && L.dir != lastmousedir) //Skyrat change
 		L.setDir(lastmousedir, ismousemovement = TRUE)
 
 /*/// Added movement delay if moving backward. //Skyrat change - unusued


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Combat mode was substituted with registering where you're downing or upping your mouse clicks and locking you to that direction for a small amount of time. The backpeddle slowdown was removed as it may prove to be annoying with those changes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
low TD zooms lets goo

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
de; removed the use of MouseMove
del: removed combat mode backpeddle slowdown
tweak: tweaked how combat mode rotates you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
