### PR TITLE
Let's make transfer votes go off real time, rather than byond time.

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(autotransfer)
 	if(!init_vote) //Autotransfer voting disabled.
 		can_fire = FALSE
 		return ..()
-	starttime = world.time
+	starttime = world.realtime // Skyrat edit
 	targettime = starttime + init_vote
 	voteinterval = CONFIG_GET(number/vote_autotransfer_interval)
 	maxvotes = CONFIG_GET(number/vote_autotransfer_maximum)
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(autotransfer)
 	curvotes = SSautotransfer.curvotes
 
 /datum/controller/subsystem/autotransfer/fire()
-	if(world.time < targettime)
+	if(world.realtime < targettime)
 		return
 	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
 		SSvote.initiate_vote("transfer","server")

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(autotransfer)
 	curvotes = SSautotransfer.curvotes
 
 /datum/controller/subsystem/autotransfer/fire()
-	if(world.realtime < targettime)
+	if(world.realtime < targettime) // Skyrat edit
 		return
 	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
 		SSvote.initiate_vote("transfer","server")


### PR DESCRIPTION
## Why It's Good For The Game

Rounds will now be exactly as long as they should be, regardless of time dilation.

## Changelog
:cl:
tweak: Round end votes now use real time instead of byond time, which was affected by time dilation, making some rounds longer than they should be.
/:cl: