### PR TITLE
[FULLMERGE PLEASE I BEG YOU] Come to <BR>azil

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -364,7 +364,7 @@
 	
 	//descriptors
 	var/list/show_descs = show_descriptors_to(user)
-	msg += length(show_descs) ? "<br>[show_descs.Join("<br>")]<br>" : "<br>"
+	msg += length(show_descs) ? "[show_descs.Join("\n")]\n" : "<br>"
 	
 	//Skyrat changes end
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -364,7 +364,7 @@
 	
 	//descriptors
 	var/list/show_descs = show_descriptors_to(user)
-	msg += length(show_descs) ? "[show_descs.Join("\n")]\n" : "<br>"
+	msg += length(show_descs) ? "[show_descs.Join("\n")]\n" : ""
 	
 	//Skyrat changes end
 

--- a/modular_skyrat/code/datums/descriptors/_descriptor.dm
+++ b/modular_skyrat/code/datums/descriptors/_descriptor.dm
@@ -44,7 +44,7 @@
 	if(ishuman(me) && !skip_species_mention)
 		var/mob/living/carbon/human/H = me
 		
-		var/use_name = (H.dna.species.custom_species ? "\improper [H.dna.custom_species]" : "\improper [H.dna.species.name]")
+		var/use_name = (H.dna.custom_species ? "\improper [H.dna.custom_species]" : "\improper [H.dna.species.name]")
 		var/species_visible = TRUE
 		var/skipface = (H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || (H.head && (H.head.flags_inv & HIDEFACE))
 

--- a/modular_skyrat/code/datums/descriptors/_descriptor.dm
+++ b/modular_skyrat/code/datums/descriptors/_descriptor.dm
@@ -43,13 +43,13 @@
 	var/species_text
 	if(ishuman(me) && !skip_species_mention)
 		var/mob/living/carbon/human/H = me
-		var/use_name = (H.dna.species.custom_species ? "\improper [H.dna.species.custom_species]" : "\improper [H.dna.species.name]")
+		
+		var/use_name = (H.dna.species.custom_species ? "\improper [H.dna.custom_species]" : "\improper [H.dna.species.name]")
+		var/species_visible = TRUE
 		var/skipface = (H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || (H.head && (H.head.flags_inv & HIDEFACE))
 
-		if(skipface || get_visible_name() == "Unknown")
+		if(skipface || H.get_visible_name() == "Unknown")
 			species_visible = FALSE
-		else
-			species_visible = TRUE
 
 		if(!species_visible)
 			species_text = ""

--- a/modular_skyrat/code/datums/descriptors/_descriptor.dm
+++ b/modular_skyrat/code/datums/descriptors/_descriptor.dm
@@ -43,8 +43,19 @@
 	var/species_text
 	if(ishuman(me) && !skip_species_mention)
 		var/mob/living/carbon/human/H = me
-		var/use_name = "\improper [H.dna.species.name]"
-		species_text = " for \a [use_name]"
+		var/use_name = (H.dna.species.custom_species ? "\improper [H.dna.species.custom_species]" : "\improper [H.dna.species.name]")
+		var/skipface = (H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || (H.head && (H.head.flags_inv & HIDEFACE))
+
+		if(skipface || get_visible_name() == "Unknown")
+			species_visible = FALSE
+		else
+			species_visible = TRUE
+
+		if(!species_visible)
+			species_text = ""
+		else
+			species_text = " for \a [use_name]"
+
 	. = "[get_third_person_message_start(me)] [get_standalone_value_descriptor(my_value)][species_text]"
 
 /datum/mob_descriptor/proc/get_secondary_comparison_component(mob/me, mob/other_mob, my_value, comparing_value)


### PR DESCRIPTION
## About The Pull Request

removes newlines because of descriptors because people are examine aficionados and examine everything and yet complain when examine is verbose

examining descriptors will no longer oust your species if your face is hidden, and it will take custom species into account

## Why It's Good For The Game

brazil is bad and brazil is gone

## Changelog
:cl:
fix: Descriptors no longer oust your species without checking certain identification conditions first.
spellcheck: Examine no longer is full of newlines for descriptors.
/:cl:
