### PR TITLE
Obfuscates the contractor tablet

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -22,7 +22,7 @@
 		icon_state = icon_state_powered = icon_state_unpowered = "tablet-[finish_color]"
 
 /obj/item/modular_computer/tablet/syndicate_contract_uplink
-	name = "contractor tablet"
+	name = "tablet computer" // Skyrat Edit - antimeta
 	icon = 'icons/obj/contractor_tablet.dmi'
 	icon_state = "tablet"
 	icon_state_unpowered = "tablet"


### PR DESCRIPTION
## About The Pull Request

Changes the name of the contractor tablet so that it's not distinguishable on-sight from a normal tablet computer. 

## Why It's Good For The Game

It was decided that people should not be using the tablet to identify contractors, so removing this needless information from the item seems like the best way to prevent issues in the future.

## Changelog
:cl:
tweak: Contractor tablets are less identifiable and more stealthy.
/:cl:
