### PR TITLE
Hopefully fixes terrospiders :t conflict with traitors :t

### DIFF
--- a/modular_skyrat/code/modules/language/terrorspider.dm
+++ b/modular_skyrat/code/modules/language/terrorspider.dm
@@ -5,7 +5,7 @@
 	ask_verb = "chitters"
 	exclaim_verb = "chitters"
 	sing_verb = "chitters"
-	key = "ts"
+	key = "w"
 
 /datum/language_holder/terror_spider
 	understood_languages = list(/datum/language/terrorspider = list(LANGUAGE_ATOM))


### PR DESCRIPTION
Changing the key from "ts" which is not a thing on TG code apparently to :w for "wooo"

Fixes #2926 

## About The Pull Request

Changes the language/hivemind key for tspiders from "ts" which results in :t to :w for "Wooo".

## Why It's Good For The Game

Conflict bad. Wooo good.

## What alternatives were considered.
Making it :y for your *** is sealed. But I had a different thing for far later down the line in mind for :y being used. 

## Changelog
:cl:
tweak: Tspiders hivemind/language key is now w for "wooo"
/:cl:



M̷̨͓̫̝̜̱̜̹̲̰͇̻͉͉̟̎̌̂̆͋y̷̬̟̖͖̣̦̮̦̯̥̋ ̸̢̛̻̣͓̰̪̙̭̎̉͋̀͗͌̏̑̔́͘̚͜͝l̵̛̙̫̗͓̯̹͇͊̍̿̾͌̽̈́͊̅͠į̴͍̞͇̪͇̙͇̂̃̏̆̆̈́͝ͅͅf̸̢͓̝̭͖͕̺̺̝̝̠͐̎ě̵̞͊̈́̓̓͗͌͗́̐̏̉̈́͝͝ ̵̰̩̦̣̳̙͎̗͎͚̰͖͕̭̅̎̊̀͒̀̎f̷̛̳͇̜̹̩͍̰̖̣̍̇̍̾͛̉̐̌ͅͅơ̵̩͎͚̣̫͕͈̒͐̉̍̋̉͒͒͊͘͝ŗ̵͕̣̱̳̲̩̆̃̆ ̵̨̘̺̻̬̭̪̫̰̭̋̿̀̎͛͑͋̆̄̕̚:̵̡̡̨͓͓̗̝̺̥̞͈͈̫̮̲̓͛̌͂́̎̾̿̚͠ÿ̷̧͍̟͍͈̪̠̯̠̦́͆͛̀̓̚̚͘:̶̢̧͓̘̝̣̹͉̖̩͒̀̄͂̋̇͘͜͝û̴̡̟͚̱͇̦̬̔̀͗̉̃̓̾̅̀͌͠͝͠ŗ̴̗̦̹̝̌̾̅̿̆̀́͋̒̆ī̷̧̢̺̺͔̪̫͇̦̺̣͊͜ͅ