### PR TITLE
TESTMERGE ONLY small atmos tweak

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -396,7 +396,7 @@
 	min_requirements = list(
 		/datum/gas/nitrogen = 10,
 		/datum/gas/tritium = 5,
-		"TEMP" = 5000000)
+		"TEMP" = 500000)
 
 /datum/gas_reaction/nobliumformation/react(datum/gas_mixture/air)
 	var/list/cached_gases = air.gases


### PR DESCRIPTION
Knocked a zero off the temp req for hypernoblium cause fusion is kill for now (when will it return????)
keep this a testmerge only, if fusion is to be removed entirely a more elegant solution can be made
## Changelog
:cl:
tweak: Hypernoblium reaction now requires 500,000k, down from 5,000,000k
/:cl:
