### PR TITLE
[Maps] Remove Public Shuttle, Quantum Instead

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -58356,17 +58356,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "iDS" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/machinery/quantumpad{
+	map_pad_id = "toxenoarch";
+	map_pad_link_id = "tostation"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -60626,13 +60621,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nGI" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "nLc" = (
 /obj/structure/cable{
@@ -65162,15 +65154,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "xfS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xgk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -65481,12 +65466,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "xQG" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+/obj/structure/sign/warning/docking,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "xTy" = (
@@ -72981,7 +72962,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -73490,11 +73471,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+awW
+awW
+awW
+awW
+awW
 aaa
 aaa
 aaa
@@ -73747,11 +73728,11 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aaa
-aaa
-aaa
-aaa
+awW
+ayl
+ayl
+ayl
+awW
 aaa
 aaa
 aaa
@@ -74004,11 +73985,11 @@ aaa
 aaa
 aaa
 aaa
-aoV
-aaa
+awW
+nGI
 iDS
-aaa
-aaa
+xfS
+awW
 aoV
 aaa
 aaa
@@ -74261,11 +74242,11 @@ aaa
 aaa
 aaa
 aaa
-asE
-asE
-nGI
-asE
-asE
+awW
+ayl
+ayl
+ayl
+awW
 aoV
 aaa
 aaa
@@ -74518,11 +74499,11 @@ aaa
 aaa
 aaa
 aaa
-aaf
 awW
-auP
 awW
-aaf
+ayl
+awW
+xQG
 kls
 aaa
 aaa
@@ -74775,11 +74756,11 @@ aaa
 aaa
 aaa
 aaa
-arB
-arB
-xQG
-asE
-aAC
+awW
+ayl
+ayl
+awW
+aaa
 aaf
 aaa
 aaa
@@ -75032,8 +75013,8 @@ aaa
 aaa
 aaa
 aaa
-arB
-xfS
+awW
+awZ
 ayk
 awW
 aAD

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -244,9 +244,8 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/construction/mining/aux_base)
 "abe" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -99557,11 +99556,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mvx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/quantumpad{
+	map_pad_id = "toxenoarch";
+	map_pad_link_id = "tostation"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -99677,13 +99674,8 @@
 /turf/open/space,
 /area/engine/atmos)
 "mLI" = (
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -100080,11 +100072,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"nQR" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/computer/shuttle/mining/common,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nSh" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/closed/wall/r_wall,
@@ -100117,19 +100104,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/psych)
-"nSS" = (
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nUG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/box,
@@ -103316,17 +103290,6 @@
 "xbV" = (
 /turf/open/floor/wood,
 /area/security/prison)
-"xdp" = (
-/obj/docking_port/stationary{
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "xdL" = (
 /obj/machinery/requests_console{
 	department = "Prison";
@@ -135743,11 +135706,11 @@ oZp
 aaa
 aaa
 aaa
-aaa
-aaa
-rqh
-rqh
-aad
+aaO
+aaO
+aaO
+aaO
+aaO
 aad
 aaa
 aaa
@@ -136000,10 +135963,10 @@ oZp
 aaa
 aaa
 aaa
-aaa
 aaO
-aaO
-aaO
+aco
+abe
+aco
 aaO
 abf
 aaO
@@ -136257,11 +136220,11 @@ oZp
 aaa
 aaa
 aaa
-xdp
-mLI
+aaO
+aco
 mvx
-nSS
-abe
+aco
+aeb
 abp
 abC
 abC
@@ -136514,11 +136477,11 @@ oZp
 aaa
 aaa
 aaa
-aaa
 aaO
+aco
+mLI
+aco
 aaO
-aaO
-nQR
 abq
 abD
 abD
@@ -136771,12 +136734,12 @@ oZp
 aaa
 aaa
 aaa
-aaa
-aaa
-rqh
 aaO
 aaO
-abf
+aaO
+aaO
+aaO
+aaO
 aaO
 aaO
 abf

--- a/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_Skyrat.dmm
@@ -48579,14 +48579,8 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "bTS" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -49744,8 +49738,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bWn" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Dock"
+/obj/machinery/quantumpad{
+	map_pad_id = "toxenoarch";
+	map_pad_link_id = "tostation"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -49850,16 +49845,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bWx" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bWy" = (
 /obj/machinery/holopad,
@@ -106427,9 +106414,9 @@ bTq
 bSL
 cyG
 cyG
-cyG
-cyG
-cyG
+caQ
+caQ
+caQ
 cyG
 cyG
 bSr
@@ -106682,13 +106669,13 @@ bhY
 car
 bTr
 bSr
+bTS
 cyG
+caQ
+bWn
+caQ
 cyG
-cyG
-cyG
-cyG
-cyG
-cyG
+bWx
 bSr
 bYf
 ceU
@@ -106941,9 +106928,9 @@ bTs
 cav
 cyG
 cyG
-cyG
-cyG
-cyG
+caQ
+caQ
+caQ
 cyG
 cyG
 bSr
@@ -107199,7 +107186,7 @@ bSr
 cyG
 cyG
 cyG
-bTS
+caQ
 cyG
 cyG
 cyG
@@ -107456,8 +107443,8 @@ bOc
 bOc
 bOc
 bPe
-bWn
-bWx
+caQ
+bSr
 bSr
 bSL
 bSr

--- a/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
@@ -32685,8 +32685,8 @@
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
 "bnP" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Dock"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
@@ -33806,16 +33806,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "bqg" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/machinery/quantumpad{
+	map_pad_id = "toxenoarch";
+	map_pad_link_id = "tostation"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bqh" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -76777,16 +76772,7 @@
 	},
 /area/maintenance/aft)
 "eQf" = (
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/machinery/light,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "eQP" = (
@@ -94316,11 +94302,11 @@ bix
 bjY
 bma
 bqi
+bnP
 bqf
 bqf
 bqf
-bqf
-bqf
+eQf
 bqi
 djW
 bNd
@@ -94831,9 +94817,9 @@ bka
 bma
 bnM
 bqf
-bqf
-bqf
-bqf
+bbY
+bbY
+bbY
 bqf
 bnM
 bBf
@@ -95086,11 +95072,11 @@ bgz
 biA
 bnR
 blY
-bnP
+bbY
+bbY
+bbY
 bqg
-bqf
-bqf
-bqf
+bbY
 bqf
 bnM
 rNX
@@ -95343,11 +95329,11 @@ bgA
 biz
 bkb
 blZ
-eQf
+bnM
 bqf
-bqf
-bqf
-bqf
+bbY
+bbY
+bbY
 bqf
 bnM
 bBh
@@ -95858,11 +95844,11 @@ bcW
 dhP
 bqd
 bqi
+bnP
 bqf
 bqf
 bqf
-bqf
-bqf
+eQf
 bqi
 cbr
 biP

--- a/_maps/map_files/Mining/Lavaland_Skyrat.dmm
+++ b/_maps/map_files/Mining/Lavaland_Skyrat.dmm
@@ -21,7 +21,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "aj" = (
@@ -30,6 +29,15 @@
 	},
 /turf/open/floor/engine/n2,
 /area/xenoarch/eng)
+"al" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "an" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -592,6 +600,18 @@
 /obj/structure/stone_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"dn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "do" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -862,6 +882,12 @@
 /obj/structure/stone_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"fd" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "fg" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -991,6 +1017,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/gen)
+"fL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "fM" = (
 /obj/machinery/requests_console{
 	department = "Xenoarchaeology Security";
@@ -2104,9 +2137,9 @@
 /area/template_noop)
 "lu" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "lv" = (
 /obj/machinery/light/small{
@@ -2794,9 +2827,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "pf" = (
@@ -3440,9 +3470,12 @@
 /area/xenoarch/arch)
 "rX" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 6
 	},
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "rZ" = (
 /obj/machinery/power/compressor{
@@ -3690,9 +3723,10 @@
 /area/lavaland/surface/outdoors)
 "tr" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "tv" = (
 /turf/open/floor/plasteel/stairs,
@@ -4290,10 +4324,7 @@
 	c_tag = "Xenoarchaeology Nine";
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "wQ" = (
 /obj/structure/stone_tile/block,
@@ -4307,9 +4338,6 @@
 /area/lavaland/surface/outdoors)
 "wW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "wY" = (
@@ -4640,6 +4668,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/sec)
+"yu" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "tostation";
+	map_pad_link_id = "toxenoarch"
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "yv" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -4831,8 +4866,8 @@
 /turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zl" = (
-/obj/machinery/computer/shuttle/mining/common,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "zn" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -5055,16 +5090,14 @@
 	},
 /area/ruin/unpowered/ash_walkers)
 "AG" = (
-/obj/docking_port/stationary{
-	area_type = /area/xenoarch/arch;
-	dir = 8;
-	dwidth = 3;
-	height = 7;
-	id = "lavaland_common_away";
-	name = "Mining base public dock";
-	width = 7
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plating,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "AH" = (
 /obj/machinery/firealarm{
@@ -5103,8 +5136,13 @@
 /turf/open/floor/plasteel,
 /area/xenoarch/bot)
 "AT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/xenoarch/arch)
 "AU" = (
 /turf/open/floor/plasteel,
@@ -5179,6 +5217,15 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
+"Bl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "Br" = (
 /obj/machinery/atmospherics/pipe/simple/dark/hidden{
 	dir = 6
@@ -5899,9 +5946,6 @@
 /area/xenoarch/arch)
 "EX" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "EY" = (
@@ -8810,6 +8854,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/xenoarch/eng)
+"TI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/xenoarch/arch)
 "TJ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/breath/vox,
@@ -9167,7 +9217,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/xenoarch/arch)
 "Vt" = (
@@ -19837,15 +19886,15 @@ AK
 CV
 AK
 BS
-AU
+lu
+vz
 tr
-tr
-tr
+Bl
 wO
 tr
-tr
-tr
-AU
+Bl
+vz
+TI
 BS
 Za
 Za
@@ -20094,15 +20143,15 @@ KE
 as
 KE
 BS
-AT
-jn
-jn
-jn
-jn
-jn
-jn
-jn
-rX
+vz
+vz
+zl
+fd
+yu
+zl
+fd
+vz
+vz
 BS
 DM
 DM
@@ -20352,13 +20401,13 @@ Ho
 ND
 BS
 AT
-jn
-jn
-jn
-jn
-jn
-jn
-jn
+vz
+AG
+al
+vz
+fL
+dn
+vz
 rX
 BS
 pl
@@ -20609,13 +20658,13 @@ as
 KE
 BS
 ai
-jn
-jn
-jn
-jn
-jn
-jn
-jn
+AU
+AU
+AU
+AU
+AU
+AU
+AU
 EX
 BS
 DM
@@ -20866,14 +20915,14 @@ as
 OM
 BS
 Vs
-jn
-jn
-jn
-jn
-jn
-jn
-jn
-rX
+AU
+AU
+AU
+AU
+AU
+AU
+AU
+AU
 BS
 DM
 DM
@@ -21122,15 +21171,15 @@ Wc
 yL
 Uk
 BS
-AT
-jn
-jn
-jn
-AG
-jn
-jn
-jn
-rX
+AU
+AU
+AU
+AU
+AU
+AU
+AU
+AU
+AU
 BS
 DM
 DM
@@ -21380,13 +21429,13 @@ as
 HK
 BS
 AU
-lu
-lu
+AU
+AU
 wW
 Td
 pe
-lu
-lu
+AU
+AU
 AU
 BS
 DM
@@ -21638,7 +21687,7 @@ OM
 BS
 AU
 AU
-zl
+AU
 AU
 Bf
 km

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -16673,6 +16673,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"aOe" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "toxenoarch";
+	map_pad_link_id = "tostation"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aOf" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/neutral{
@@ -57694,6 +57701,10 @@
 /obj/structure/floodlight_frame,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ldR" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62398,9 +62409,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tcY" = (
@@ -64623,17 +64631,11 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "wPW" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -84575,11 +84577,11 @@ baK
 bon
 aZx
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aZx
+aZx
+aZx
+aZx
+aZx
 aaa
 gDV
 aZx
@@ -84832,11 +84834,11 @@ baK
 bon
 aZx
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aZx
+baK
+baK
+baK
+aZx
 aaa
 sty
 gKd
@@ -85089,11 +85091,11 @@ baL
 bon
 aZx
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aZx
+wPW
+aOe
+ldR
+aZx
 aaa
 sty
 mVD
@@ -85346,11 +85348,11 @@ baK
 boo
 aZx
 aaa
-aaa
-aaa
-wPW
-aaa
-aaa
+aZx
+baK
+baK
+baK
+aZx
 aaa
 sty
 mVD
@@ -85605,7 +85607,7 @@ aZx
 aZx
 aZx
 bsl
-btL
+baK
 aZx
 aZx
 aZx
@@ -85862,7 +85864,7 @@ aZx
 bDf
 tbY
 aZx
-bcX
+baK
 aZx
 kBp
 xeN
@@ -86119,7 +86121,7 @@ aZx
 epg
 uxI
 bsl
-btM
+baK
 aZx
 mVD
 dpc

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -104,11 +104,11 @@
 		to_chat(user, "<span class='warning'>[src] is charging up. Please wait.</span>")
 		return
 
-	if(target_pad.teleporting)
+	if(target_pad?.teleporting) // skyrat - no runtime on xenoarch telepads
 		to_chat(user, "<span class='warning'>Target pad is busy. Please wait.</span>")
 		return
 
-	if(target_pad.stat & NOPOWER)
+	if(target_pad?.stat & NOPOWER)
 		to_chat(user, "<span class='warning'>Target pad is not responding to ping.</span>")
 		return
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes public mining shuttle
places quantum pads instead
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
hopeful fix for shuttle crashing
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added xenoarch quantum pad
del: Removed public mining shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
