### PR TITLE
Removes weapon circuitry from research

### DIFF
--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -23,7 +23,7 @@
 
 	)
 	var/obj/item/gun/energy/installed_gun = null
-	spawn_flags = IC_SPAWN_RESEARCH
+	//spawn_flags = IC_SPAWN_RESEARCH //skyrat edit - removes weaponry circuitry
 	action_flags = IC_ACTION_COMBAT
 	power_draw_per_use = 0
 	ext_cooldown = 1


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

Weaponry circuitry serves no purpose beyond power gaming. The latest installment has been research making 4 aeguns melded together into an autocharging abomination that fires 4 shots at once. This is harmful for the game, and i cannot see any reason to not remove this entirely - even a single aegun circuit, or any gun for that matter, can cause a lot of damage.

## Changelog
:cl:
del: Gun circuits are no longer obtainable through research,
/:cl:
