### PR TITLE
Ventclog Chem Remix

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -24,8 +24,6 @@
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/lube,
 		/datum/reagent/glitter/pink,
-		/datum/reagent/drug/methamphetamine,
-		/datum/reagent/toxin/zombiepowder,
 		/datum/reagent/toxin/pancuronium,
 		/datum/reagent/medicine/omnizine,
 		/datum/reagent/medicine/epinephrine,

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -6,7 +6,7 @@
 	gamemode_blacklist = list("dynamic")
 	min_players = 25
 
-/datum/round_event/vent_clog
+/datum/round_event/vent_clog	//skyrats change begin
 	announceWhen	= 1
 	startWhen		= 5
 	endWhen			= 35
@@ -24,6 +24,11 @@
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/lube,
 		/datum/reagent/glitter/pink,
+		/datum/reagent/drug/methamphetamine,
+		/datum/reagent/toxin/zombiepowder,
+		/datum/reagent/toxin/pancuronium,
+		/datum/reagent/medicine/omnizine,
+		/datum/reagent/medicine/epinephrine,
 		/datum/reagent/cryptobiolin,
 		/datum/reagent/toxin/plantbgone,
 		/datum/reagent/blood,
@@ -35,30 +40,28 @@
 		/datum/reagent/consumable/hot_coco,
 		/datum/reagent/toxin/acid,
 		/datum/reagent/toxin/mindbreaker,
-		/datum/reagent/toxin/rotatium,
 		/datum/reagent/bluespace,
 		/datum/reagent/pax,
 		/datum/reagent/consumable/laughter,
-		/datum/reagent/concentrated_barbers_aid,
-		/datum/reagent/baldium,
 		/datum/reagent/colorful_reagent,
 		/datum/reagent/peaceborg_confuse,
 		/datum/reagent/peaceborg_tire,
 		/datum/reagent/consumable/sodiumchloride,
 		/datum/reagent/consumable/ethanol/beer,
-		/datum/reagent/hair_dye,
 		/datum/reagent/consumable/sugar,
 		/datum/reagent/glitter/white,
-		/datum/reagent/growthserum,
+		/datum/reagent/consumable/ethanol/vodka,
 		/datum/reagent/consumable/cornoil,
 		/datum/reagent/uranium,
 		/datum/reagent/carpet,
+		/datum/reagent/consumable/orangejuice,
 		/datum/reagent/firefighting_foam,
 		/datum/reagent/consumable/tearjuice,
 		/datum/reagent/medicine/strange_reagent
 
 	)
-	//needs to be chemid unit checked at some point
+	//needs to be chemid unit checked at some point	
+	//skyrats change end
 
 /datum/round_event/vent_clog/announce()
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")


### PR DESCRIPTION
## About The Pull Request

Changes a couple chems in the vent clog event.

## Why It's Good For The Game

No griff chems in vent clog. Quantum Hairdye is not fixable with mirrors. It needs genetics for fixing and that in turn needs somebody to know hexadecimal (unlikely) or how to use google for a converter (unlikely). Baldium is removed for the same reason. Barbers Acid aswell. Rotatium while fun on paper got removed because it tends to bug out when in gas form keeping the screen spinning indefinitly. 

Added: Vodka, some paralytic toxins namely pancuronium and zombie powder (idea behind it it should give medical something to do and puzzle people every now and then), among some other not so nice stuff like meth (its nerfed here so you will most likely get addicted to it, addiction is not permanent btw) and omnizine (OD is really bad and being in smoke tends to result in quick OD) and the stuff in epipens which I always forget how to properly write which also has a pretty nasty OD effect.

## Changelog
:cl:
tweak: Changes the ventclog events chems. Rotatium out cause it never fixes itself. Everything that dyes out because no fix apart from genetics and outside of that its legit used simply as a griff tool. Baldium out aswell, same reason, barber acid out aswell, same reason. What went in? Couple toxins, couple meds, vodka and most importantly orange juice.
/:cl:

