### PR TITLE
Small Engineering QoL changes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1091,7 +1091,7 @@
 			prying_so_hard = FALSE
 			if(result)
 				open(2)
-				take_damage(30, BRUTE, 0, 0)
+				take_damage(25, BRUTE, 0, 0) // Skyrat change
 				if(density && !open(2))
 					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -95,6 +95,7 @@
 
 	var/air_tight = FALSE	//TRUE means density will be set as soon as the door begins to close
 	var/prying_so_hard = FALSE
+	var/pried_so_hard = FALSE // Skyrat change
 
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 	rad_insulation = RAD_MEDIUM_INSULATION
@@ -653,6 +654,8 @@
 		. += "<span class='warning'>The maintenance panel seems haphazardly fastened.</span>"
 	if(charge && panel_open)
 		. += "<span class='warning'>Something is wired up to the airlock's electronics!</span>"
+	if(pried_so_hard) // Skyrat change
+		. += "<span class='warning'>There are signs of forced entry where the halves meet, dents and scratches in the airlock's metal.</span>"
 	if(note)
 		if(!in_range(user, src))
 			. += "There's a [note.name] pinned to the front. You can't read it from here."
@@ -1018,6 +1021,7 @@
 								"<span class='italics'>You hear welding.</span>")
 				if(W.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
 					obj_integrity = max_integrity
+					pried_so_hard = FALSE // Skyrat
 					stat &= ~BROKEN
 					user.visible_message("[user.name] has repaired [src].", \
 										"<span class='notice'>You finish repairing the airlock.</span>")
@@ -1092,6 +1096,7 @@
 			if(result)
 				open(2)
 				take_damage(25, BRUTE, 0, 0) // Skyrat change
+				pried_so_hard = TRUE // Skyrat change
 				if(density && !open(2))
 					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1091,6 +1091,7 @@
 			prying_so_hard = FALSE
 			if(result)
 				open(2)
+				take_damage(30, BRUTE, 0, 0)
 				if(density && !open(2))
 					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
 

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -27,22 +27,17 @@
 /obj/machinery/space_heater/get_cell()
 	return cell
 
-/obj/machinery/space_heater/Initialize()
+/obj/machinery/space_heater/Initialize() // Skyrat change: cell change
 	. = ..()
-	cell = new(src)
 	update_icon()
 
-/obj/machinery/space_heater/on_construction()
-	qdel(cell)
-	cell = null
+/obj/machinery/space_heater/on_construction() // Skyrat change: cell change
 	panel_open = TRUE
 	update_icon()
 	return ..()
 
-/obj/machinery/space_heater/on_deconstruction()
-	if(cell)
-		component_parts += cell
-		cell = null
+/obj/machinery/space_heater/on_deconstruction() // Skyrat change: cell change
+	cell = null
 	return ..()
 
 /obj/machinery/space_heater/examine(mob/user)
@@ -121,6 +116,8 @@
 		laser += M.rating
 	for(var/obj/item/stock_parts/capacitor/M in component_parts)
 		cap += M.rating
+	for(var/obj/item/stock_parts/cell/P in component_parts) // Skyrat change
+		cell = P
 
 	heatingPower = laser * 40000
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -58,8 +58,19 @@ RLD
 	. = ..()
 
 /obj/item/construction/attackby(obj/item/W, mob/user, params)
-	if(iscyborg(user))
+	if(!rcd_item_insertion(W, user)) // Skyrat change: moved all logic to this proc
+		return ..()
+	update_icon()	//ensures that ammo counters (if present) get updated
+
+/obj/item/construction/pre_attack(atom/A, mob/living/user, params) // Skyrat change
+	if(rcd_item_insertion(A, user))
+		update_icon()
 		return
+	return ..()
+
+/obj/item/construction/proc/rcd_item_insertion(obj/item/W, mob/user) // Skyrat change: Moved logic to own proc, to prevent duplicate code
+	if(iscyborg(user))
+		return FALSE
 	var/loaded = 0
 	if(istype(W, /obj/item/rcd_ammo))
 		var/obj/item/rcd_ammo/R = W
@@ -95,8 +106,8 @@ RLD
 			playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 			qdel(W)
 	else
-		return ..()
-	update_icon()	//ensures that ammo counters (if present) get updated
+		return FALSE
+	return TRUE
 
 /obj/item/construction/proc/loadwithsheets(obj/item/stack/sheet/S, value, mob/user)
 	var/maxsheets = round((max_matter-matter)/value)    //calculate the max number of sheets that will fit in RCD

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -146,7 +146,9 @@
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stock_parts/capacitor = 1,
-		/obj/item/stack/cable_coil = 3)
+		/obj/item/stack/cable_coil = 3,
+		/obj/item/stock_parts/cell = 1) // Skyrat edit: adds cell to recipe
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/telecomms/broadcaster

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -60,6 +60,10 @@
 		to_chat(user, "<span class='notice'>You clear all active holograms.</span>")
 
 
+/obj/item/holosign_creator/examine(mob/user) // Skyrat change
+	. = ..()
+	. += "<span class='notice'>It is currently maintaining <b>[signs.len]</b> projections.</span>"
+
 /obj/item/holosign_creator/security
 	name = "security holobarrier projector"
 	desc = "A holographic projector that creates holographic security barriers."

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -39,7 +39,7 @@
 	Radio.listening = 0
 	Radio.set_frequency(FREQ_ENGINEERING)
 
-/obj/machinery/power/tesla_coil/on_construction() // Skyrat bugfix
+/obj/machinery/power/rad_collector/on_construction() // Skyrat bugfix
 	if(anchored)
 		connect_to_network()
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -184,7 +184,7 @@
 /obj/machinery/power/rad_collector/analyzer_act(mob/living/user, obj/item/I)
 	if(loaded_tank)
 		loaded_tank.analyzer_act(user, I)
-	return TRUE // Skyrat change
+	return TRUE // Skyrat change 
 
 /obj/machinery/power/rad_collector/examine(mob/user)
 	. = ..()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -39,6 +39,10 @@
 	Radio.listening = 0
 	Radio.set_frequency(FREQ_ENGINEERING)
 
+/obj/machinery/power/tesla_coil/on_construction() // Skyrat bugfix
+	if(anchored)
+		connect_to_network()
+
 /obj/machinery/power/rad_collector/Destroy()
 	QDEL_NULL(Radio)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A couple QoL changes that crossed my mind while playing engineering roles recently.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Yay QoL and bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:  Forcing open an airlock with Jaws of Life damages the airlock somewhat.
tweak: Holosign creators (ATMOS fans, security barriers etc) show the amount of current active projections on examine.
tweak: The Space Heater machinery now has the power cell included in its recipe, instead of adding it after construction.
tweak: You can now click sheets and upgrades with the RCD, instead of exclusively the other way around.
fix: Radiation collectors now check for powergrid upon construction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
