### PR TITLE
Exempt upstream PRs from actions/stale.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3.0.7
       with:
         repo-token: ${{ secrets.SKYRATBOT_TOKEN }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 7 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
         days-before-stale: 14
         days-before-close: 7
         stale-pr-label: 'Stale'
-        exempt-pr-label: 'RED LABEL'
+        exempt-pr-labels: 'RED LABEL,Upstream PR Merged'


### PR DESCRIPTION
## About The Pull Request 
As of actions/stale@v2 (which came out about 2 months ago), it's possible to exempt multiple issue and PRs labels instead of one.
Also updating stale to the latest release, if anything goes wrong, feel free to rollback a bit.

## Why It's Good For The Game
Pretty sure Useroth spoke bout exempting mirror PRs a while ago.

## Changelog
Nope, no impact to the server.