### PR TITLE
Holorifle buff

### DIFF
--- a/modular_skyrat/code/datums/status_effects/debuffs.dm
+++ b/modular_skyrat/code/datums/status_effects/debuffs.dm
@@ -21,7 +21,7 @@
 	id = "holoburn"
 	status_type = STATUS_EFFECT_REFRESH
 	tick_interval = 10
-	duration = 100
+	duration = 200
 	alert_type = null
 	var/icon/burn
 


### PR DESCRIPTION
## About The Pull Request

Buffs the holorifle by doubling the duration of the holoburn status effects, effectively making it deal 20 damage over 20 seconds instead of 10 damage over 10 seconds.

## Why It's Good For The Game

The holorifle is currently quite useless considering it's late game tech - there are almost no situations in which a shotgun slug isn't preferred. This may make it a bit more worthwhile.

## Changelog
:cl:
balance: Holoburn duration has been doubled.
/:cl:
