### PR TITLE
(BOUNTY) Silicon Interactions Menu 2: Electric Boogaloo (Or why I don't use git bash)

### DIFF
--- a/modular_skyrat/code/interactions/_interaction.dm
+++ b/modular_skyrat/code/interactions/_interaction.dm
@@ -1,4 +1,4 @@
-/**********************************
+/*********************************
 *******Interactions code by HONKERTRON feat TestUnit********
 **Contains a lot ammount of ERP and MEHANOYEBLYA**
 **CREDIT TO ATMTA STATION FOR MOST OF THIS CODE, I ONLY MADE IT WORK IN /vg/ - Matt
@@ -19,7 +19,7 @@ var/list/interactions
 			var/datum/interaction/I = new itype()
 			interactions[I.command] = I
 
-/mob/living/carbon/human/proc/list_interaction_attributes()
+/mob/living/proc/list_interaction_attributes()
 	var/dat = ""
 	if(has_hands())
 		dat += "...have hands."
@@ -49,24 +49,24 @@ var/list/interactions
 
 	var/user_is_target = FALSE //Boolean. Pretty self explanatory.
 
-/datum/interaction/proc/evaluate_user(mob/living/carbon/human/user, silent = TRUE)
+/datum/interaction/proc/evaluate_user(mob/living/user, silent = TRUE)
 	if(user.get_refraction_dif())
 		if(!silent) //bye spam
 			to_chat(user, "<span class='warning'>You're still exhausted from the last time. You need to wait [DisplayTimeText(user.get_refraction_dif(), TRUE)] until you can do that!</span>")
 		return FALSE
 
 	if(require_user_mouth)
-		if(!user.has_mouth())
+		if(!user.has_mouth() && !issilicon(user)) //Again, silicons do not have the required parts normally.
 			if(!silent)
 				to_chat(user, "<span class = 'warning'>You don't have a mouth.</span>")
 			return FALSE
 
-		if(!user.mouth_is_free())
+		if(!user.mouth_is_free() && !issilicon(user)) //Borgs cannot wear mouthgear, bypassing the check.
 			if(!silent)
 				to_chat(user, "<span class = 'warning'>Your mouth is covered.</span>")
 			return FALSE
 
-	if(require_user_hands && !user.has_hands())
+	if(require_user_hands && !user.has_hands() && !issilicon(user)) //Edited to allow silicons to interact.
 		if(!silent)
 			to_chat(user, "<span class = 'warning'>You don't have hands.</span>")
 		return FALSE
@@ -75,32 +75,32 @@ var/list/interactions
 		return TRUE
 	return FALSE
 
-/datum/interaction/proc/evaluate_target(mob/living/carbon/human/user, mob/living/carbon/human/target, silent = TRUE)
+/datum/interaction/proc/evaluate_target(mob/living/user, mob/living/target, silent = TRUE)
 	if(!user_is_target)
 		if(user == target)
 			if(!silent)
 				to_chat(user, "<span class = 'warning'>You can't do that to yourself.</span>")
 			return FALSE
-	
+
 	if(require_target_mouth)
 		if(!target.has_mouth())
 			if(!silent)
 				to_chat(user, "<span class = 'warning'>They don't have a mouth.</span>")
 			return FALSE
 
-		if(!target.mouth_is_free())
+		if(!target.mouth_is_free() && !issilicon(target))
 			if(!silent)
 				to_chat(user, "<span class = 'warning'>Their mouth is covered.</span>")
 			return FALSE
 
-	if(require_target_hands && !target.has_hands())
+	if(require_target_hands && !target.has_hands() && !issilicon(target))
 		if(!silent)
 			to_chat(user, "<span class = 'warning'>They don't have hands.</span>")
 		return FALSE
 
 	return TRUE
 
-/datum/interaction/proc/get_action_link_for(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/interaction/proc/get_action_link_for(mob/living/user, mob/living/target)
 	return "<a HREF='byond://?src=[REF(src)];action=1;action_user=[REF(user)];action_target=[REF(target)]'>[description]</a><br>"
 
 /datum/interaction/Topic(href, href_list)
@@ -111,7 +111,7 @@ var/list/interactions
 		return TRUE
 	return FALSE
 
-/datum/interaction/proc/do_action(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/interaction/proc/do_action(mob/living/user, mob/living/target)
 	if(!user_is_target)
 		if(user == target) //tactical href fix
 			to_chat(user, "<span class='warning'>You cannot target yourself.</span>")
@@ -144,38 +144,38 @@ var/list/interactions
 		//add_logs(target, user, "fucked2")
 	//target.attack_log += text("\[[time_stamp()]\] <font color='orange'>[write_log_target] [user.name] ([user.ckey])</font>")
 
-/datum/interaction/proc/display_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/interaction/proc/display_interaction(mob/living/user, mob/living/target)
 	if(simple_message)
 		var/use_message = replacetext(simple_message, "USER", "\the [user]")
 		use_message = replacetext(use_message, "TARGET", "\the [target]")
 		user.visible_message("<span class='[simple_style]'>[capitalize(use_message)]</span>")
 
-/datum/interaction/proc/post_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/interaction/proc/post_interaction(mob/living/user, mob/living/target)
 	user.last_interaction_time = world.time + 6
 	if(interaction_sound)
 		playsound(get_turf(user), interaction_sound, 50, 1, -1)
 	return
 /*
-/atom/movable/attack_hand(mob/living/carbon/human/user)
+/atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(can_buckle && buckled_mob)
 		if(user_unbuckle_mob(user))
 			return TRUE
 
-/atom/movable/MouseDrop_T(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	if(can_buckle && istype(M) && !buckled_mob)
 		if(user_buckle_mob(M, user))
 			return TRUE
 
 
-/atom/movable/attack_hand(mob/living/carbon/human/user)
+/atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(can_buckle && buckled_mob)
 		if(user_unbuckle_mob(user))
 			return TRUE
 
-/atom/movable/MouseDrop_T(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/atom/movable/MouseDrop_T(mob/living/carbon/human/M, mob/living/user)
 	. = ..()
 	if(can_buckle && istype(M) && !buckled_mob)
 		if(user_buckle_mob(M, user))

--- a/modular_skyrat/code/interactions/interaction_interface.dm
+++ b/modular_skyrat/code/interactions/interaction_interface.dm
@@ -9,27 +9,45 @@
 	return ..()
 */
 
-/mob/living/carbon/human/MouseDrop_T(mob/M as mob, mob/living/carbon/human/user as mob)
+/mob/living/MouseDrop_T(mob/M as mob, mob/living/user as mob)
 	. = ..()
 	if(M == src || src == usr || M != usr)
 		return
 	if(usr.restrained())
 		return
-	if(!ishuman(src))
-		return
 
 	user.try_interaction(src)
 
-/mob/living/carbon/human/verb/interact_with()
+/mob/living/verb/interact_with()
 	set name = "Interact With"
 	set desc = "Perform an interaction with someone."
 	set category = "IC"
 	set src in view()
 
-	if(!usr.restrained() && ishuman(src))
+	if(!usr.restrained())
 		usr.try_interaction(src)
 
-/mob/living/carbon/human/try_interaction(mob/living/carbon/human/partner)
+/mob/living/silicon/robot/verb/toggle_gender() //Change to add silicon genderchanges. Experimental.
+	set category = "IC"
+	set name = "Set Gender"
+	set desc = "Allows you to set your gender."
+
+	if(stat != CONSCIOUS)
+		to_chat(usr, "<span class='warning'>You cannot toggle your gender while unconcious!</span>")
+		return
+	var/choice = alert(src, "Select Gender.", "", "Male", "Female", "Neither")
+	switch(choice)
+		if("Male")
+			src.has_penis = TRUE
+			src.has_vagina = FALSE
+		if("Female")
+			src.has_penis = FALSE
+			src.has_vagina = TRUE
+		if("Neither")
+			src.has_penis = FALSE
+			src.has_vagina = FALSE
+
+/mob/living/try_interaction(mob/living/partner)
 	var/dat
 	if(partner != src)
 		dat = "<B><HR><FONT size=3>Interacting with \the [partner]...</FONT></B><HR>"

--- a/modular_skyrat/code/interactions/interaction_interface.dm
+++ b/modular_skyrat/code/interactions/interaction_interface.dm
@@ -35,17 +35,18 @@
 	if(stat != CONSCIOUS)
 		to_chat(usr, "<span class='warning'>You cannot toggle your gender while unconcious!</span>")
 		return
-	var/choice = alert(src, "Select Gender.", "", "Male", "Female", "Neither")
+		
+	var/choice = alert(src, "Select Gender.", "Gender", "Both", "Male", "Female")
 	switch(choice)
+		if("Both")
+			src.has_penis = TRUE
+			src.has_vagina = TRUE
 		if("Male")
 			src.has_penis = TRUE
 			src.has_vagina = FALSE
 		if("Female")
 			src.has_penis = FALSE
 			src.has_vagina = TRUE
-		if("Neither")
-			src.has_penis = FALSE
-			src.has_vagina = FALSE
 
 /mob/living/try_interaction(mob/living/partner)
 	var/dat

--- a/modular_skyrat/code/interactions/lewd/_lewd.dm
+++ b/modular_skyrat/code/interactions/lewd/_lewd.dm
@@ -99,6 +99,8 @@
 
 /mob/living/proc/has_penis(var/nintendo = REQUIRE_ANY)
 	var/mob/living/carbon/C = src
+	if(issilicon(src) && C.has_penis)
+		return TRUE
 	if(istype(C))
 		var/obj/item/organ/genital/peepee = C.getorganslot(ORGAN_SLOT_PENIS)
 		if(peepee)
@@ -143,6 +145,8 @@
 
 /mob/living/proc/has_vagina(var/nintendo = REQUIRE_ANY)
 	var/mob/living/carbon/C = src
+	if(issilicon(src) && C.has_vagina)
+		return TRUE
 	if(istype(C))
 		var/obj/item/organ/genital/peepee = C.getorganslot(ORGAN_SLOT_VAGINA)
 		if(peepee)
@@ -186,6 +190,8 @@
 	return FALSE
 
 /mob/living/proc/has_anus(var/nintendo = REQUIRE_ANY)
+	if(issilicon(src))
+		return TRUE
 	switch(nintendo)
 		if(REQUIRE_EXPOSED)
 			if(is_bottomless())

--- a/modular_skyrat/code/interactions/lewd/lewd_interactions.dm
+++ b/modular_skyrat/code/interactions/lewd/lewd_interactions.dm
@@ -68,7 +68,7 @@
 	var/user_refractory_cost
 	var/target_refractory_cost
 
-/datum/interaction/lewd/evaluate_user(mob/living/carbon/human/user, silent = TRUE)
+/datum/interaction/lewd/evaluate_user(mob/living/user, silent = TRUE)
 	if(..(user, silent))
 		if(user_not_tired && user.get_refraction_dif())
 			if(!silent) //bye spam
@@ -284,7 +284,7 @@
 		return FALSE
 	return FALSE
 
-/datum/interaction/lewd/evaluate_target(mob/living/carbon/human/user, mob/living/carbon/human/target, silent = TRUE)
+/datum/interaction/lewd/evaluate_target(mob/living/user, mob/living/target, silent = TRUE)
 	if(..(user, target, silent))
 		if(target_not_tired && target.get_refraction_dif())
 			if(!silent) //same with this
@@ -505,7 +505,7 @@
 		return FALSE
 	return FALSE
 
-/datum/interaction/lewd/post_interaction(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/interaction/lewd/post_interaction(mob/living/user, mob/living/target)
 	if(user_refractory_cost)
 		user.refractory_period = world.time + user_refractory_cost*10
 	if(target_refractory_cost)
@@ -516,7 +516,7 @@
 	user.cleartimer = addtimer(CALLBACK(user, /mob/living/proc/clear_lewd_datum), 300, TIMER_STOPPABLE)
 	return ..()
 
-/datum/interaction/lewd/get_action_link_for(mob/living/carbon/human/user, mob/living/carbon/human/target)
+/datum/interaction/lewd/get_action_link_for(mob/living/user, mob/living/target)
 	if(user.stat == DEAD)
 		to_chat(user, "<span class='warning'>You cannot do that while deceased!</span>")
 		return
@@ -524,7 +524,7 @@
 		return "<font color='#FF0000'><b>EXTREME:</b></font> [..()]"
 	return "<font color='#FF0000'><b>LEWD:</b></font> [..()]"
 
-/mob/living/carbon/human/list_interaction_attributes(var/mob/living/LM)
+/mob/living/list_interaction_attributes(var/mob/living/LM)
 	var/dat = ..()
 	if(get_refraction_dif())
 		dat += "<br>...are sexually exhausted for the time being."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As stated by the title, allows silicons to use the interaction Menu.
![image](https://user-images.githubusercontent.com/65188584/87064020-115ba600-c207-11ea-9a79-d62adcbcaa38.png)
Along with the ability to inherently switch gender's on the fly (You start neutered, herm borgs now.)

Also changes some of the background code to be better, and to rely on less on ishuman(), further support for cursed things like _ash drake ERP_
![image](https://user-images.githubusercontent.com/65188584/87064319-74e5d380-c207-11ea-89fb-064a1a089382.png)
![image](https://user-images.githubusercontent.com/65188584/87064360-85964980-c207-11ea-8a88-cb8e8a96ec34.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was a bounty, plus it adds a feature silicons have been lacking for a while. People kinda want it too.
Also no runtimes so please dont crucify me.
![image](https://user-images.githubusercontent.com/65188584/87064398-95159280-c207-11ea-80f9-7db5a9be66ad.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New Verb - Set Gender for cyborgs/silicons. Allows them to inherently switch their gender.
tweak: Silicons can now use the interaction menu.
tweak: People can now interact with other mobs via the interaction menu (mostly untested)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
