### PR TITLE
Fixes an oversight with medipen dispensing

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -388,6 +388,10 @@
 				return TRUE
 			// SKYRAT EDIT: Medipens/injectors
 			if(item_type == "injector")
+				for(var/datum/reagent/M in reagents.reagent_list)
+					if(!istype(M, /datum/reagent/medicine))
+						to_chat(usr, "<span class = 'warning'>Non-medicinal reagent detected. Halting operation.</span>")
+						return FALSE
 				var/obj/item/reagent_containers/hypospray/medipen/empty/P
 				for(var/i = 0; i < amount; i++)
 					P = new /obj/item/reagent_containers/hypospray/medipen/empty(drop_location())

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -198,6 +198,7 @@
 /obj/item/reagent_containers/hypospray/medipen/empty
 	name = "medipen"
 	desc = "An empty medipen."
+	icon_state = "lepopen"
 	volume = 10
 	list_reagents = null
 	amount_per_transfer_from_this = 10


### PR DESCRIPTION
## About The Pull Request

The chem dispenser now correctly checks to ensure that the reagents being put into the pens are actually medicine. I'm assuming this was an oversight because having the medipens be instant-inject toxin vectors obviously runs counter to the game's design.

UPDATE: incorporates https://github.com/Skyrat-SS13/Skyrat13/pull/2931

## Why It's Good For The Game

Free sleepypens from the ChemMaster was a silly thing.

## Changelog
:cl:
tweak: The ChemMaster will now only allow medicinal reagents to be dispensed into medipens.
tweak: Medipens printed at the ChemMaster now have a unique icon.
/:cl: