### PR TITLE
Buffs .50 and renames it to .50 BMG

### DIFF
--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -1,12 +1,12 @@
 // .50 (Sniper)
 
 /obj/item/projectile/bullet/p50
-	name =".50 bullet"
+	name =".50 BMG bullet"
 	pixels_per_second = TILES_TO_PIXELS(25)
-	damage = 70
+	damage = 92
 	knockdown = 100
 	dismemberment = 50
-	armour_penetration = 50
+	armour_penetration = 85        //This means it will go clean through bulletproof armor, it's 18000> Joules of kinetic force jfc
 	zone_accuracy_factor = 100		//guarunteed 100%
 	var/breakthings = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Ups the damage and AP values of normal .50 to make it a viable round for the weapons that use it.

## Why It's Good For The Game

.357 In-game deals 60 damage per shot. The kinetic force of .357 JHC Buffalo is 1087 Joules.
.50 previously dealt 70 damage. The kinetic force of .50 BMG Barnes on a 700 grain load is 18942 Joules.

Also, every gun that fires normal .50 is slow as fuck. 

## Changelog
:cl:
".50" > ".50 BMG"
.50 AP value "50" > "85"
.50 Damage value "70" > "92"
/:cl: