### PR TITLE
Preservahyde is now a medicine

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -396,7 +396,7 @@
 			if(O)
 				O.on_life()
 	else
-		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/preservahyde, 1)) // No organ decay if the body contains formaldehyde. Or preservahyde.
+		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/medicine/preservahyde, 1)) // No  organ decay if the body contains formaldehyde. Orpreservahyde. Skyrat Edit - repaths perservahyde
 			return
 		for(var/V in internal_organs)
 			var/obj/item/organ/O = V

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2200,12 +2200,12 @@
 
 	..()
 
-/datum/reagent/preservahyde
+/* /datum/reagent/preservahyde // Skyrat Edit - Relocated to modular_skyrat's medicine_reagents.dm
 	name = "Preservahyde"
 	description = "A powerful preservation agent, utilizing the preservative effects of formaldehyde with significantly less of the histamine."
 	reagent_state = LIQUID
 	color = "#f7685e"
-	metabolization_rate = REAGENTS_METABOLISM * 0.25
+	metabolization_rate = REAGENTS_METABOLISM * 0.25 */ 
 
 
 //body bluids

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -47,11 +47,11 @@
 	results = list(/datum/reagent/consumable/sodiumchloride = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/sodium = 1, /datum/reagent/chlorine = 1)
 
-/datum/chemical_reaction/preservahyde
+/* /datum/chemical_reaction/preservahyde // Skyrat Edit - Relocated to modular_skyrat's recipes/medicine.dm
 	name = "Preservahyde"
 	id = "preservahyde"
 	results = list(/datum/reagent/preservahyde = 3)
-	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/bromine = 1)
+	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/bromine = 1) */
 
 /datum/chemical_reaction/plasmasolidification
 	name = "Solid Plasma"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -95,7 +95,7 @@
 	ignore_flags = 1 //so you can medipen through hardsuits
 	reagent_flags = DRAWABLE
 	flags_1 = null
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/preservahyde = 3)
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/preservahyde = 3) // Skyrat Edit - repaths preservahyde
 	custom_premium_price = PRICE_ALMOST_EXPENSIVE
 
 /obj/item/reagent_containers/hypospray/medipen/suicide_act(mob/living/carbon/user)

--- a/modular_skyrat/code/modules/mob/living/carbon/life.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/life.dm
@@ -4,7 +4,7 @@
 		return
 
 	// No decay if formaldehyde/preservahyde in corpse or when the corpse is charred
-	if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || HAS_TRAIT(src, TRAIT_HUSK) || reagents.has_reagent(/datum/reagent/preservahyde, 1))
+	if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || HAS_TRAIT(src, TRAIT_HUSK) || reagents.has_reagent(/datum/reagent/medicine/preservahyde, 1))
 		return
 
 	// Also no decay if corpse chilled or not organic/undead

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -182,3 +182,10 @@
 	C.heal_bodypart_damage(0.5*REM, 0.5*REM, stamina = 0, updating_health = TRUE, only_robotic = TRUE, only_organic = FALSE)
 	..()
 	. = 1
+
+/datum/reagent/medicine/preservahyde
+	name = "Preservahyde"
+	description = "A powerful preservation agent, utilizing the preservative effects of formaldehyde with significantly less of the histamine."
+	reagent_state = LIQUID
+	color = "#f7685e"
+	metabolization_rate = REAGENTS_METABOLISM * 0.25

--- a/modular_skyrat/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -18,3 +18,9 @@
 	results = list(/datum/reagent/medicine/nanite_slurry = 3)
 	required_reagents = list(/datum/reagent/foaming_agent = 1, /datum/reagent/gold = 1, /datum/reagent/iron = 1)
 	mix_message = "The mixture becomes a metallic slurry."
+
+/datum/chemical_reaction/preservahyde
+	name = "Preservahyde"
+	id = "preservahyde"
+	results = list(/datum/reagent/medicine/preservahyde = 3)
+	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/bromine = 1)


### PR DESCRIPTION
## About The Pull Request

Preservahyde is now a medicine, and legal for use in medipens.

## Why It's Good For The Game

This was an oversight, preservahyde should always have been a medicine reagent.

## Changelog
:cl:
tweak: Preservahyde is now classified as medicine.
/:cl: