### PR TITLE
Examining sends a chat message

### DIFF
--- a/code/__DEFINES/dcs/modular_skyrat/signals.dm
+++ b/code/__DEFINES/dcs/modular_skyrat/signals.dm
@@ -1,0 +1,2 @@
+//SKYRAT signals
+#define COMSIG_MOB_EXAMINED "mob_examined" //Called when an atom get examined to do stuff like visible messages when something gets examined

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -372,6 +372,7 @@
 				. += "<span class='danger'>It's empty.</span>"
 
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
+	SEND_SIGNAL(src, COMSIG_MOB_EXAMINED, user, src)
 
 /**
   * Called when a mob examines (shift click or verb) this atom twice (or more) within EXAMINE_MORE_TIME (default 1.5 seconds)

--- a/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
@@ -14,4 +14,4 @@
 	
 	if(!((wear_mask && wear_mask.flags_inv & HIDEFACE) || (head && head.flags_inv & HIDEFACE) || (glasses && glasses.flags_inv & HIDEFACE)))
 	
-	visible_message("<span class='notice'>\The [src] examines [examined].</span>")
+	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 3)

--- a/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
@@ -4,3 +4,14 @@
 		var/dir = get_dir(get_turf(gunpointing.source),get_turf(gunpointing.target))
 		if(dir)
 			setDir(dir)
+
+/mob/living/carbon/on_examine_atom(atom/examined)
+	if(!istype(examined) || !client)
+		return
+
+	if(get_dist(src, examined) > EYE_CONTACT_RANGE)
+		return
+	
+	if(!((wear_mask && wear_mask.flags_inv & HIDEFACE) || (head && head.flags_inv & HIDEFACE) || (glasses && glasses.flags_inv & HIDEFACE)))
+	
+	visible_message("<span class='notice'>\The [src] examines [examined].</span>")

--- a/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
@@ -15,4 +15,4 @@
 	if(!((wear_mask && wear_mask.flags_inv & (wear_mask.flags_inv & HIDEFACE || wear_mask.flags_inv & HIDEEYES)) || (head && (head.flags_inv & HIDEFACE || head.flags_inv & HIDEEYES)) || (glasses && (glasses.flags_inv & HIDEFACE || glasses.flags_inv & HIDEEYES))))
 		return
 	
-	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 3)
+	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 2)

--- a/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
@@ -13,5 +13,6 @@
 		return
 	
 	if(!((wear_mask && wear_mask.flags_inv & (wear_mask.flags_inv & HIDEFACE || wear_mask.flags_inv & HIDEEYES)) || (head && (head.flags_inv & HIDEFACE || head.flags_inv & HIDEEYES)) || (glasses && (glasses.flags_inv & HIDEFACE || glasses.flags_inv & HIDEEYES))))
+		return
 	
 	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 3)

--- a/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/carbon.dm
@@ -12,6 +12,6 @@
 	if(get_dist(src, examined) > EYE_CONTACT_RANGE)
 		return
 	
-	if(!((wear_mask && wear_mask.flags_inv & HIDEFACE) || (head && head.flags_inv & HIDEFACE) || (glasses && glasses.flags_inv & HIDEFACE)))
+	if(!((wear_mask && wear_mask.flags_inv & (wear_mask.flags_inv & HIDEFACE || wear_mask.flags_inv & HIDEEYES)) || (head && (head.flags_inv & HIDEFACE || head.flags_inv & HIDEEYES)) || (glasses && (glasses.flags_inv & HIDEFACE || glasses.flags_inv & HIDEEYES))))
 	
 	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 3)

--- a/modular_skyrat/code/modules/mob/living/living.dm
+++ b/modular_skyrat/code/modules/mob/living/living.dm
@@ -5,7 +5,7 @@
 
 /mob/living/Initialize()
 	. = ..()
-	RegisterSignal(src, COMSIG_MOB_EXAMINED, .on_examine_atom)
+	RegisterSignal(src, COMSIG_MOB_EXAMINED, .proc/on_examine_atom)
 
 /mob/living/Destroy()
 	. = ..()

--- a/modular_skyrat/code/modules/mob/living/living.dm
+++ b/modular_skyrat/code/modules/mob/living/living.dm
@@ -2,3 +2,20 @@
 	var/datum/gunpoint/gunpointing
 	var/list/gunpointed = list()
 	var/obj/effect/overlay/gunpoint_effect/gp_effect
+
+/mob/living/Initialize()
+	. = ..()
+	RegisterSignal(src, COMSIG_MOB_EXAMINED, .on_examine_atom)
+
+/mob/living/Destroy()
+	. = ..()
+	UnregisterSignal(src, COMSIG_MOB_EXAMINED)
+
+/mob/living/proc/on_examine_atom(atom/examined)
+	if(!istype(examined) || !client)
+		return
+
+	if(get_dist(src, examined) > EYE_CONTACT_RANGE)
+		return
+	
+	visible_message("<span class='notice'>\The [src] examines [examined].</span>")

--- a/modular_skyrat/code/modules/mob/living/living.dm
+++ b/modular_skyrat/code/modules/mob/living/living.dm
@@ -18,4 +18,4 @@
 	if(get_dist(src, examined) > EYE_CONTACT_RANGE)
 		return
 	
-	visible_message("<span class='notice'>\The [src] examines [examined].</span>")
+	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 3)

--- a/modular_skyrat/code/modules/mob/living/living.dm
+++ b/modular_skyrat/code/modules/mob/living/living.dm
@@ -18,4 +18,4 @@
 	if(get_dist(src, examined) > EYE_CONTACT_RANGE)
 		return
 	
-	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 3)
+	visible_message(message = "<span class='notice'>\The [src] examines [examined].</span>", vision_distance = 2)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -130,6 +130,7 @@
 #include "code\__DEFINES\dcs\flags.dm"
 #include "code\__DEFINES\dcs\helpers.dm"
 #include "code\__DEFINES\dcs\signals.dm"
+#include "code\__DEFINES\dcs\modular_skyrat\signals.dm"
 #include "code\__DEFINES\flags\do_after.dm"
 #include "code\__DEFINES\flags\shields.dm"
 #include "code\__DEFINES\mapping\maploader.dm"


### PR DESCRIPTION
## About The Pull Request

Title.
When you examine something without your eyes being covered, everyone in a 3 tile radius will see a "[name] examines [x]" message.

**Things that prevent you from being seen as a creep when examining people:**
Balaclavas
Gas mask
Sunglasses
Hardsuit helmet
Virtually anything that hides your face or eyes

## Why It's Good For The Game

nice

## Changelog
:cl:
add: Examining stuff now shows a message in the chat for nearby mobs.
/:cl: