### PR TITLE
Gate Research's Passive Point Generation

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -28,9 +28,9 @@ SUBSYSTEM_DEF(research)
 
 	//SKYRAT CHANGE
 	//PROBLEM COMPUTER CHARGES
-	var/problem_computer_max_charges = 5
-	var/problem_computer_charges = 5
-	var/problem_computer_charge_time = 90 SECONDS
+	var/problem_computer_max_charges = 10
+	var/problem_computer_charges = 10
+	var/problem_computer_charge_time = 20 SECONDS
 	var/problem_computer_next_charge_time = 0
 
 	var/list/techweb_point_items = list(		//path = list(point type = value)
@@ -295,9 +295,8 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/point_generation = FALSE //skyrat edit - removing passive points
 	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 35)	//citadel edit - techwebs nerf
-	var/multiserver_calculation = FALSE
+	//var/multiserver_calculation = FALSE gating this stuff behind population
 	var/last_income
 	//^^^^^^^^ ALL OF THESE ARE PER SECOND! ^^^^^^^^
 
@@ -328,9 +327,10 @@ SUBSYSTEM_DEF(research)
 	return ..()
 
 /datum/controller/subsystem/research/fire()
-	if(point_generation) //skyrat edit - removing passive points
+	var/totalplayers = GLOB.player_list.len
+	if(totalplayers <= 30) //skyrat edit - removing passive points
 		var/list/bitcoins = list()
-		if(multiserver_calculation)
+		if(totalplayers <= 10)
 			var/eff = calculate_server_coefficient()
 			for(var/obj/machinery/rnd/server/miner in servers)
 				var/list/result = (miner.mine())	//SLAVE AWAY, SLAVE.

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -295,6 +295,7 @@ SUBSYSTEM_DEF(research)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
+	var/point_generation = FALSE //skyrat edit - removing passive points
 	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 35)	//citadel edit - techwebs nerf
 	var/multiserver_calculation = FALSE
 	var/last_income
@@ -327,26 +328,27 @@ SUBSYSTEM_DEF(research)
 	return ..()
 
 /datum/controller/subsystem/research/fire()
-	var/list/bitcoins = list()
-	if(multiserver_calculation)
-		var/eff = calculate_server_coefficient()
-		for(var/obj/machinery/rnd/server/miner in servers)
-			var/list/result = (miner.mine())	//SLAVE AWAY, SLAVE.
-			for(var/i in result)
-				result[i] *= eff
-				bitcoins[i] = bitcoins[i]? bitcoins[i] + result[i] : result[i]
-	else
-		for(var/obj/machinery/rnd/server/miner in servers)
-			if(miner.working)
-				bitcoins = single_server_income.Copy()
-				break			//Just need one to work.
-	if (!isnull(last_income))
-		var/income_time_difference = world.time - last_income
-		science_tech.last_bitcoins = bitcoins  // Doesn't take tick drift into account
-		for(var/i in bitcoins)
-			bitcoins[i] *= income_time_difference / 10
-		science_tech.add_point_list(bitcoins)
-	last_income = world.time
+	if(point_generation) //skyrat edit - removing passive points
+		var/list/bitcoins = list()
+		if(multiserver_calculation)
+			var/eff = calculate_server_coefficient()
+			for(var/obj/machinery/rnd/server/miner in servers)
+				var/list/result = (miner.mine())	//SLAVE AWAY, SLAVE.
+				for(var/i in result)
+					result[i] *= eff
+					bitcoins[i] = bitcoins[i]? bitcoins[i] + result[i] : result[i]
+		else
+			for(var/obj/machinery/rnd/server/miner in servers)
+				if(miner.working)
+					bitcoins = single_server_income.Copy()
+					break			//Just need one to work.
+		if (!isnull(last_income))
+			var/income_time_difference = world.time - last_income
+			science_tech.last_bitcoins = bitcoins  // Doesn't take tick drift into account
+			for(var/i in bitcoins)
+				bitcoins[i] *= income_time_difference / 10
+			science_tech.add_point_list(bitcoins)
+		last_income = world.time
 	// Skyrat change. Handles Problem Computer charges here
 	if(problem_computer_charges < problem_computer_max_charges && world.time >= problem_computer_next_charge_time)
 		problem_computer_next_charge_time = world.time + problem_computer_charge_time

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -1,8 +1,8 @@
 // stored_power += (pulse_strength-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
-#define RAD_COLLECTOR_EFFICIENCY 80 	// radiation needs to be over this amount to get power
+#define RAD_COLLECTOR_EFFICIENCY 40 	// radiation needs to be over this amount to get power skyrat edit
 #define RAD_COLLECTOR_COEFFICIENT 100
 #define RAD_COLLECTOR_STORED_OUT 0.04	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
-#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.00001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
+#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process() skyrat edit
 #define RAD_COLLECTOR_OUTPUT min(stored_power, (stored_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
 
 /obj/machinery/power/rad_collector
@@ -25,7 +25,7 @@
 	var/drainratio = 1
 	var/powerproduction_drain = 0.001
 
-	var/bitcoinproduction_drain = 0.15
+	var/bitcoinproduction_drain = 0.001
 	var/bitcoinmining = FALSE
 	rad_insulation = RAD_EXTREME_INSULATION
 	var/obj/item/radio/Radio
@@ -68,6 +68,8 @@
 			eject()
 		else
 			var/gasdrained = bitcoinproduction_drain*drainratio
+			//skyrat edit - makes plasma also work in research
+			loaded_tank.air_contents.gases[/datum/gas/plasma] -= gasdrained
 			loaded_tank.air_contents.gases[/datum/gas/tritium] -= gasdrained
 			loaded_tank.air_contents.gases[/datum/gas/oxygen] -= gasdrained
 			loaded_tank.air_contents.gases[/datum/gas/carbon_dioxide] += gasdrained*2

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -2,7 +2,7 @@
 #define RAD_COLLECTOR_EFFICIENCY 40 	// radiation needs to be over this amount to get power skyrat edit
 #define RAD_COLLECTOR_COEFFICIENT 100
 #define RAD_COLLECTOR_STORED_OUT 0.04	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
-#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process() skyrat edit
+#define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.0001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process() skyrat edit
 #define RAD_COLLECTOR_OUTPUT min(stored_power, (stored_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
 
 /obj/machinery/power/rad_collector
@@ -25,7 +25,7 @@
 	var/drainratio = 1
 	var/powerproduction_drain = 0.001
 
-	var/bitcoinproduction_drain = 0.001
+	var/bitcoinproduction_drain = 0.01
 	var/bitcoinmining = FALSE
 	rad_insulation = RAD_EXTREME_INSULATION
 	var/obj/item/radio/Radio

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -25,7 +25,7 @@
 	var/drainratio = 1
 	var/powerproduction_drain = 0.001
 
-	var/bitcoinproduction_drain = 0.01
+	var/bitcoinproduction_drain = 0.05
 	var/bitcoinmining = FALSE
 	rad_insulation = RAD_EXTREME_INSULATION
 	var/obj/item/radio/Radio

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -24,7 +24,7 @@
 	var/locked = FALSE
 	var/drainratio = 1
 	var/powerproduction_drain = 0.001
-
+	//skyrat edit - making it scarier
 	var/bitcoinproduction_drain = 0.05
 	var/bitcoinmining = FALSE
 	rad_insulation = RAD_EXTREME_INSULATION

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -85,7 +85,7 @@
 		if(D)
 			D.adjust_money(min(power_produced, 1))
 		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 1)) // x4 coils = ~240/m point bonus for R&D
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, power_produced) // x4 coils = ~240/m point bonus for R&D skyrat edit - buff coils
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 		zap_buckle_check(power)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -85,7 +85,7 @@
 		if(D)
 			D.adjust_money(min(power_produced, 1))
 		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 10)) // x4 coils = ~240/m point bonus for R&D skyrat edit - buff coils
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 1)) // x4 coils = ~240/m point bonus for R&D
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 		zap_buckle_check(power)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)
@@ -123,7 +123,7 @@
 		if(D)
 			D.adjust_money(min(power_produced, 3))
 		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 3)) // x4 coils with a pulse per second or so = ~720/m point bonus for R&D
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 10)) //skyrat edit 4 coils = 2400/m point RND
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 		zap_buckle_check(power)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -85,7 +85,7 @@
 		if(D)
 			D.adjust_money(min(power_produced, 1))
 		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, power_produced) // x4 coils = ~240/m point bonus for R&D skyrat edit - buff coils
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min(power_produced, 10)) // x4 coils = ~240/m point bonus for R&D skyrat edit - buff coils
 		addtimer(CALLBACK(src, .proc/reset_shocked), 10)
 		zap_buckle_check(power)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gates research's p.p.g. behind population numbers.
buffs coils and collectors and problem computers
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
passive point generation was a mistake.
Science is already a department that has no troubles/danger.
Plenty of ways to get points exist:
1) xenoarch
2) surgery
3) xenobio
4) problem computers
and a bit more. It wouldnt be hard to add more ways of getting points either.

the goal is to eventually split stored research too, so that golems or whoever dont share research.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed passive point generation for science
tweak: tweaked collectors, coils, and problem computers to generate more points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
