### PR TITLE
The blueshield no longer answers to the captain

### DIFF
--- a/modular_skyrat/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/blueshield.dm
@@ -1,12 +1,12 @@
 /datum/job/blueshield
 	title = "Blueshield"
 	flag = OFFICER
-	department_head = list("Captain")
+	department_head = list("CentCom")
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the Captain"
+	supervisors = "Central Command"
 	selection_color = "#ddddff"
 	minimal_player_age = 7
 	exp_requirements = 2400
@@ -50,6 +50,5 @@
 
 /datum/outfit/plasmaman/blueshield
 	name = "Blueshield Plasmaman"
-
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blueshield
 	uniform = /obj/item/clothing/under/plasmaman/blueshield


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

I never intended the blueshield to "answer to the captain" - they're a CentCom Navy Officer but they are only restricted in power because of their duty. By all accounts, they're higher rank than the captain himself - they just happen to be y'know, protecting the captain.

Anyways, they answer to CentCom now - Central Command. Yada yada.

## Changelog
:cl:
tweak: The blueshield no longer answers to the captain - he answers to CC themselves. Do not use this as an excuse to become captainshield.
/:cl: