### PR TITLE
Makes the meteor shuttle emag-only

### DIFF
--- a/modular_skyrat/code/datums/shuttles.dm
+++ b/modular_skyrat/code/datums/shuttles.dm
@@ -1,0 +1,7 @@
+/datum/map_template/shuttle/emergency/meteor
+	description = "(Emag only) A hollowed out asteroid with engines strapped to it. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
+
+/datum/map_template/shuttle/emergency/meteor/prerequisites_met()
+	if("emagged" in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -379,6 +379,7 @@
 #include "code\datums\recipe.dm"
 #include "code\datums\ruins.dm"
 #include "code\datums\saymode.dm"
+#include "modular_skyrat\code\datums\shuttles.dm"
 #include "code\datums\shuttles.dm"
 #include "code\datums\soullink.dm"
 #include "code\datums\spawners_menu.dm"


### PR DESCRIPTION
## About The Pull Request

Non-antagonists don't have any particularly good reason to order this shuttle, and this seems as good a solution as any to make it "antag-only". 

## Why It's Good For The Game

The game shouldn't give people the option to do things that will just get them yelled at by staff, as much as is possible.

## Changelog
:cl:
tweak: The meteor shuttle is now emag-only.
/:cl: