### PR TITLE
Nerfs executioner sword, lightly buffs the shortsword

### DIFF
--- a/modular_skyrat/code/datums/components/crafting/crafting_results/swords.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/swords.dm
@@ -87,12 +87,11 @@
 		if(!istype(BP))
 			return
 		if(prob(delimb_chance))
-			if(BP.body_zone == (BODY_ZONE_CHEST || BODY_ZONE_HEAD))
-				if(C.getarmor(def_zone, "melee") >= armorthreshold)
-					user.changeNext_move(CLICK_CD_MELEE * 2)
-					return
+			if((C.getarmor(def_zone, "melee") >= armorthreshold) || (def_zone == (BODY_ZONE_HEAD || BODY_ZONE_CHEST || BODY_ZONE_PRECISE_GROIN)))
+				user.changeNext_move(CLICK_CD_MELEE * 2)
+				return
 			BP.dismember(BRUTE)
-		user.changeNext_move(CLICK_CD_MELEE * 2)
+	user.changeNext_move(CLICK_CD_MELEE * 2)
 
 /obj/item/melee/sword/shortsword
 	name = "shortsword"

--- a/modular_skyrat/code/datums/components/crafting/crafting_results/swords.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/swords.dm
@@ -104,4 +104,4 @@
 
 /obj/item/melee/sword/shortsword/melee_attack_chain(mob/user, atom/target, params)
 	..()
-	user.changeNext_move(CLICK_CD_MELEE * 0.75)
+	user.changeNext_move(CLICK_CD_MELEE * 0.65)

--- a/modular_skyrat/code/datums/components/crafting/crafting_results/swords.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/swords.dm
@@ -86,10 +86,10 @@
 		var/obj/item/bodypart/BP = C.get_bodypart(check_zone(user.zone_selected))
 		if(!istype(BP))
 			return
+		if((C.getarmor(def_zone, "melee") >= armorthreshold) || (def_zone in list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN)))
+			user.changeNext_move(CLICK_CD_MELEE * 2)
+			return
 		if(prob(delimb_chance))
-			if((C.getarmor(def_zone, "melee") >= armorthreshold) || (def_zone == (BODY_ZONE_HEAD || BODY_ZONE_CHEST || BODY_ZONE_PRECISE_GROIN)))
-				user.changeNext_move(CLICK_CD_MELEE * 2)
-				return
 			BP.dismember(BRUTE)
 	user.changeNext_move(CLICK_CD_MELEE * 2)
 

--- a/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
@@ -270,7 +270,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(H.getarmor(def_zone, "melee") < 35)
-			if((user.zone_selected != BODY_ZONE_CHEST) && (user.zone_selected != BODY_ZONE_HEAD) && (user.zone_selected !+ BODY_ZONE_PRECISE_GROIN))
+			if((user.zone_selected != BODY_ZONE_CHEST) && (user.zone_selected != BODY_ZONE_HEAD) && (user.zone_selected != BODY_ZONE_PRECISE_GROIN))
 				..()
 				var/obj/item/bodypart/bodyp= H.get_bodypart(def_zone)
 				bodyp.dismember()

--- a/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
@@ -270,7 +270,7 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(H.getarmor(def_zone, "melee") < 35)
-			if((user.zone_selected != BODY_ZONE_CHEST) && (user.zone_selected != BODY_ZONE_HEAD))
+			if((user.zone_selected != BODY_ZONE_CHEST) && (user.zone_selected != BODY_ZONE_HEAD) && (user.zone_selected !+ BODY_ZONE_PRECISE_GROIN))
 				..()
 				var/obj/item/bodypart/bodyp= H.get_bodypart(def_zone)
 				bodyp.dismember()


### PR DESCRIPTION
## About The Pull Request

Executioner sword will now only delimb extremities - it won't disembowel or decap, and it will always respect armor - only limbs that have less than 25 melee armoring can be dismembered.

Shortsword now has 0.65x the click delay, instead of 0.75x.

## Why It's Good For The Game

balance

## Changelog
:cl:
balance: Executioner sword now respects armor and is unable to decap or disembowel.
balance: The shortsword is slightly faster at attacking.
/:cl: