### PR TITLE
Comments out the CQC Kit from Traitor Uplink.

### DIFF
--- a/modular_skyrat/code/modules/uplink/uplink_bundles.dm
+++ b/modular_skyrat/code/modules/uplink/uplink_bundles.dm
@@ -56,7 +56,7 @@
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 
 //punished venom traitor bundle. yes i'll keep the theme of inconsistent file paths and shit because i'm too lazy to create new files and shit for everything here.
-/datum/uplink_item/bundles_TC/punished
+/*/datum/uplink_item/bundles_TC/punished
 	name = "Motherbase Shipment"
 	desc = "A kit containing the essentials for any 'big boss'. Contains a tactical turtleneck, thermal eyepatch, sneaking boots and a robotic CQC arm implanter."
 	item = /obj/item/storage/box/syndie_kit/snake
@@ -76,7 +76,7 @@
 	new /obj/item/limbsurgeon/martialarm(src)
 	new /obj/item/headsetupgrader(src)
 	new /obj/item/encryptionkey/syndicate(src)
-	new /obj/item/kitchen/knife/combat/survival(src)
+	new /obj/item/kitchen/knife/combat/survival(src)*/ //As fun as this is, its just way too overpowered for normal play.
 
 /obj/item/limbsurgeon //autosurgeon is shit and does not support limbs, i had to do it to 'em
 	name = "limb autosurgeon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
INB4 Salt PR
Comments out the CQC Kit from the Traitor Uplink.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As fun and interesting as this kit was, its just way too overpowered for normal play. A hyperlethal cybernetic that gives you the most powerful, broken, and lethal (Yes, it is VERY lethal) martial art in the game, along with extra tools and the ability to see through walls? This would be great for a one-off event or TC trade, but as it stands this kit has just been used to destroy game balance and invalidate any and all attempts to bring down a perp with it unless they actively let you capture them.

TLDR: Instant disarms, Instant sleeps, and three-hit kills are bad for game balance even if it IS really fun to watch. There was a reason this was restricted to Nuclear Operatives only.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Mother Base Shipment from the Uplink. Sorry Bob, this was too good for this world.
balance: You can no longer get the Mother Base Shipment or CQC Arm by normal means.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
