### PR TITLE
[Modular] [Bugfix] Fixes the Medical Gygax to be printable; Makes the Medical Gygax no longer just a more expensive Ody reskin.

### DIFF
--- a/modular_skyrat/code/game/mecha/mech_fabricator.dm
+++ b/modular_skyrat/code/game/mecha/mech_fabricator.dm
@@ -10,6 +10,7 @@
 						"Buzz",
 						"Odysseus",
 						"Gygax",
+						"Medical-Spec Gygax",
 						"Durand",
 						"H.O.N.K",
 						"Phazon",

--- a/modular_skyrat/code/game/mecha/medical/medigax.dm
+++ b/modular_skyrat/code/game/mecha/medical/medigax.dm
@@ -1,0 +1,14 @@
+/obj/mecha/medical/medigax
+	desc = "A specialized variant of the standard Gygax, stripped of its weaponry holsters in place of medical apparatus slots, coated in a slick white color scheme. Produced by Vey-Med.(&copy; All rights reserved)."
+	deflect_chance = 5
+	force = 30
+	internal_damage_threshold = 50
+	leg_overload_coeff = 300
+
+/obj/mecha/medical/medigax/GrantActions(mob/living/user, human_occupant = 0)
+	..()
+	overload_action.Grant(user, src)
+
+/obj/mecha/medical/medigax/RemoveActions(mob/living/user, human_occupant = 0)
+	..()
+	overload_action.Remove(user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3553,6 +3553,7 @@
 #include "modular_skyrat\code\game\mecha\equipment\weapons\killdozer.dm"
 #include "modular_skyrat\code\game\mecha\makeshift\lockermech.dm"
 #include "modular_skyrat\code\game\mecha\makeshift\makeshift_tools.dm"
+#include "modular_skyrat\code\game\mecha\medical\medigax.dm"
 #include "modular_skyrat\code\game\mecha\working\buzz.dm"
 #include "modular_skyrat\code\game\mecha\working\clarke.dm"
 #include "modular_skyrat\code\game\mecha\working\killdozer.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug that would prevent you from printing the parts required to construct a Medical Gygax. Gives the Medical Gygax its punch force and actuator overload back.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It was quite literally just a far more expensive Odysseus that was the ever-so-smallest-bit faster (so small in fact that you wouldn't even know it was faster unless you read the code). Also, bugfixes are good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Medical Gygax is now worth its pricetag.
fix: You can now actually make the Medical Gygax.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
