### PR TITLE
Changes Chem Medipen Icon

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -198,6 +198,7 @@
 /obj/item/reagent_containers/hypospray/medipen/empty
 	name = "medipen"
 	desc = "An empty medipen."
+	icon_state = "lepopen"
 	volume = 10
 	list_reagents = null
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
## About The Pull Request

Gives chemistry-made medipens their own icon so it's obvious they're not a common medipen.

I'd honestly prefer https://github.com/Skyrat-SS13/Skyrat13/pull/2938 get merged instead, but if it gets denied, this is here.

## Why It's Good For The Game

I would really like to know I'm jabbing someone with a normal medipen and not someones instant killmix / healmix / knockout needle.

![image](https://user-images.githubusercontent.com/7543955/87500018-88d76e00-c629-11ea-9f45-91e0fe91d0b2.png)

## Changelog
:cl:
tweak: Chemistry-made medipens are now red.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
