### PR TITLE
Medical and Goodie Cargo Additions

### DIFF
--- a/modular_skyrat/code/modules/cargo/packs/bloat.dm
+++ b/modular_skyrat/code/modules/cargo/packs/bloat.dm
@@ -1,5 +1,7 @@
-//fuck you citadel maintainers for removing all this cool shit _|_ (this is still a middle finger)
-//yeah f you citadel!
+//Reminders-
+// If you add something to this list, please group it by type and sort it alphabetically instead of just jamming it in like an animal
+// cost = 700- Minimum cost, or infinite points are possible.
+
 /datum/supply_pack/security/armory/riotshotguns
 	name = "Riot Shotgun Crate"
 	desc = "For when the greytide gets really uppity. Contains three riot shotguns, seven rubber shot and beanbag shells. Requires Armory access to open."

--- a/modular_skyrat/code/modules/cargo/packs/goodies.dm
+++ b/modular_skyrat/code/modules/cargo/packs/goodies.dm
@@ -1,0 +1,41 @@
+//Cargo can -technically- get 200 credits back for each goodie bag purchase, but because
+//they're bundled, it would be incredibly inefficient and time consuming to do so.
+
+/datum/supply_pack/goody/airsuppliesnitrogen
+	name = "Emergency Air Supplies (Nitrogen)"
+	desc = "A vox breathing mask and nitrogen tank."
+	cost = 125
+	contains = list(/obj/item/tank/internals/nitrogen/belt,
+                    /obj/item/clothing/mask/breath/vox)
+
+/datum/supply_pack/goody/airsuppliesplasma
+	name = "Emergency Air Supplies (Plasma)"
+	desc = "A breathing mask and plasmaman plasma tank."
+	cost = 125
+	contains = list(/obj/item/tank/internals/plasmaman/belt,
+                    /obj/item/clothing/mask/breath)
+
+/datum/supply_pack/goody/airsuppliesoxygen
+	name = "Emergency Air Supplies (Oxygen)"
+	desc = "A breathing mask and emergency oxygen tank."
+	cost = 75
+	contains = list(/obj/item/tank/internals/emergency_oxygen,
+                    /obj/item/clothing/mask/breath)
+
+/datum/supply_pack/goody/medipen
+	name = "Epinephrine Medipen"
+	desc = "A single-use medipen. Useful for keeping people stable, or from rotting."
+	cost = 40
+	contains = list(/obj/item/reagent_containers/hypospray/medipen)
+
+/datum/supply_pack/goody/crayons
+	name = "Box of Crayons"
+	desc = "Colorful!"
+	cost = 40
+	contains = list(/obj/item/storage/crayons)
+
+/datum/supply_pack/goody/crayons
+	name = "Handheld Mirror"
+	desc = "Contains one handheld mirror, for style changes on the go!"
+	cost = 40
+	contains = list(/obj/item/hhmirror)

--- a/modular_skyrat/code/modules/cargo/packs/medical.dm
+++ b/modular_skyrat/code/modules/cargo/packs/medical.dm
@@ -1,0 +1,36 @@
+/datum/supply_pack/medical/firstaidmixed
+	name = "Mixed Medical Kits"
+	desc = "Contains one of each medical kits for dealing with a variety of injured crewmembers."
+	cost = 2000
+	contains = list(/obj/item/storage/firstaid/toxin,
+					/obj/item/storage/firstaid/o2,
+					/obj/item/storage/firstaid/brute,
+					/obj/item/storage/firstaid/fire,
+					/obj/item/storage/firstaid/regular)
+	crate_name = "medical kit crate"
+
+/datum/supply_pack/medical/medipens
+	name = "Epinephrine Medipens"
+	desc = "Contains two boxes of epinephrine medipens. Each box contains seven pens."
+	cost = 1300
+	contains = list(/obj/item/storage/box/medipens,
+                    /obj/item/storage/box/medipens)
+	crate_name = "medipen crate"
+
+/datum/supply_pack/medical/anesthetics
+	name = "Anesthetics Crate"
+	desc = "Contains two of the following: Morphine bottles, syringes, breath masks, anesthetic tanks, miners salve patches (40u). Requires Medical Access to open."
+	access = ACCESS_MEDICAL
+	cost = 3500
+	contains = list(/obj/item/reagent_containers/glass/bottle/morphine,
+                    /obj/item/reagent_containers/glass/bottle/morphine,
+                    /obj/item/reagent_containers/syringe,
+                    /obj/item/reagent_containers/syringe,
+                    /obj/item/clothing/mask/breath,
+                    /obj/item/clothing/mask/breath,
+                    /obj/item/tank/internals/anesthetic,
+                    /obj/item/tank/internals/anesthetic,
+                    /obj/item/reagent_containers/pill/patch/salve,
+                    /obj/item/reagent_containers/pill/patch/salve)
+	crate_name = "anesthetics crate"
+	crate_type = /obj/structure/closet/crate/secure/medical

--- a/modular_skyrat/code/modules/cargo/packs/special.dm
+++ b/modular_skyrat/code/modules/cargo/packs/special.dm
@@ -33,8 +33,6 @@
 	contains = list(/obj/item/clothing/suit/space/hardsuit/security/metrocop)
 	crate_name = "HEV Hardsuit crate"
 
-
-//Fuck you citadel maintainers for merging the removal of null crates _|_ (this is a middle finger)
 /datum/supply_pack/emergency/syndicate
 	name = "NULL_ENTRY"
 	desc = "(#@&^$THIS PACKAGE CONTAINS 30TC WORTH OF SOME RANDOM SYNDICATE GEAR WE HAD LYING AROUND THE WAREHOUSE. GIVE 'EM HELL OPERATIVE@&!*() "

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3732,6 +3732,8 @@
 #include "modular_skyrat\code\modules\cargo\packs.dm"
 #include "modular_skyrat\code\modules\cargo\exports\sheets.dm"
 #include "modular_skyrat\code\modules\cargo\packs\bloat.dm"
+#include "modular_skyrat\code\modules\cargo\packs\goodies.dm"
+#include "modular_skyrat\code\modules\cargo\packs\medical.dm"
 #include "modular_skyrat\code\modules\cargo\packs\misc.dm"
 #include "modular_skyrat\code\modules\cargo\packs\special.dm"
 #include "modular_skyrat\code\modules\client\asset_cache.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds Personal Oxygen, Plasma, and Nitrogen tanks to Cargo.
Adds Mixed Medical Kit, Anesthetics, and Medipen Crates
Adds Hand Mirror and Crayons to cargo.

## Why It's Good For The Game

Because being unable to order life-sustaining equipment for crewmembers is pretty important. Also, more goodie bag stuff.

## Changelog
:cl:
add: Individual Oxygen, Plasma, and Nitrogen Tanks can be ordered at cargo.
add: Medical Kit, Anesthetic, and Medipen Crates can be ordered at cargo.
add: Individual packs of hand mirrors and crayons can be ordered at cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
