### PR TITLE
Temporarily adjusts bombs on syndicate uplinks

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_explosives.dm
+++ b/code/modules/uplink/uplink_items/uplink_explosives.dm
@@ -114,7 +114,6 @@
 	cost = 6
 	surplus = 8
 
-/* Temporary removal for balancing. - SK13
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
@@ -124,7 +123,6 @@
 			be defused, and some crew may attempt to do so."
 	item = /obj/item/sbeacondrop/bomb
 	cost = 11
-*/
 
 /datum/uplink_item/explosives/syndicate_detonator
 	name = "Syndicate Detonator"

--- a/code/modules/uplink/uplink_items/uplink_explosives.dm
+++ b/code/modules/uplink/uplink_items/uplink_explosives.dm
@@ -114,6 +114,7 @@
 	cost = 6
 	surplus = 8
 
+/* Temporary removal for balancing. - SK13
 /datum/uplink_item/explosives/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
@@ -123,6 +124,7 @@
 			be defused, and some crew may attempt to do so."
 	item = /obj/item/sbeacondrop/bomb
 	cost = 11
+*/
 
 /datum/uplink_item/explosives/syndicate_detonator
 	name = "Syndicate Detonator"

--- a/modular_skyrat/code/modules/uplink/uplink_explosives.dm
+++ b/modular_skyrat/code/modules/uplink/uplink_explosives.dm
@@ -1,5 +1,5 @@
 /datum/uplink_item/explosives/syndicate_bomb
-	cost = 8
+	cost = 11
 
 /* Temporary removal for balancing. - SK13
 /datum/uplink_item/explosives/syndicate_bomb_he

--- a/modular_skyrat/code/modules/uplink/uplink_explosives.dm
+++ b/modular_skyrat/code/modules/uplink/uplink_explosives.dm
@@ -1,6 +1,7 @@
 /datum/uplink_item/explosives/syndicate_bomb
 	cost = 8
 
+/* Temporary removal for balancing. - SK13
 /datum/uplink_item/explosives/syndicate_bomb_he
 	name = "Syndicate Bomb (HE)"
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
@@ -10,3 +11,4 @@
 			be defused, and some crew may attempt to do so. This one is extra highly explosive"
 	item = /obj/item/sbeacondrop/bomb_high_explosive
 	cost = 15
+*/


### PR DESCRIPTION
## About The Pull Request

Temporarily removes the syndicate HE bomb from the syndicate uplink. This will be temporary until a proper solution can be found.

## Why It's Good For The Game

Temporary removal to gauge what to do with them in future.

## Changelog
:cl:
balance: Temporarily removes syndicate HE bomb from the uplink.
balance: Increases the standard syndicate bomb to 11 TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
