### PR TITLE
Removes hypnotic stupor quirk

### DIFF
--- a/modular_skyrat/code/datums/traits/neutral.dm
+++ b/modular_skyrat/code/datums/traits/neutral.dm
@@ -98,20 +98,6 @@
 	if(H)
 		H.disable_speech_mod(/datum/speech_mod/impediment_rw_lw)
 
-/datum/quirk/hypnotic_stupor
-	name = "Hypnotic Stupor"
-	desc = "Your prone to episodes of extreme stupor that leaves you extremely suggestible."
-	value = 0
-	human_only = TRUE
-	gain_text = null // Handled by trauma.
-	lose_text = null
-	medical_record_text = "Patient has an untreatable condition with their brain, wiring them to be extreamly suggestible..."
-
-/datum/quirk/hypnotic_stupor/add()
-	var/datum/brain_trauma/severe/hypnotic_stupor/T = new()
-	var/mob/living/carbon/human/H = quirk_holder
-	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
-
 //uncontrollable laughter
 /datum/quirk/joker
 	name = "Pseudobulbar Affect"


### PR DESCRIPTION
## About The Pull Request
Deletes the hypnotic stupor quirk from the game.

## Why It's Good For The Game

Its poorly implemented in its current state. You really aren't able to roleplay with it, and while there are maybe plans to rework at it at some point, its honestly just the kind of thing that should maybe be RPed out instead, and really doesn't need this type of stuff. It also personally triggers my autism to the point where I figured out how github worked just to do this. It just spams you with random phrases that you over hear, before switching to the next one in a couple moments. There is a reason it was just supposed to be some funny brain damage that you get cured. I also suspect it might break some stuff, but can't be asked to test it. I know this isn't a real issue, but it annoys me personally. Watch me learn coding just to try and make a better one at some point maybe don't count on it.