### PR TITLE
Exotic Seed Crates and Contraband Crates can have some additional cool seeds

### DIFF
--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -75,22 +75,6 @@
 					/obj/item/storage/bag/ammo)
 	crate_name = "crate"
 
-/datum/supply_pack/costumes_toys/randomised/contraband/fill(obj/structure/closet/crate/C)
-	. = ..()
-	// Some chance to get some useful and dangerous botany seeds.
-	if(prob(34)) // One in three contraband crates has a chance to spawn seeds.
-		 // Guaranteed to have either a cherrybomb or a gatfruit
-		if(prob(50))
-			new /obj/item/seeds/cherry/bomb(C)
-		else
-			new /obj/item/seeds/gatfruit(C)
-
-		// If you get lucky, you get these extra. Small chance.
-		if(prob(34)) // One in six contraband crates
-			new /obj/item/seeds/starthistle/corpse_flower(C)
-		if(prob(10)) // One in thirty contraband crates
-			new /obj/item/seeds/kudzu(C)
-
 /datum/supply_pack/costumes_toys/foamforce
 	name = "Foam Force Crate"
 	desc = "Break out the big guns with eight Foam Force shotguns!"

--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -75,6 +75,18 @@
 					/obj/item/storage/bag/ammo)
 	crate_name = "crate"
 
+/datum/supply_pack/costumes_toys/randomised/contraband/fill(obj/structure/closet/crate/C)
+	. = ..()
+	// Some chance to get some useful and dangerous botany seeds.
+	if(prob(50))
+		new /obj/item/seeds/cherry/bomb(C)
+	else // Guaranteed either one of those
+		new /obj/item/seeds/gatfruit(C)
+	if(prob(33))
+		new /obj/item/seeds/starthistle/corpse_flower(C)
+	if(prob(10))
+		new /obj/item/seeds/kudzu(C)
+
 /datum/supply_pack/costumes_toys/foamforce
 	name = "Foam Force Crate"
 	desc = "Break out the big guns with eight Foam Force shotguns!"

--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -78,14 +78,18 @@
 /datum/supply_pack/costumes_toys/randomised/contraband/fill(obj/structure/closet/crate/C)
 	. = ..()
 	// Some chance to get some useful and dangerous botany seeds.
-	if(prob(50))
-		new /obj/item/seeds/cherry/bomb(C)
-	else // Guaranteed either one of those
-		new /obj/item/seeds/gatfruit(C)
-	if(prob(33))
-		new /obj/item/seeds/starthistle/corpse_flower(C)
-	if(prob(10))
-		new /obj/item/seeds/kudzu(C)
+	if(prob(34)) // One in three contraband crates has a chance to spawn seeds.
+		 // Guaranteed to have either a cherrybomb or a gatfruit
+		if(prob(50))
+			new /obj/item/seeds/cherry/bomb(C)
+		else
+			new /obj/item/seeds/gatfruit(C)
+
+		// If you get lucky, you get these extra. Small chance.
+		if(prob(34)) // One in six contraband crates
+			new /obj/item/seeds/starthistle/corpse_flower(C)
+		if(prob(10)) // One in thirty contraband crates
+			new /obj/item/seeds/kudzu(C)
 
 /datum/supply_pack/costumes_toys/foamforce
 	name = "Foam Force Crate"

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -350,7 +350,7 @@
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds! Has a slight chance to come with some additional, dangerous seeds."
-	cost = 1500
+	cost = 2500
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/replicapod,
 					/obj/item/seeds/replicapod,
@@ -368,13 +368,12 @@
 
 /datum/supply_pack/organic/exoticseeds/fill(obj/structure/closet/crate/C)
 	. = ..()
-	for(var/i=0, i < 2, i++) // 2 extra seeds
-		if(prob(33))
-			new /obj/item/seeds/cherry/bomb(C)
-		else if(prob(33))
-			new /obj/item/seeds/gatfruit(C)
-		else
-			new /obj/item/seeds/starthistle/corpse_flower(C)
+	if(prob(33))
+		new /obj/item/seeds/cherry/bomb(C)
+	else if(prob(33))
+		new /obj/item/seeds/gatfruit(C)
+	else
+		new /obj/item/seeds/starthistle/corpse_flower(C)
 	
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////// Misc /////////////////////////////////////

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -349,7 +349,7 @@
 
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
-	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds!"
+	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds! Has a slight chance to come with some additional, dangerous seeds."
 	cost = 1500
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/replicapod,
@@ -365,6 +365,15 @@
 					/obj/item/seeds/random)
 	crate_name = "exotic seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
+
+/datum/supply_pack/organic/exoticseeds/fill(obj/structure/closet/crate/C)
+	. = ..()
+	if(prob(33))
+		new /obj/item/seeds/cherry/bomb(C)
+	else if(prob(33))
+		new /obj/item/seeds/gatfruit(C)
+	else new /obj/item/seeds/starthistle/corpse_flower(C)
+	
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////// Misc /////////////////////////////////////

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -368,13 +368,14 @@
 
 /datum/supply_pack/organic/exoticseeds/fill(obj/structure/closet/crate/C)
 	. = ..()
-	if(prob(33))
-		new /obj/item/seeds/cherry/bomb(C)
-	else if(prob(33))
-		new /obj/item/seeds/gatfruit(C)
-	else new /obj/item/seeds/starthistle/corpse_flower(C)
+	for(i=0, i < 2, i++) // 2 extra seeds
+		if(prob(33))
+			new /obj/item/seeds/cherry/bomb(C)
+		else if(prob(33))
+			new /obj/item/seeds/gatfruit(C)
+		else
+			new /obj/item/seeds/starthistle/corpse_flower(C)
 	
-
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////// Misc /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -350,7 +350,8 @@
 /datum/supply_pack/organic/exoticseeds
 	name = "Seeds Crate (Exotic)"
 	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, including three replica-pod seeds and two mystery seeds! Has a slight chance to come with some additional, dangerous seeds."
-	cost = 2500
+	cost = 5000
+	access = ACCESS_HYDROPONICS
 	contains = list(/obj/item/seeds/nettle,
 					/obj/item/seeds/replicapod,
 					/obj/item/seeds/replicapod,
@@ -374,6 +375,8 @@
 		new /obj/item/seeds/gatfruit(C)
 	else
 		new /obj/item/seeds/starthistle/corpse_flower(C)
+	if(prob(5))
+		new /obj/item/seeds/kudzu(C)
 	
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////// Misc /////////////////////////////////////

--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -368,7 +368,7 @@
 
 /datum/supply_pack/organic/exoticseeds/fill(obj/structure/closet/crate/C)
 	. = ..()
-	for(i=0, i < 2, i++) // 2 extra seeds
+	for(var/i=0, i < 2, i++) // 2 extra seeds
 		if(prob(33))
 			new /obj/item/seeds/cherry/bomb(C)
 		else if(prob(33))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Made on request of discord: Hay#9365

Exotic crate has 2 extra seeds guaranteed, randomly picked from cherrybomb/gatfruit/corpseflower.

Contraband crate has a 34% chance to spawn with seeds. If it does, it's guaranteed either a gatfruit seed or a cherrybomb seed. If lucky, (very rare) you can get corpseflower (one in six crates) or kudzu (one in thirty crates).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fun seeds for crates, making botanist traitors happy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Exotic Seeds Crate can spawn with corpse flower, gatfruit or cherry bombs seeds.
add: The Contraband crate has a 1 in 3 chance to spawn with one or more rare seeds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
