### PR TITLE
Revert "Revert "Removes fusion""

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -203,7 +203,7 @@
 //fusion: a terrible idea that was fun but broken. Now reworked to be less broken and more interesting. Again (and again, and again). Again!
 //Fusion Rework Counter: Please increment this if you make a major overhaul to this system again.
 //6 reworks
-
+/* Skyrat Edit NAN pressure edition
 /datum/gas_reaction/fusion
 	exclude = FALSE
 	priority = 2
@@ -283,7 +283,7 @@
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 			air.temperature = clamp(((air.temperature*old_heat_capacity + reaction_energy)/new_heat_capacity),TCMB,INFINITY)
-		return REACTING
+		return REACTING */
 
 /datum/gas_reaction/nitrylformation //The formation of nitryl. Endothermic. Requires N2O as a catalyst.
 	priority = 3


### PR DESCRIPTION
Reverts Skyrat-SS13/Skyrat13#2534

Reasons for no fusion:

1. Fusion doesn't really give you anything you need, atmospherics or gas wise.
2. Fusion usually ends up fucking the station.
3. Shitters use fusion to fuck up the station.
## 4. Fusion literally has no use on the station other than screwing it up. It doesn't generate research or anything like that, literally all it does is make heat that you can't do anything with because it's too hot.

Cargo doesn't ever get any fusion canisters because atmos technicians don't bother to give it to them, so don't give that excuse.

# literally no reason to keep fusion.