### PR TITLE
[TESTMERGE ONLY] Buffs the absolute /fuck/ out of exports and bounties

### DIFF
--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -1,7 +1,7 @@
 /datum/bounty/item/medical/heart
 	name = "Heart"
 	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto!"
-	reward = 3000
+	reward = 5000 //Hearts should be expensive.
 	wanted_types = list(/obj/item/organ/heart)
 
 /datum/bounty/item/medical/lung

--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -1,7 +1,7 @@
 /datum/bounty/item/medical/heart
 	name = "Heart"
 	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto!"
-	reward = 5000 //Hearts should be expensive.
+	reward = 5000 //Hearts should be expensive. //Skyrat edit
 	wanted_types = list(/obj/item/organ/heart)
 
 /datum/bounty/item/medical/lung

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -33,7 +33,7 @@
 
 /datum/bounty/reagent/simple_drink
 	name = "Simple Drink"
-	reward = 1500
+	reward = 2500
 
 datum/bounty/reagent/simple_drink/New()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
@@ -89,7 +89,7 @@ datum/bounty/reagent/simple_drink/New()
 
 /datum/bounty/reagent/complex_drink
 	name = "Complex Drink"
-	reward = 4000
+	reward = 4500
 
 datum/bounty/reagent/complex_drink/New()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
@@ -121,7 +121,7 @@ datum/bounty/reagent/complex_drink/New()
 
 /datum/bounty/reagent/chemical
 	name = "Chemical"
-	reward = 2750
+	reward = 4750
 	required_volume = 30
 
 datum/bounty/reagent/chemical/New()

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -167,6 +167,6 @@ datum/bounty/reagent/chemical/New()
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "SolFed is in shortage of [name], can you send us some so that we may sell it to them? You can have a 40% cut."
+	description = "SolFed is in shortage of [name], can you send us some so that we may sell it to them? You can have a 40% cut." //Skyrat edit
 	reward += rand(0, 4) * 500
 

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -33,7 +33,7 @@
 
 /datum/bounty/reagent/simple_drink
 	name = "Simple Drink"
-	reward = 2500
+	reward = 2500 //Skyrat edit
 
 datum/bounty/reagent/simple_drink/New()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
@@ -84,12 +84,12 @@ datum/bounty/reagent/simple_drink/New()
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "CentCom is thirsty! Send a shipment of [name] to CentCom to quench the company's thirst."
+	description = "Our miners at installation 025 are demanding [name] for their hard work. Send us some, will you?" //Skyrat edit
 	reward += rand(0, 2) * 500
 
 /datum/bounty/reagent/complex_drink
 	name = "Complex Drink"
-	reward = 4500
+	reward = 4500 //Skyrat edit
 
 datum/bounty/reagent/complex_drink/New()
 	// Don't worry about making this comprehensive. It doesn't matter if some drinks are skipped.
@@ -116,7 +116,7 @@ datum/bounty/reagent/complex_drink/New()
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "CentCom is offering a reward for talented mixologists. Ship a container of [name] to claim the prize."
+	description = "The FTU is going to discuss important matters with Lopland, we need a talented barman to get their commander a drink. We've heard they like [name] best." //Skyrat edit
 	reward += rand(0, 4) * 300
 
 /datum/bounty/reagent/chemical
@@ -167,6 +167,6 @@ datum/bounty/reagent/chemical/New()
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
-	description = "CentCom is in desperate need of the chemical [name]. Ship a container of it to be rewarded."
+	description = "SolFed is in shortage of [name], can you send us some so that we may sell it to them? You can have a 40% cut."
 	reward += rand(0, 4) * 500
 

--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -121,7 +121,7 @@ datum/bounty/reagent/complex_drink/New()
 
 /datum/bounty/reagent/chemical
 	name = "Chemical"
-	reward = 4750
+	reward = 4750 //skyrat edit
 	required_volume = 30
 
 datum/bounty/reagent/chemical/New()

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -44,66 +44,66 @@
 /datum/bounty/item/science/diamond_drill
 	name = "Diamond Mining Drill"
 	description = "Our contractors in Post 074 had a shortcircuit explosion in the gear room, we'll pay you big in exchange for one diamond mining drill." //Skyrat edit
-	reward = 8000
+	reward = 8000 //Skyrat edit
 	wanted_types = list(/obj/item/pickaxe/drill/diamonddrill, /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill)
 
 /datum/bounty/item/science/floor_buffer
 	name = "Floor Buffer Upgrade"
 	description = "One of CentCom's janitors made a small fortune betting on carp races. Now they'd like to commission an upgrade to their floor buffer."
-	reward = 5500
+	reward = 5500 //Skyrat edit
 	wanted_types = list(/obj/item/janiupgrade)
 
 /datum/bounty/item/science/advanced_mop
 	name = "Advanced Mop"
 	description = "Excuse me. I'd like to request 17 cr for a push broom rebristling. Either that, or an advanced mop."
-	reward = 5500
+	reward = 5500 //Skyrat edit
 	wanted_types = list(/obj/item/mop/advanced)
 
 /datum/bounty/item/science/advanced_egun
 	name = "Advanced Energy Gun"
 	description = "With the price of rechargers on the rise, upper management is interested in purchasing guns that are self-powered. If you ship one, they'll pay."
-	reward = 12000
+	reward = 12000 //Skyrat edit
 	wanted_types = list(/obj/item/gun/energy/e_gun/nuclear)
 
 /datum/bounty/item/science/bscells
 	name = "Bluespace Power Cells"
 	description = "Someone in upper management keeps using the excuse that his tablet battery dies when he's in the middle of work. This will be the last time he doesn't have his presentation, I swear to -"
-	reward = 4500
+	reward = 4500 //Skyrat edit
 	required_count = 10 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/cell/bluespace)
 
 /datum/bounty/item/science/t4manip
 	name = "Femto-Manipulators"
 	description = "One of our Chief Engineers has OCD. Can you send us some femto-manipulators so he stops complaining that his ID doesn't fit perfectly in the PDA slot?"
-	reward = 2500
+	reward = 2500 //Skyrat edit
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/manipulator/femto)
 
 /datum/bounty/item/science/t4bins
 	name = "Bluespace Matter Bins"
 	description = "The local Janitorial union has gone on strike. Can you send us some bluespace bins so we don't have to take out our own trash?"
-	reward = 2500
+	reward = 2500 //Skyrat edit
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/matter_bin/bluespace)
 
 /datum/bounty/item/science/t4capacitor
 	name = "Quadratic Capacitor"
 	description = "One of our linguists doesn't understand why they're called Quadratic capacitors. Can you give him a few so he leaves us alone about it?"
-	reward = 2000
+	reward = 2000 //Skyrat edit
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/capacitor/quadratic)
 
 /datum/bounty/item/science/t4triphasic
 	name = "Triphasic Scanning Module"
 	description = "One of our scientists got into the liberty caps and is demanding new scanning modules so he can talk to ghosts. At this point we just want him out of our office."
-	reward = 2500
+	reward = 2500 //Skyrat edit
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/scanning_module/triphasic)
 
 /datum/bounty/item/science/t4microlaser
 	name = "Quad-Ultra Micro-Laser"
 	description = "The cats on Vega 9 are breeding out of control. We need something to corral them into one area so we can saturation bomb it."
-	reward = 2500
+	reward = 2500 //Skyrat edit
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/micro_laser/quadultra)
 
@@ -120,7 +120,7 @@
 /datum/bounty/item/science/noneactive_reactivearmor
 	name = "Reactive Armor Shells"
 	description = "Due to the breakthroughs in anomalies, we can not keep up in making reactive armor shells, can you send us a few?"
-	reward = 5000
+	reward = 5000 //Skyrat edit
 	required_count = 5
 	wanted_types = list(/obj/item/reactive_armour_shell, /obj/item/clothing/suit/armor/reactive)
 	exclude_types = list(/obj/item/clothing/suit/armor/reactive/repulse,
@@ -132,14 +132,14 @@
 /datum/bounty/item/science/anomaly_core
 	name = "Anomaly Core"
 	description = "A new theory has begun that each sector of space has different anomalies, this all started when a local station tried to make a fire based reactive suit and failed making a stealth version, please send us a core so we may study it more."
-	reward = 5500
+	reward = 5500 //Skyrat edit
 	required_count = 1
 	wanted_types = list(/obj/item/assembly/signaler/anomaly)
 
 /datum/bounty/item/science/anomaly_neutralizer
 	name = "Anomaly Neutralizers"
 	description = "An idea for a long time was to use an unstable Supermatter Shard to help create the breeding grounds for an unstable part of space to harvest any anomalies we want. It worked a little too well and now we're out of anomaly neutralizers, please send us a baker's dozen."
-	reward = 5000
+	reward = 5000 //Skyrat edit
 	required_count = 13
 	wanted_types = list(/obj/item/anomaly_neutralizer)
 

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -146,14 +146,14 @@
 /datum/bounty/item/science/integrated_circuit_printer
 	name = "Integrated Circuit Printer"
 	description = "Due to a paperwork error, a newly made integrated circuit manufacturer line is missing three of its printers needed to operate. Until the paper work is corrected we are outsourcing this problem, so please send us three integrated circuit printers."
-	reward = 2500
+	reward = 2500 //Skyrat edit
 	required_count = 3
 	wanted_types = list(/obj/item/integrated_circuit_printer)
 
 /datum/bounty/item/science/integrated_circuit_disks
 	name = "Integrated Circuit Printer Upgrade Disks"
 	description = "HR has requested ten more integrated circuit printer upgrade disks, please send them to CC as soon as possible."
-	reward = 2000
+	reward = 2000 
 	required_count = 10 //Its just metal
 	wanted_types = list(/obj/item/disk/integrated_circuit/upgrade)
 

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,49 +1,49 @@
 /datum/bounty/item/science/boh
 	name = "Bag of Holding"
-	description = "Nanotrasen would make good use of high-capacity backpacks. If you have any, please ship them."
-	reward = 8000
+	description = "Our buyers would make good use of high-capacity backpacks. If you have any, please ship them." //Skyrat edit
+	reward = 8000 //Skyrat edit
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/tboh
 	name = "Trash Bag of Holding"
-	description = "Nanotrasen would make good use of high-capacity trash bags. If you have any, please ship them."
-	reward = 6000
+	description = "Our buyers would make good use of high-capacity trash bags. If you have any, please ship them." //Skyrat edit
+	reward = 6000 //Skyrat edit
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/bluespace_syringe
 	name = "Bluespace Syringe"
-	description = "Nanotrasen would make good use of high-capacity syringes. If you have any, please ship them."
-	reward = 2500
+	description = "Our buyers would make good use of high-capacity syringes. If you have any, please ship them." //Skyrat edit
+	reward = 2500 //Skyrat edit
 	wanted_types = list(/obj/item/reagent_containers/syringe/bluespace)
 
 /datum/bounty/item/science/bluespace_body_bag
 	name = "Bluespace Body Bag"
-	description = "Nanotrasen would make good use of high-capacity body bags. If you have any, please ship them."
-	reward = 6000
+	description = "The FTU's security forces have repelled a mercenary attack, and we need a bluespace body bag. Pronto." //Skyrat edit
+	reward = 6000 //Skyrat edit
 	wanted_types = list(/obj/item/bodybag/bluespace)
 
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at CentCom. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"
-	reward = 2500
+	reward = 2500 //Skyrat edit
 	wanted_types = list(/obj/item/clothing/glasses/night, /obj/item/clothing/glasses/meson/night, /obj/item/clothing/glasses/hud/health/night, /obj/item/clothing/glasses/hud/security/night, /obj/item/clothing/glasses/hud/diagnostic/night)
 
 /datum/bounty/item/science/experimental_welding_tool
 	name = "Experimental Welding Tool"
 	description = "A recent accident has left most of CentCom's welding tools exploded. Ship replacements to be rewarded."
-	reward = 8000
+	reward = 8000 //Skyrat edit
 	required_count = 3
 	wanted_types = list(/obj/item/weldingtool/experimental)
 
 /datum/bounty/item/science/cryostasis_beaker
 	name = "Cryostasis Beaker"
 	description = "Chemists at Central Command have discovered a new chemical that can only be held in cryostasis beakers. The only problem is they don't have any! Rectify this to receive payment."
-	reward = 2000
+	reward = 2000 //Skyrat edit
 	wanted_types = list(/obj/item/reagent_containers/glass/beaker/noreact)
 
 /datum/bounty/item/science/diamond_drill
 	name = "Diamond Mining Drill"
-	description = "Central Command is willing to pay three months salary in exchange for one diamond mining drill."
+	description = "Our contractors in Post 074 had a shortcircuit explosion in the gear room, we'll pay you big in exchange for one diamond mining drill." //Skyrat edit
 	reward = 8000
 	wanted_types = list(/obj/item/pickaxe/drill/diamonddrill, /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill)
 
@@ -109,7 +109,7 @@
 
 /datum/bounty/item/science/fakecrystals
 	name = "Synthetic Bluespace Crystals"
-	description = "Don't, uh, tell anyone, but one of our BSA arrays might have had a little... accident. Send us some bluespace crystals so we can recalibrate it before anyone realizes. The whole set uses artificial bluespace crystals, so we need and not any other type of bluespace crystals..."
+	description = "Don't, uh, tell anyone, but one of CC's BSA arrays might have had a little... accident. Send us some bluespace crystals so we can help them recalibrate it before anyone realizes. The whole set uses artificial bluespace crystals, so make sure they're printed." //Skyrat edit
 	reward = 8000
 	required_count = 5
 	wanted_types = list(/obj/item/stack/ore/bluespace_crystal/artificial)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,37 +1,37 @@
 /datum/bounty/item/science/boh
 	name = "Bag of Holding"
 	description = "Nanotrasen would make good use of high-capacity backpacks. If you have any, please ship them."
-	reward = 5000
+	reward = 8000
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/tboh
 	name = "Trash Bag of Holding"
 	description = "Nanotrasen would make good use of high-capacity trash bags. If you have any, please ship them."
-	reward = 3000
+	reward = 6000
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/bluespace_syringe
 	name = "Bluespace Syringe"
 	description = "Nanotrasen would make good use of high-capacity syringes. If you have any, please ship them."
-	reward = 1500
+	reward = 2500
 	wanted_types = list(/obj/item/reagent_containers/syringe/bluespace)
 
 /datum/bounty/item/science/bluespace_body_bag
 	name = "Bluespace Body Bag"
 	description = "Nanotrasen would make good use of high-capacity body bags. If you have any, please ship them."
-	reward = 5000
+	reward = 6000
 	wanted_types = list(/obj/item/bodybag/bluespace)
 
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at CentCom. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"
-	reward = 1250
+	reward = 2500
 	wanted_types = list(/obj/item/clothing/glasses/night, /obj/item/clothing/glasses/meson/night, /obj/item/clothing/glasses/hud/health/night, /obj/item/clothing/glasses/hud/security/night, /obj/item/clothing/glasses/hud/diagnostic/night)
 
 /datum/bounty/item/science/experimental_welding_tool
 	name = "Experimental Welding Tool"
 	description = "A recent accident has left most of CentCom's welding tools exploded. Ship replacements to be rewarded."
-	reward = 5000
+	reward = 8000
 	required_count = 3
 	wanted_types = list(/obj/item/weldingtool/experimental)
 
@@ -44,45 +44,45 @@
 /datum/bounty/item/science/diamond_drill
 	name = "Diamond Mining Drill"
 	description = "Central Command is willing to pay three months salary in exchange for one diamond mining drill."
-	reward = 5500
+	reward = 8000
 	wanted_types = list(/obj/item/pickaxe/drill/diamonddrill, /obj/item/mecha_parts/mecha_equipment/drill/diamonddrill)
 
 /datum/bounty/item/science/floor_buffer
 	name = "Floor Buffer Upgrade"
 	description = "One of CentCom's janitors made a small fortune betting on carp races. Now they'd like to commission an upgrade to their floor buffer."
-	reward = 3000
+	reward = 5500
 	wanted_types = list(/obj/item/janiupgrade)
 
 /datum/bounty/item/science/advanced_mop
 	name = "Advanced Mop"
 	description = "Excuse me. I'd like to request 17 cr for a push broom rebristling. Either that, or an advanced mop."
-	reward = 3000
+	reward = 5500
 	wanted_types = list(/obj/item/mop/advanced)
 
 /datum/bounty/item/science/advanced_egun
 	name = "Advanced Energy Gun"
 	description = "With the price of rechargers on the rise, upper management is interested in purchasing guns that are self-powered. If you ship one, they'll pay."
-	reward = 1800
+	reward = 12000
 	wanted_types = list(/obj/item/gun/energy/e_gun/nuclear)
 
 /datum/bounty/item/science/bscells
 	name = "Bluespace Power Cells"
 	description = "Someone in upper management keeps using the excuse that his tablet battery dies when he's in the middle of work. This will be the last time he doesn't have his presentation, I swear to -"
-	reward = 3000
+	reward = 4500
 	required_count = 10 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/cell/bluespace)
 
 /datum/bounty/item/science/t4manip
 	name = "Femto-Manipulators"
 	description = "One of our Chief Engineers has OCD. Can you send us some femto-manipulators so he stops complaining that his ID doesn't fit perfectly in the PDA slot?"
-	reward = 2000
+	reward = 2500
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/manipulator/femto)
 
 /datum/bounty/item/science/t4bins
 	name = "Bluespace Matter Bins"
 	description = "The local Janitorial union has gone on strike. Can you send us some bluespace bins so we don't have to take out our own trash?"
-	reward = 2000
+	reward = 2500
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/matter_bin/bluespace)
 
@@ -96,14 +96,14 @@
 /datum/bounty/item/science/t4triphasic
 	name = "Triphasic Scanning Module"
 	description = "One of our scientists got into the liberty caps and is demanding new scanning modules so he can talk to ghosts. At this point we just want him out of our office."
-	reward = 2000
+	reward = 2500
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/scanning_module/triphasic)
 
 /datum/bounty/item/science/t4microlaser
 	name = "Quad-Ultra Micro-Laser"
 	description = "The cats on Vega 9 are breeding out of control. We need something to corral them into one area so we can saturation bomb it."
-	reward = 2000
+	reward = 2500
 	required_count = 20 //Easy to make
 	wanted_types = list(/obj/item/stock_parts/micro_laser/quadultra)
 
@@ -120,7 +120,7 @@
 /datum/bounty/item/science/noneactive_reactivearmor
 	name = "Reactive Armor Shells"
 	description = "Due to the breakthroughs in anomalies, we can not keep up in making reactive armor shells, can you send us a few?"
-	reward = 2000
+	reward = 5000
 	required_count = 5
 	wanted_types = list(/obj/item/reactive_armour_shell, /obj/item/clothing/suit/armor/reactive)
 	exclude_types = list(/obj/item/clothing/suit/armor/reactive/repulse,
@@ -132,21 +132,21 @@
 /datum/bounty/item/science/anomaly_core
 	name = "Anomaly Core"
 	description = "A new theory has begun that each sector of space has different anomalies, this all started when a local station tried to make a fire based reactive suit and failed making a stealth version, please send us a core so we may study it more."
-	reward = 2500
+	reward = 5500
 	required_count = 1
 	wanted_types = list(/obj/item/assembly/signaler/anomaly)
 
 /datum/bounty/item/science/anomaly_neutralizer
 	name = "Anomaly Neutralizers"
 	description = "An idea for a long time was to use an unstable Supermatter Shard to help create the breeding grounds for an unstable part of space to harvest any anomalies we want. It worked a little too well and now we're out of anomaly neutralizers, please send us a baker's dozen."
-	reward = 2500
+	reward = 5000
 	required_count = 13
 	wanted_types = list(/obj/item/anomaly_neutralizer)
 
 /datum/bounty/item/science/integrated_circuit_printer
 	name = "Integrated Circuit Printer"
 	description = "Due to a paperwork error, a newly made integrated circuit manufacturer line is missing three of its printers needed to operate. Until the paper work is corrected we are outsourcing this problem, so please send us three integrated circuit printers."
-	reward = 2000
+	reward = 2500
 	required_count = 3
 	wanted_types = list(/obj/item/integrated_circuit_printer)
 

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -1,14 +1,14 @@
 /datum/bounty/item/alien_organs
 	name = "Alien Organs"
 	description = "Nanotrasen is interested in studying Xenomorph biology. Ship a set of organs to be thoroughly compensated."
-	reward = 13500
+	reward = 15000
 	required_count = 3
 	wanted_types = list(/obj/item/organ/brain/alien, /obj/item/organ/alien, /obj/item/organ/body_egg/alien_embryo)
 
 /datum/bounty/item/syndicate_documents
 	name = "Syndicate Documents"
 	description = "Intel regarding the syndicate is highly prized at CentCom. If you find syndicate documents, ship them. You could save lives."
-	reward = 10000
+	reward = 15000
 	wanted_types = list(/obj/item/documents/syndicate, /obj/item/documents/photocopy)
 
 /datum/bounty/item/syndicate_documents/applies_to(obj/O)
@@ -22,7 +22,7 @@
 /datum/bounty/item/adamantine
 	name = "Adamantine"
 	description = "Nanotrasen's anomalous materials division is in desparate need for Adamantine. Send them a large shipment and we'll make it worth your while."
-	reward = 15000
+	reward = 30000
 	required_count = 10
 	wanted_types = list(/obj/item/stack/sheet/mineral/adamantine)
 

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -1,14 +1,14 @@
 /datum/bounty/item/alien_organs
 	name = "Alien Organs"
-	description = "Nanotrasen is interested in studying Xenomorph biology. Ship a set of organs to be thoroughly compensated."
-	reward = 15000
+	description = "Letheia is interested in studying Xenomorph biology. Ship a set of organs to be thoroughly compensated." //Skyrat edit
+	reward = 15000 //Skyrat edit
 	required_count = 3
 	wanted_types = list(/obj/item/organ/brain/alien, /obj/item/organ/alien, /obj/item/organ/body_egg/alien_embryo)
 
 /datum/bounty/item/syndicate_documents
 	name = "Syndicate Documents"
-	description = "Intel regarding the syndicate is highly prized at CentCom. If you find syndicate documents, ship them. You could save lives."
-	reward = 15000
+	description = "Intel regarding the syndicate is highly prized by NT. If you find syndicate documents, ship them." //Skyrat edit
+	reward = 15000 //Skyrat edit
 	wanted_types = list(/obj/item/documents/syndicate, /obj/item/documents/photocopy)
 
 /datum/bounty/item/syndicate_documents/applies_to(obj/O)
@@ -22,15 +22,15 @@
 /datum/bounty/item/adamantine
 	name = "Adamantine"
 	description = "Nanotrasen's anomalous materials division is in desparate need for Adamantine. Send them a large shipment and we'll make it worth your while."
-	reward = 30000
+	reward = 30000 //Skyrat edit
 	required_count = 10
 	wanted_types = list(/obj/item/stack/sheet/mineral/adamantine)
 
 /datum/bounty/more_bounties
 	name = "More Bounties"
-	description = "Complete enough bounties and CentCom will issue new ones!"
+	description = "Completion of enough bounties will allow us to open another transport route." //Skyrat edit
 	reward = 8 // number of bounties
-	var/required_bounties = 3
+	var/required_bounties = 5 //Skyrat edit
 
 /datum/bounty/more_bounties/can_claim()
 	return ..() && completed_bounty_count() >= required_bounties

--- a/code/modules/cargo/exports/food_wine.dm
+++ b/code/modules/cargo/exports/food_wine.dm
@@ -104,12 +104,12 @@
 	export_types = list(/obj/item/reagent_containers/food/snacks/breadslice)
 
 /datum/export/food/burger
-	cost = 50
+	cost = 50 //Skyrat edit
 	unit_name = "burger"
 	export_types = list(/obj/item/reagent_containers/food/snacks/burger)
 
 /datum/export/food/cake
-	cost = 100
+	cost = 100 //Skyrat edit
 	unit_name = "cake"
 	export_types = list(/obj/item/reagent_containers/food/snacks/store/cake)
 

--- a/code/modules/cargo/exports/food_wine.dm
+++ b/code/modules/cargo/exports/food_wine.dm
@@ -63,12 +63,12 @@
 	export_types = list(/obj/item/reagent_containers/food/snacks/rawpastrybase, /obj/item/reagent_containers/food/snacks/pastrybase)
 
 /datum/export/food/cake_pie_raw
-	cost = 12
-	unit_name = "food base"
+	cost = 12 //Skyrat edit
+	unit_name = "food base" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/cakebatter, /obj/item/reagent_containers/food/snacks/piedough)
 
 /datum/export/food/cooked_cake_pie
-	cost = 15
+	cost = 15 //Skyrat edit
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/store/cake/plain, /obj/item/reagent_containers/food/snacks/pie/plain)
 

--- a/code/modules/cargo/exports/food_wine.dm
+++ b/code/modules/cargo/exports/food_wine.dm
@@ -8,52 +8,52 @@
 	include_subtypes = TRUE
 
 /datum/export/food/meat
-	cost = 21
-	unit_name = "raw animal protein"
+	cost = 21  //Skyrat edit
+	unit_name = "raw animal protein" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/slab)
 
 /datum/export/food/raw_cutlets
-	cost = 7
-	unit_name = "raw prepared animal protein"
+	cost = 7 //Skyrat edit
+	unit_name = "raw prepared animal protein" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/rawcutlet)
 
 /datum/export/food/cooked_cutlets
-	cost = 14
-	unit_name = "cooked prepared animal protein"
+	cost = 14 //Skyrat edit
+	unit_name = "cooked prepared animal protein" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/cutlet)
 
 /datum/export/food/cooked_meat
-	cost = 42
-	unit_name = "cooked animal protein"
+	cost = 42 //Skyrat edit
+	unit_name = "cooked animal protein" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/steak)
 
 /datum/export/food/dough
-	cost = 9
-	unit_name = "food base"
+	cost = 9 //Skyrat edit
+	unit_name = "food base" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/dough, /obj/item/reagent_containers/food/snacks/flatdough)
 
 /datum/export/food/cooked_dough
-	cost = 15
+	cost = 15 //Skyrat edit
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/pizzabread)
 
 /datum/export/food/buns
-	cost = 15
+	cost = 15 //Skyrat edit
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/bun)
 
 /datum/export/food/buns
-	cost = 15
+	cost = 15 //Skyrat edit
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/bun)
 
 /datum/export/food/eggs
-	cost = 21
+	cost = 21 //Skyrat edit
 	unit_name = "prepared egg protein"
 	export_types = list(/obj/item/reagent_containers/food/snacks/friedegg)
 
 /datum/export/food/eggs_food
-	cost = 35
+	cost = 35 //Skyrat edit
 	unit_name = "prepared egg dish"
 	export_types = list(/obj/item/reagent_containers/food/snacks/omelette, /obj/item/reagent_containers/food/snacks/benedict, /obj/item/reagent_containers/food/snacks/salad/eggbowl)
 
@@ -148,17 +148,17 @@
 						/obj/item/reagent_containers/food/snacks/meatballspaghetti, /obj/item/reagent_containers/food/snacks/spesslaw, /obj/item/reagent_containers/food/snacks/chowmein, /obj/item/reagent_containers/food/snacks/beefnoodle, /obj/item/reagent_containers/food/snacks/butternoodles)
 
 /datum/export/food/pizza
-	cost = 720
+	cost = 720 //Skyrat edit
 	unit_name = "pizza"
 	export_types = list(/obj/item/reagent_containers/food/snacks/pizza)
 
 /datum/export/food/sliced_pizza
-	cost = 72
+	cost = 72 //Skyrat edit
 	unit_name = "pizza slice"
 	export_types = list(/obj/item/reagent_containers/food/snacks/pizzaslice)
 
 /datum/export/food/snowcone
-	cost = 10
+	cost = 10 //Skyrat edit
 	unit_name = "snowcone"
 	export_types = list(/obj/item/reagent_containers/food/snacks/snowcones)
 

--- a/code/modules/cargo/exports/food_wine.dm
+++ b/code/modules/cargo/exports/food_wine.dm
@@ -8,63 +8,63 @@
 	include_subtypes = TRUE
 
 /datum/export/food/meat
-	cost = 5
-	unit_name = "protein based food"
+	cost = 21
+	unit_name = "raw animal protein"
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/slab)
 
 /datum/export/food/raw_cutlets
-	cost = 3
-	unit_name = "protein based food"
+	cost = 7
+	unit_name = "raw prepared animal protein"
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/rawcutlet)
 
 /datum/export/food/cooked_cutlets
-	cost = 4
-	unit_name = "cooked protein based food"
+	cost = 14
+	unit_name = "cooked prepared animal protein"
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/cutlet)
 
 /datum/export/food/cooked_meat
-	cost = 8
-	unit_name = "cooked protein based food"
+	cost = 42
+	unit_name = "cooked animal protein"
 	export_types = list(/obj/item/reagent_containers/food/snacks/meat/steak)
 
 /datum/export/food/dough
-	cost = 3
-	unit_name = "uncooked food base"
+	cost = 9
+	unit_name = "food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/dough, /obj/item/reagent_containers/food/snacks/flatdough)
 
 /datum/export/food/cooked_dough
-	cost = 5
+	cost = 15
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/pizzabread)
 
 /datum/export/food/buns
-	cost = 3
+	cost = 15
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/bun)
 
 /datum/export/food/buns
-	cost = 3
+	cost = 15
 	unit_name = "cooked food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/bun)
 
 /datum/export/food/eggs
-	cost = 4
-	unit_name = "cooked food base"
+	cost = 21
+	unit_name = "prepared egg protein"
 	export_types = list(/obj/item/reagent_containers/food/snacks/friedegg)
 
 /datum/export/food/eggs_food
-	cost = 20
-	unit_name = "cooked egg based food"
+	cost = 35
+	unit_name = "prepared egg dish"
 	export_types = list(/obj/item/reagent_containers/food/snacks/omelette, /obj/item/reagent_containers/food/snacks/benedict, /obj/item/reagent_containers/food/snacks/salad/eggbowl)
 
 /datum/export/food/sweets
 	cost = 4
-	unit_name = "pastery base"
+	unit_name = "pastry base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/rawpastrybase, /obj/item/reagent_containers/food/snacks/pastrybase)
 
 /datum/export/food/cake_pie_raw
 	cost = 12
-	unit_name = "uncooked food base"
+	unit_name = "food base"
 	export_types = list(/obj/item/reagent_containers/food/snacks/cakebatter, /obj/item/reagent_containers/food/snacks/piedough)
 
 /datum/export/food/cooked_cake_pie
@@ -104,12 +104,12 @@
 	export_types = list(/obj/item/reagent_containers/food/snacks/breadslice)
 
 /datum/export/food/burger
-	cost = 12
+	cost = 50
 	unit_name = "burger"
 	export_types = list(/obj/item/reagent_containers/food/snacks/burger)
 
 /datum/export/food/cake
-	cost = 50
+	cost = 100
 	unit_name = "cake"
 	export_types = list(/obj/item/reagent_containers/food/snacks/store/cake)
 
@@ -148,17 +148,17 @@
 						/obj/item/reagent_containers/food/snacks/meatballspaghetti, /obj/item/reagent_containers/food/snacks/spesslaw, /obj/item/reagent_containers/food/snacks/chowmein, /obj/item/reagent_containers/food/snacks/beefnoodle, /obj/item/reagent_containers/food/snacks/butternoodles)
 
 /datum/export/food/pizza
-	cost = 120
+	cost = 720
 	unit_name = "pizza"
 	export_types = list(/obj/item/reagent_containers/food/snacks/pizza)
 
 /datum/export/food/sliced_pizza
-	cost = 12
+	cost = 72
 	unit_name = "pizza slice"
 	export_types = list(/obj/item/reagent_containers/food/snacks/pizzaslice)
 
 /datum/export/food/snowcone
-	cost = 3
+	cost = 10
 	unit_name = "snowcone"
 	export_types = list(/obj/item/reagent_containers/food/snacks/snowcones)
 

--- a/code/modules/cargo/exports/food_wine.dm
+++ b/code/modules/cargo/exports/food_wine.dm
@@ -59,7 +59,7 @@
 
 /datum/export/food/sweets
 	cost = 4
-	unit_name = "pastry base"
+	unit_name = "pastry base" //Skyrat edit
 	export_types = list(/obj/item/reagent_containers/food/snacks/rawpastrybase, /obj/item/reagent_containers/food/snacks/pastrybase)
 
 /datum/export/food/cake_pie_raw

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -30,12 +30,12 @@
 	exclude_types = list()
 
 /datum/export/large/barrel
-	cost = 300 //double the wooden cost of a coffin.
+	cost = 600 //double the wooden cost of a coffin.
 	unit_name = "wooden barrel"
 	export_types = list(/obj/structure/fermenting_barrel)
 
 /datum/export/large/crate/coffin
-	cost = 150
+	cost = 300
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 
@@ -196,22 +196,22 @@
 	export_types = list(/obj/structure/statue/uranium/eng)
 
 /datum/export/large/plasmastatue
-	cost = 720
+	cost = 900
 	unit_name = "Scientist statue"
 	export_types = list(/obj/structure/statue/plasma/scientist)
 
 /datum/export/large/hosstatue
-	cost = 225
+	cost = 400
 	unit_name = "HoS statue"
 	export_types = list(/obj/structure/statue/gold/hos)
 
 /datum/export/large/rdstatue
-	cost = 225
+	cost = 400
 	unit_name = "RD statue"
 	export_types = list(/obj/structure/statue/gold/rd)
 
 /datum/export/large/hopstatue
-	cost = 225
+	cost = 400
 	unit_name = "HoP statue"
 	export_types = list(/obj/structure/statue/gold/hop)
 
@@ -256,12 +256,12 @@
 	export_types = list(/obj/structure/statue/diamond/captain)
 
 /datum/export/large/aistatue
-	cost = 1200
+	cost = 2500
 	unit_name = "AI statue"
 	export_types = list(/obj/structure/statue/diamond/ai1, /obj/structure/statue/diamond/ai2)
 
 /datum/export/large/clownstatue
-	cost = 2750
+	cost = 6500
 	unit_name = "Clown statue"
 	export_types = list(/obj/structure/statue/bananium/clown)
 
@@ -283,22 +283,22 @@
 	export_types = list(/obj/mecha/medical/odysseus)
 
 /datum/export/large/mech/ripley
-	cost = 12000
+	cost = 13000
 	unit_name = "working ripley"
 	export_types = list(/obj/mecha/working/ripley)
 
 /datum/export/large/mech/firefighter
-	cost = 14000
+	cost = 15000
 	unit_name = "working firefighter"
 	export_types = list(/obj/mecha/working/ripley/firefighter)
 
 /datum/export/large/mech/gygax
-	cost = 19000
+	cost = 20000
 	unit_name = "working gygax"
 	export_types = list(/obj/mecha/combat/gygax)
 
 /datum/export/large/mech/durand
-	cost = 16000
+	cost = 20000
 	unit_name = "working durand"
 	export_types = list(/obj/mecha/combat/durand)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -236,7 +236,7 @@
 	export_types = list(/obj/structure/statue/silver/janitor)
 
 /datum/export/large/secstatue
-	cost = 200 
+	cost = 200
 	unit_name = "Sec statue"
 	export_types = list(/obj/structure/statue/silver/sec)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -261,12 +261,12 @@
 	export_types = list(/obj/structure/statue/diamond/ai1, /obj/structure/statue/diamond/ai2)
 
 /datum/export/large/clownstatue
-	cost = 6500
+	cost = 6500 //Skyrat edit
 	unit_name = "Clown statue"
 	export_types = list(/obj/structure/statue/bananium/clown)
 
 /datum/export/large/sandstatue
-	cost = 90 //Big cash
+	cost = 150 //Big cash //Skyrat edit
 	unit_name = "sandstone statue"
 	export_types = list(/obj/structure/statue/sandstone/assistant)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -186,52 +186,52 @@
 //////////////
 
 /datum/export/large/nukestatue
-	cost = 175
+	cost = 235
 	unit_name = "Nuke statue"
 	export_types = list(/obj/structure/statue/uranium/nuke)
 
 /datum/export/large/engstatue
-	cost = 175
+	cost = 235
 	unit_name = "Engine statue"
 	export_types = list(/obj/structure/statue/uranium/eng)
 
 /datum/export/large/plasmastatue
-	cost = 900 //Skyrat edit
+	cost = 1800 //Skyrat edit
 	unit_name = "Scientist statue"
 	export_types = list(/obj/structure/statue/plasma/scientist)
 
 /datum/export/large/hosstatue
-	cost = 400 //Skyrat edit
+	cost = 800 //Skyrat edit
 	unit_name = "HoS statue"
 	export_types = list(/obj/structure/statue/gold/hos)
 
 /datum/export/large/rdstatue
-	cost = 400 //Skyrat edit
+	cost = 800 //Skyrat edit
 	unit_name = "RD statue"
 	export_types = list(/obj/structure/statue/gold/rd)
 
 /datum/export/large/hopstatue
-	cost = 400 //Skyrat edit
+	cost = 800 //Skyrat edit
 	unit_name = "HoP statue"
 	export_types = list(/obj/structure/statue/gold/hop)
 
 /datum/export/large/cmostatue
-	cost = 400 //Skyrat edit
+	cost = 8'0 //Skyrat edit
 	unit_name = "CMO statue"
 	export_types = list(/obj/structure/statue/gold/cmo)
 
 /datum/export/large/cestatue
-	cost = 400 //Skyrat edit
+	cost = 800 //Skyrat edit
 	unit_name = "CE statue"
 	export_types = list(/obj/structure/statue/gold/ce)
 
 /datum/export/large/mdstatue
-	cost = 200 //Skyrat edit
+	cost = 300 //Skyrat edit
 	unit_name = "MD statue"
 	export_types = list(/obj/structure/statue/silver/md)
 
 /datum/export/large/janitorstatue
-	cost = 200
+	cost = 300
 	unit_name = "Janitor statue"
 	export_types = list(/obj/structure/statue/silver/janitor)
 
@@ -278,7 +278,7 @@
 	include_subtypes = FALSE
 
 /datum/export/large/mech/odysseus
-	cost = 7500
+	cost = 14500 //Why the fuck does an Ody cost less than a ripley anyway
 	unit_name = "working odysseus"
 	export_types = list(/obj/mecha/medical/odysseus)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -30,12 +30,12 @@
 	exclude_types = list()
 
 /datum/export/large/barrel
-	cost = 600 //double the wooden cost of a coffin.
+	cost = 600 //double the wooden cost of a coffin. //Skyrat edit
 	unit_name = "wooden barrel"
 	export_types = list(/obj/structure/fermenting_barrel)
 
 /datum/export/large/crate/coffin
-	cost = 300
+	cost = 300 //Skyrat edit
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 
@@ -196,37 +196,37 @@
 	export_types = list(/obj/structure/statue/uranium/eng)
 
 /datum/export/large/plasmastatue
-	cost = 900
+	cost = 900 //Skyrat edit
 	unit_name = "Scientist statue"
 	export_types = list(/obj/structure/statue/plasma/scientist)
 
 /datum/export/large/hosstatue
-	cost = 400
+	cost = 400 //Skyrat edit
 	unit_name = "HoS statue"
 	export_types = list(/obj/structure/statue/gold/hos)
 
 /datum/export/large/rdstatue
-	cost = 400
+	cost = 400 //Skyrat edit
 	unit_name = "RD statue"
 	export_types = list(/obj/structure/statue/gold/rd)
 
 /datum/export/large/hopstatue
-	cost = 400
+	cost = 400 //Skyrat edit
 	unit_name = "HoP statue"
 	export_types = list(/obj/structure/statue/gold/hop)
 
 /datum/export/large/cmostatue
-	cost = 225
+	cost = 400 //Skyrat edit
 	unit_name = "CMO statue"
 	export_types = list(/obj/structure/statue/gold/cmo)
 
 /datum/export/large/cestatue
-	cost = 225
+	cost = 400 //Skyrat edit
 	unit_name = "CE statue"
 	export_types = list(/obj/structure/statue/gold/ce)
 
 /datum/export/large/mdstatue
-	cost = 200
+	cost = 200 //Skyrat edit
 	unit_name = "MD statue"
 	export_types = list(/obj/structure/statue/silver/md)
 
@@ -236,7 +236,7 @@
 	export_types = list(/obj/structure/statue/silver/janitor)
 
 /datum/export/large/secstatue
-	cost = 200
+	cost = 200 
 	unit_name = "Sec statue"
 	export_types = list(/obj/structure/statue/silver/sec)
 
@@ -251,12 +251,12 @@
 	export_types = list(/obj/structure/statue/silver/secborg)
 
 /datum/export/large/capstatue
-	cost = 1200
+	cost = 2500 //Skyrat edit
 	unit_name = "Captain statue"
 	export_types = list(/obj/structure/statue/diamond/captain)
 
 /datum/export/large/aistatue
-	cost = 2500
+	cost = 2500 //Skyrat edit
 	unit_name = "AI statue"
 	export_types = list(/obj/structure/statue/diamond/ai1, /obj/structure/statue/diamond/ai2)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -283,22 +283,22 @@
 	export_types = list(/obj/mecha/medical/odysseus)
 
 /datum/export/large/mech/ripley
-	cost = 13000
+	cost = 13000 //Skyrat edit
 	unit_name = "working ripley"
 	export_types = list(/obj/mecha/working/ripley)
 
 /datum/export/large/mech/firefighter
-	cost = 15000
+	cost = 15000 //Skyrat edit
 	unit_name = "working firefighter"
 	export_types = list(/obj/mecha/working/ripley/firefighter)
 
 /datum/export/large/mech/gygax
-	cost = 20000
+	cost = 20000 //Skyrat edit
 	unit_name = "working gygax"
 	export_types = list(/obj/mecha/combat/gygax)
 
 /datum/export/large/mech/durand
-	cost = 20000
+	cost = 20000 //Skyrat edit
 	unit_name = "working durand"
 	export_types = list(/obj/mecha/combat/durand)
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -38,17 +38,17 @@
 	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
-	cost = 250 //Skyrat edit
+	cost = 150 //Skyrat edit
 	material_id = /datum/material/plasma
 	message = "cm3 of plasma"
 
 /datum/export/material/uranium
-	cost = 150 //Skyrat edit
+	cost = 120 //Skyrat edit
 	material_id = /datum/material/uranium
 	message = "cm3 of uranium"
 
 /datum/export/material/gold
-	cost = 120 //Skyrat edit
+	cost = 100 //Skyrat edit
 	material_id = /datum/material/gold
 	message = "cm3 of gold"
 
@@ -83,7 +83,7 @@
 		/obj/item/shard)
 
 /datum/export/material/adamantine
-	cost = 500 //Skyrat edit
+	cost = 600 //Skyrat edit
 	material_id = /datum/material/adamantine
 	message = "cm3 of adamantine"
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -28,37 +28,37 @@
 // Materials. Selling raw can lead to a big payout but takes a lot of work for miners to get a lot. Best to craft art/rnd gear
 
 /datum/export/material/bananium
-	cost = 800
+	cost = 800 //Skyrat edit
 	material_id = /datum/material/bananium
 	message = "cm3 of bananium"
 
 /datum/export/material/diamond
-	cost = 500
+	cost = 500 //Skyrat edit
 	material_id = /datum/material/diamond
 	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
-	cost = 250
+	cost = 250 //Skyrat edit
 	material_id = /datum/material/plasma
 	message = "cm3 of plasma"
 
 /datum/export/material/uranium
-	cost = 150
+	cost = 150 //Skyrat edit
 	material_id = /datum/material/uranium
 	message = "cm3 of uranium"
 
 /datum/export/material/gold
-	cost = 120
+	cost = 120 //Skyrat edit
 	material_id = /datum/material/gold
 	message = "cm3 of gold"
 
 /datum/export/material/silver
-	cost = 80
+	cost = 80 //Skyrat edit
 	material_id = /datum/material/silver
 	message = "cm3 of silver"
 
 /datum/export/material/titanium
-	cost = 60
+	cost = 60 //Skyrat edit
 	material_id = /datum/material/titanium
 	message = "cm3 of titanium"
 
@@ -83,7 +83,7 @@
 		/obj/item/shard)
 
 /datum/export/material/adamantine
-	cost = 500
+	cost = 500 //Skyrat edit
 	material_id = /datum/material/adamantine
 	message = "cm3 of adamantine"
 
@@ -93,7 +93,7 @@
 	message = "cm3 of mythril"
 
 /datum/export/material/bscrystal
-	cost = 600
+	cost = 600 //Skyrat edit
 	message = "cm3 of bluespace crystals"
 	material_id = /datum/material/bluespace
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -28,32 +28,32 @@
 // Materials. Selling raw can lead to a big payout but takes a lot of work for miners to get a lot. Best to craft art/rnd gear
 
 /datum/export/material/bananium
-	cost = 500
+	cost = 800
 	material_id = /datum/material/bananium
 	message = "cm3 of bananium"
 
 /datum/export/material/diamond
-	cost = 250
+	cost = 500
 	material_id = /datum/material/diamond
 	message = "cm3 of diamonds"
 
 /datum/export/material/plasma
-	cost = 100
+	cost = 250
 	material_id = /datum/material/plasma
 	message = "cm3 of plasma"
 
 /datum/export/material/uranium
-	cost = 50
+	cost = 150
 	material_id = /datum/material/uranium
 	message = "cm3 of uranium"
 
 /datum/export/material/gold
-	cost = 60
+	cost = 120
 	material_id = /datum/material/gold
 	message = "cm3 of gold"
 
 /datum/export/material/silver
-	cost = 25
+	cost = 80
 	material_id = /datum/material/silver
 	message = "cm3 of silver"
 
@@ -83,7 +83,7 @@
 		/obj/item/shard)
 
 /datum/export/material/adamantine
-	cost = 300
+	cost = 500
 	material_id = /datum/material/adamantine
 	message = "cm3 of adamantine"
 
@@ -93,7 +93,7 @@
 	message = "cm3 of mythril"
 
 /datum/export/material/bscrystal
-	cost = 150
+	cost = 600
 	message = "cm3 of bluespace crystals"
 	material_id = /datum/material/bluespace
 

--- a/code/modules/cargo/exports/organs_robotics.dm
+++ b/code/modules/cargo/exports/organs_robotics.dm
@@ -166,9 +166,9 @@
 						/obj/item/mecha_parts/mecha_equipment/drill, /obj/item/mecha_parts/mecha_equipment/mining_scanner, /obj/item/mecha_parts/mecha_equipment/medical/sleeper)
 
 /datum/export/robotics/mech_blue_space
-	cost = 950
+	cost = 950 //Skyrat edit
 	k_elasticity = 1/10
-	unit_name = "mech teleportation tech"
+	unit_name = "mech teleportation tech" //Skyrat edit
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/teleporter, /obj/item/mecha_parts/mecha_equipment/wormhole_generator, /obj/item/mecha_parts/mecha_equipment/gravcatapult)
 
 /datum/export/robotics/mech_reactors

--- a/code/modules/cargo/exports/organs_robotics.dm
+++ b/code/modules/cargo/exports/organs_robotics.dm
@@ -106,19 +106,19 @@
 	exclude_types = list(/obj/item/organ/liver/cybernetic, /obj/item/organ/liver/cybernetic/upgraded)
 
 /datum/export/organs/cybernetic
-	cost = 225
+	cost = 300
 	unit_name = "cybernetic organ"
 	export_types = list(/obj/item/organ/liver/cybernetic, /obj/item/organ/lungs/cybernetic, /obj/item/organ/eyes/robotic, /obj/item/organ/heart/cybernetic)
 	exclude_types = list(/obj/item/organ/lungs/cybernetic/upgraded, /obj/item/organ/liver/cybernetic/upgraded)
 
 /datum/export/organs/upgraded
-	cost = 275
+	cost = 425
 	unit_name = "upgraded cybernetic organ"
 	export_types = list(/obj/item/organ/lungs/cybernetic/upgraded, /obj/item/organ/liver/cybernetic/upgraded)
 
 /datum/export/organs/tail //Shhh
-	cost = 500
-	unit_name = "error shipment failer"
+	cost = 550
+	unit_name = "organic tail"
 	export_types = list(/obj/item/organ/tail)
 
 /datum/export/orgains/vocal_cords
@@ -127,8 +127,8 @@
 	export_types = list(/obj/item/organ/vocal_cords) //These are gotten via different races
 
 /datum/export/robotics/lims
-	cost = 30
-	unit_name = "robotic lim replacement"
+	cost = 60
+	unit_name = "robotic limb replacement"
 	export_types = list(/obj/item/bodypart/l_arm/robot, /obj/item/bodypart/r_arm/robot, /obj/item/bodypart/l_leg/robot, /obj/item/bodypart/r_leg/robot, /obj/item/bodypart/chest/robot, /obj/item/bodypart/head/robot)
 
 /datum/export/robotics/surpluse
@@ -137,46 +137,46 @@
 	export_types = list(/obj/item/bodypart/l_arm/robot/surplus, /obj/item/bodypart/r_arm/robot/surplus, /obj/item/bodypart/l_leg/robot/surplus, /obj/item/bodypart/r_leg/robot/surplus)
 
 /datum/export/robotics/surplus_upgraded
-	cost = 50
+	cost = 80
 	unit_name = "upgraded robotic lim replacement"
 	export_types = list(/obj/item/bodypart/l_arm/robot/surplus_upgraded, /obj/item/bodypart/r_arm/robot/surplus_upgraded, /obj/item/bodypart/l_leg/robot/surplus_upgraded, /obj/item/bodypart/r_leg/robot/surplus_upgraded)
 
 /datum/export/robotics/surgery_gear_basic
-	cost = 10
+	cost = 20
 	unit_name = "surgery tool"
 	export_types = list(/obj/item/retractor, /obj/item/hemostat, /obj/item/cautery, /obj/item/surgicaldrill, /obj/item/scalpel, /obj/item/circular_saw, /obj/item/surgical_drapes)
 
 /datum/export/robotics/mech_weapon_laser
 	cost = 300 //Sadly just metal and glass
-	unit_name = "mech laser based weapon"
+	unit_name = "mech energy weapon"
 	include_subtypes = TRUE
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam, /obj/item/mecha_parts/mecha_equipment/weapon/energy)
 
 /datum/export/robotics/mech_weapon_bullet
 	cost = 250
-	unit_name = "mech bullet based weapon"
+	unit_name = "mech ballistic weapon"
 	include_subtypes = TRUE
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun, /obj/item/mecha_parts/mecha_equipment/weapon/honker, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic)
 
 /datum/export/robotics/mech_tools
 	cost = 150
-	unit_name = "mech based tool"
+	unit_name = "mech tool"
 	include_subtypes = TRUE
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp, /obj/item/mecha_parts/mecha_equipment/extinguisher, /obj/item/mecha_parts/mecha_equipment/rcd, /obj/item/mecha_parts/mecha_equipment/cable_layer, \
 						/obj/item/mecha_parts/mecha_equipment/drill, /obj/item/mecha_parts/mecha_equipment/mining_scanner, /obj/item/mecha_parts/mecha_equipment/medical/sleeper)
 
 /datum/export/robotics/mech_blue_space
-	cost = 750
+	cost = 950
 	k_elasticity = 1/10
-	unit_name = "mech bluespace tech"
+	unit_name = "mech teleportation tech"
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/teleporter, /obj/item/mecha_parts/mecha_equipment/wormhole_generator, /obj/item/mecha_parts/mecha_equipment/gravcatapult)
 
 /datum/export/robotics/mech_reactors
 	cost = 350
-	unit_name = "mech based reactor"
+	unit_name = "mech reactor"
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay, /obj/item/mecha_parts/mecha_equipment/generator, /obj/item/mecha_parts/mecha_equipment/generator/nuclear)
 
 /datum/export/robotics/mech_armor
 	cost = 350
-	unit_name = "mech armor tech"
+	unit_name = "mech armor platings"
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster, /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster, /obj/item/mecha_parts/mecha_equipment/repair_droid)

--- a/code/modules/cargo/exports/organs_robotics.dm
+++ b/code/modules/cargo/exports/organs_robotics.dm
@@ -106,18 +106,18 @@
 	exclude_types = list(/obj/item/organ/liver/cybernetic, /obj/item/organ/liver/cybernetic/upgraded)
 
 /datum/export/organs/cybernetic
-	cost = 300
+	cost = 300 //Skyrat edit
 	unit_name = "cybernetic organ"
 	export_types = list(/obj/item/organ/liver/cybernetic, /obj/item/organ/lungs/cybernetic, /obj/item/organ/eyes/robotic, /obj/item/organ/heart/cybernetic)
 	exclude_types = list(/obj/item/organ/lungs/cybernetic/upgraded, /obj/item/organ/liver/cybernetic/upgraded)
 
 /datum/export/organs/upgraded
-	cost = 425
+	cost = 425 //Skyrat edit
 	unit_name = "upgraded cybernetic organ"
 	export_types = list(/obj/item/organ/lungs/cybernetic/upgraded, /obj/item/organ/liver/cybernetic/upgraded)
 
 /datum/export/organs/tail //Shhh
-	cost = 550
+	cost = 550 //Skyrat edit
 	unit_name = "organic tail"
 	export_types = list(/obj/item/organ/tail)
 
@@ -127,40 +127,40 @@
 	export_types = list(/obj/item/organ/vocal_cords) //These are gotten via different races
 
 /datum/export/robotics/lims
-	cost = 60
+	cost = 60 //Skyrat edit
 	unit_name = "robotic limb replacement"
 	export_types = list(/obj/item/bodypart/l_arm/robot, /obj/item/bodypart/r_arm/robot, /obj/item/bodypart/l_leg/robot, /obj/item/bodypart/r_leg/robot, /obj/item/bodypart/chest/robot, /obj/item/bodypart/head/robot)
 
 /datum/export/robotics/surpluse
-	cost = 40
+	cost = 40 //Skyrat edit
 	unit_name = "robotic lim replacement"
 	export_types = list(/obj/item/bodypart/l_arm/robot/surplus, /obj/item/bodypart/r_arm/robot/surplus, /obj/item/bodypart/l_leg/robot/surplus, /obj/item/bodypart/r_leg/robot/surplus)
 
 /datum/export/robotics/surplus_upgraded
-	cost = 80
+	cost = 80 //Skyrat edit
 	unit_name = "upgraded robotic lim replacement"
 	export_types = list(/obj/item/bodypart/l_arm/robot/surplus_upgraded, /obj/item/bodypart/r_arm/robot/surplus_upgraded, /obj/item/bodypart/l_leg/robot/surplus_upgraded, /obj/item/bodypart/r_leg/robot/surplus_upgraded)
 
 /datum/export/robotics/surgery_gear_basic
-	cost = 20
+	cost = 20 //Skyrat edit
 	unit_name = "surgery tool"
 	export_types = list(/obj/item/retractor, /obj/item/hemostat, /obj/item/cautery, /obj/item/surgicaldrill, /obj/item/scalpel, /obj/item/circular_saw, /obj/item/surgical_drapes)
 
 /datum/export/robotics/mech_weapon_laser
-	cost = 300 //Sadly just metal and glass
-	unit_name = "mech energy weapon"
+	cost = 300 //Sadly just metal and glass 
+	unit_name = "mech energy weapon" //Skyrat edit
 	include_subtypes = TRUE
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam, /obj/item/mecha_parts/mecha_equipment/weapon/energy)
 
 /datum/export/robotics/mech_weapon_bullet
 	cost = 250
-	unit_name = "mech ballistic weapon"
+	unit_name = "mech ballistic weapon" //Skyrat edit
 	include_subtypes = TRUE
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun, /obj/item/mecha_parts/mecha_equipment/weapon/honker, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic)
 
 /datum/export/robotics/mech_tools
-	cost = 150
-	unit_name = "mech tool"
+	cost = 150 //Skyrat edit
+	unit_name = "mech tool" //Skyrat edit
 	include_subtypes = TRUE
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp, /obj/item/mecha_parts/mecha_equipment/extinguisher, /obj/item/mecha_parts/mecha_equipment/rcd, /obj/item/mecha_parts/mecha_equipment/cable_layer, \
 						/obj/item/mecha_parts/mecha_equipment/drill, /obj/item/mecha_parts/mecha_equipment/mining_scanner, /obj/item/mecha_parts/mecha_equipment/medical/sleeper)
@@ -177,6 +177,6 @@
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay, /obj/item/mecha_parts/mecha_equipment/generator, /obj/item/mecha_parts/mecha_equipment/generator/nuclear)
 
 /datum/export/robotics/mech_armor
-	cost = 350
-	unit_name = "mech armor platings"
+	cost = 350 //Skyrat edit
+	unit_name = "mech armor platings" //Skyrat edit
 	export_types = list(/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster, /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster, /obj/item/mecha_parts/mecha_equipment/repair_droid)

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -44,22 +44,22 @@
 	include_subtypes = TRUE
 
 /datum/export/t1
-	cost = 1
+	cost = 10
 	unit_name = "basic stock part"
 	export_types = list(/obj/item/stock_parts/capacitor, /obj/item/stock_parts/scanning_module, /obj/item/stock_parts/manipulator, /obj/item/stock_parts/micro_laser, /obj/item/stock_parts/matter_bin)
 
 /datum/export/t2
-	cost = 2
+	cost = 20
 	unit_name = "upgraded stock part"
 	export_types = list(/obj/item/stock_parts/capacitor/adv, /obj/item/stock_parts/scanning_module/adv, /obj/item/stock_parts/manipulator/nano, /obj/item/stock_parts/micro_laser/high, /obj/item/stock_parts/matter_bin/adv)
 
 /datum/export/t3
-	cost = 3
+	cost = 30
 	unit_name = "advanced stock part"
 	export_types = list(/obj/item/stock_parts/capacitor/super, /obj/item/stock_parts/scanning_module/phasic, /obj/item/stock_parts/manipulator/pico, /obj/item/stock_parts/micro_laser/ultra, /obj/item/stock_parts/matter_bin/super)
 
 /datum/export/t4
-	cost = 4
+	cost = 50
 	unit_name = "blue space stock part"
 	export_types = list(/obj/item/stock_parts/capacitor/quadratic, /obj/item/stock_parts/scanning_module/triphasic, /obj/item/stock_parts/manipulator/femto, /obj/item/stock_parts/micro_laser/quadultra, /obj/item/stock_parts/matter_bin/bluespace)
 
@@ -87,17 +87,17 @@
 	export_types = list(/obj/item/stock_parts/cell/super, /obj/item/stock_parts/cell/hyper)
 
 /datum/export/cellbs
-	cost = 25
+	cost = 200
 	unit_name = "bluespace power cell"
 	export_types = list(/obj/item/stock_parts/cell/bluespace)
 
 /datum/export/cellyellow
-	cost = 200
+	cost = 400
 	unit_name = "slime power cell"
 	export_types = list(/obj/item/stock_parts/cell/high/slime)
 
 /datum/export/cellyellowhyper
-	cost = 1200 //Takes a lot to make and is really good
+	cost = 1800 //Takes a lot to make and is really good
 	unit_name = "hyper slime power cell"
 	export_types = list(/obj/item/stock_parts/cell/high/slime/hypercharged)
 

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -97,8 +97,8 @@
 	export_types = list(/obj/item/stock_parts/cell/high/slime)
 
 /datum/export/cellyellowhyper
-	cost = 1800 //Takes a lot to make and is really good
-	unit_name = "hyper slime power cell"
+	cost = 1800 //Takes a lot to make and is really good //Skyrat edit
+	unit_name = "hypercharged power cell" //Skyrat edit
 	export_types = list(/obj/item/stock_parts/cell/high/slime/hypercharged)
 
 //Glass working stuff

--- a/code/modules/cargo/exports/parts.dm
+++ b/code/modules/cargo/exports/parts.dm
@@ -44,22 +44,22 @@
 	include_subtypes = TRUE
 
 /datum/export/t1
-	cost = 10
+	cost = 10 //Skyrat edit
 	unit_name = "basic stock part"
 	export_types = list(/obj/item/stock_parts/capacitor, /obj/item/stock_parts/scanning_module, /obj/item/stock_parts/manipulator, /obj/item/stock_parts/micro_laser, /obj/item/stock_parts/matter_bin)
 
 /datum/export/t2
-	cost = 20
+	cost = 20 //Skyrat edit
 	unit_name = "upgraded stock part"
 	export_types = list(/obj/item/stock_parts/capacitor/adv, /obj/item/stock_parts/scanning_module/adv, /obj/item/stock_parts/manipulator/nano, /obj/item/stock_parts/micro_laser/high, /obj/item/stock_parts/matter_bin/adv)
 
 /datum/export/t3
-	cost = 30
+	cost = 30 //Skyrat edit
 	unit_name = "advanced stock part"
 	export_types = list(/obj/item/stock_parts/capacitor/super, /obj/item/stock_parts/scanning_module/phasic, /obj/item/stock_parts/manipulator/pico, /obj/item/stock_parts/micro_laser/ultra, /obj/item/stock_parts/matter_bin/super)
 
 /datum/export/t4
-	cost = 50
+	cost = 50 //Skyrat edit
 	unit_name = "blue space stock part"
 	export_types = list(/obj/item/stock_parts/capacitor/quadratic, /obj/item/stock_parts/scanning_module/triphasic, /obj/item/stock_parts/manipulator/femto, /obj/item/stock_parts/micro_laser/quadultra, /obj/item/stock_parts/matter_bin/bluespace)
 
@@ -87,12 +87,12 @@
 	export_types = list(/obj/item/stock_parts/cell/super, /obj/item/stock_parts/cell/hyper)
 
 /datum/export/cellbs
-	cost = 200
+	cost = 200 //Skyrat edit
 	unit_name = "bluespace power cell"
 	export_types = list(/obj/item/stock_parts/cell/bluespace)
 
 /datum/export/cellyellow
-	cost = 400
+	cost = 400 //Skyrat edit
 	unit_name = "slime power cell"
 	export_types = list(/obj/item/stock_parts/cell/high/slime)
 

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -68,13 +68,13 @@
 
 // Basic tools
 /datum/export/tool/basicmining
-	cost = 30
+	cost = 50
 	unit_name = "basic mining tool"
 	export_types = list(/obj/item/pickaxe, /obj/item/pickaxe/mini, /obj/item/shovel, /obj/item/resonator)
 	include_subtypes = FALSE
 
 /datum/export/tool/upgradedmining
-	cost = 80
+	cost = 125
 	unit_name = "mining tool"
 	export_types = list(/obj/item/pickaxe/silver, /obj/item/pickaxe/drill, /obj/item/gun/energy/plasmacutter, /obj/item/resonator/upgraded)
 	include_subtypes = FALSE

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -68,19 +68,19 @@
 
 // Basic tools
 /datum/export/tool/basicmining
-	cost = 50
+	cost = 50 //Skyrat edit
 	unit_name = "basic mining tool"
 	export_types = list(/obj/item/pickaxe, /obj/item/pickaxe/mini, /obj/item/shovel, /obj/item/resonator)
 	include_subtypes = FALSE
 
 /datum/export/tool/upgradedmining
-	cost = 125
+	cost = 125 //Skyrat edit
 	unit_name = "mining tool"
 	export_types = list(/obj/item/pickaxe/silver, /obj/item/pickaxe/drill, /obj/item/gun/energy/plasmacutter, /obj/item/resonator/upgraded)
 	include_subtypes = FALSE
 
 /datum/export/tool/advdmining
-	cost = 150
+	cost = 150 //Skyrat edit
 	unit_name = "advanced mining tool"
 	export_types = list(/obj/item/pickaxe/diamond, /obj/item/pickaxe/drill/diamonddrill, /obj/item/pickaxe/drill/jackhammer, /obj/item/gun/energy/plasmacutter/adv)
 	include_subtypes = FALSE

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -4,85 +4,85 @@
 	include_subtypes = FALSE
 
 /datum/export/weapon/makeshift_shield
-	cost = 30
+	cost = 250
 	unit_name = "unknown shield"
 	export_types = list(/obj/item/shield/riot, /obj/item/shield/riot/roman, /obj/item/shield/riot/buckler, /obj/item/shield/makeshift)
 
 /datum/export/weapon/riot_shield
-	cost = 50
+	cost = 250
 	unit_name = "riot shield"
 	export_types = list(/obj/item/shield/riot, /obj/item/shield/riot/tower)
 
 /datum/export/weapon/riot_shield
-	cost = 70
+	cost = 350
 	unit_name = "flash shield"
 	export_types = list(/obj/item/assembly/flash/shield)
 
 /datum/export/weapon/tele_shield
-	cost = 100
+	cost = 650
 	unit_name = "tele shield"
 	export_types = list(/obj/item/shield/riot/tele, /obj/item/shield/energy)
 
 /datum/export/weapon/baton
-	cost = 100
+	cost = 850
 	unit_name = "stun baton"
 	export_types = list(/obj/item/melee/baton)
 	exclude_types = list(/obj/item/melee/baton/cattleprod)
 	include_subtypes = TRUE
 
 /datum/export/weapon/knife
-	cost = 100
+	cost = 950
 	unit_name = "combat knife"
 	export_types = list(/obj/item/kitchen/knife/combat)
 
 /datum/export/weapon/taser
-	cost = 200
+	cost = 500
 	unit_name = "advanced taser"
 	export_types = list(/obj/item/gun/energy/e_gun/advtaser)
 
 /datum/export/weapon/laser
-	cost = 200
+	cost = 800
 	unit_name = "laser gun"
 	export_types = list(/obj/item/gun/energy/laser)
 
 /datum/export/weapon/disabler
-	cost = 50
+	cost = 300
 	unit_name = "disabler"
 	export_types = list(/obj/item/gun/energy/disabler)
 
 /datum/export/weapon/energy_gun
-	cost = 200
+	cost = 500
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 
 /datum/export/weapon/wt550
-	cost = 130
+	cost = 1250
 	unit_name = "WT-550 automatic rifle"
 	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
 
 /datum/export/weapon/shotgun
-	cost = 200
+	cost = 4000
 	unit_name = "combat shotgun"
 	export_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
 
 /datum/export/weapon/flashbang
-	cost = 5
+	cost = 50
 	unit_name = "flashbang grenade"
 	export_types = list(/obj/item/grenade/flashbang)
 
 /datum/export/weapon/teargas
-	cost = 5
+	cost = 50
 	unit_name = "tear gas grenade"
 	export_types = list(/obj/item/grenade/chem_grenade/teargas)
 
 /datum/export/weapon/flash
-	cost = 5
+	cost = 50
 	unit_name = "handheld flash"
 	export_types = list(/obj/item/assembly/flash)
 	include_subtypes = TRUE
 
 /datum/export/weapon/handcuffs
-	cost = 3
+	cost = 30
 	unit_name = "pair"
 	message = "of handcuffs"
 	export_types = list(/obj/item/restraints/handcuffs)
@@ -92,18 +92,18 @@
 //////////////
 
 /datum/export/weapon/lasercarbine
-	cost = 120
+	cost = 500
 	unit_name = "laser carbine"
 	export_types = list(/obj/item/gun/energy/laser/carbine)
 	include_subtypes = TRUE
 
 /datum/export/weapon/teslagun
-	cost = 130
+	cost = 900
 	unit_name = "tesla revolver"
 	export_types = list(/obj/item/gun/energy/tesla_revolver)
 
 /datum/export/weapon/aeg
-	cost = 200 //Endless power
+	cost = 1000 //Endless power
 	unit_name = "advance engery gun"
 	export_types = list(/obj/item/gun/energy/e_gun/nuclear)
 
@@ -113,7 +113,7 @@
 	export_types = list(/obj/item/gun/energy/decloner)
 
 /datum/export/weapon/ntsniper
-	cost = 500
+	cost = 1500
 	unit_name = "beam rifle"
 	export_types = list(/obj/item/gun/energy/beam_rifle)
 
@@ -134,7 +134,7 @@
 	export_types = list(/obj/item/gun/energy/floragun)
 
 /datum/export/weapon/xraygun
-	cost = 300 //Wall hacks
+	cost = 1300 //Wall hacks
 	unit_name = "x ray gun"
 	export_types = list(/obj/item/gun/energy/xray)
 
@@ -145,7 +145,7 @@
 	export_types = list(/obj/item/gun/energy/ionrifle/carbine)
 
 /datum/export/weapon/largeebow
-	cost = 500
+	cost = 1500
 	unit_name = "crossbow"
 	export_types = list(/obj/item/gun/energy/kinetic_accelerator/crossbow/large)
 
@@ -155,7 +155,7 @@
 	export_types = list(/obj/item/grenade/chem_grenade/large)
 
 /datum/export/weapon/gravworm
-	cost = 150
+	cost = 1000
 	unit_name = "bluespace weapon"
 	export_types = list(/obj/item/gun/energy/wormhole_projector, /obj/item/gun/energy/gravity_gun)
 
@@ -174,12 +174,12 @@
 /////////////////
 
 /datum/export/weapon/wtammo
-	cost = 15
+	cost = 500
 	unit_name = "WT-550 automatic rifle ammo"
 	export_types = list(/obj/item/ammo_box/magazine/wt550m9, /obj/item/ammo_box/magazine/wt550m9/wtrubber)
 
 /datum/export/weapon/wtammo/advanced
-	cost = 45
+	cost = 550
 	unit_name = "advanced WT-550 automatic rifle ammo"
 	export_types = list( /obj/item/ammo_box/magazine/wt550m9/wtap,  /obj/item/ammo_box/magazine/wt550m9/wttx, /obj/item/ammo_box/magazine/wt550m9/wtic)
 
@@ -229,23 +229,23 @@
 /////////////////////////
 
 /datum/export/weapon/pistol
-	cost = 120
+	cost = 1250
 	unit_name = "illegal firearm"
 	export_types = list(/obj/item/gun/ballistic/automatic/pistol)
 
 /datum/export/weapon/revolver
-	cost = 200
+	cost = 4000
 	unit_name = "large handgun"
 	export_types = list(/obj/item/gun/ballistic/revolver)
 	exclude_types = list(/obj/item/gun/ballistic/revolver/russian, /obj/item/gun/ballistic/revolver/doublebarrel)
 
 /datum/export/weapon/rocketlauncher
-	cost = 1000
+	cost = 8000
 	unit_name = "rocketlauncher"
 	export_types = list(/obj/item/gun/ballistic/rocketlauncher)
 
 /datum/export/weapon/antitank
-	cost = 300
+	cost = 2500
 	unit_name = "hand cannon"
 	export_types = list(/obj/item/gun/ballistic/automatic/pistol/antitank/syndicate)
 
@@ -255,7 +255,7 @@
 	export_types = list(/obj/item/pneumatic_cannon/pie/selfcharge, /obj/item/shield/energy/bananium, /obj/item/melee/transforming/energy/sword/bananium, )
 
 /datum/export/weapon/bulldog
-	cost = 400
+	cost = 4500
 	unit_name = "drum loaded shotgun"
 	export_types = list(/obj/item/gun/ballistic/automatic/shotgun/bulldog)
 
@@ -290,12 +290,12 @@
 	export_types = list(/obj/item/clothing/gloves/fingerless/pugilist/rapid)
 
 /datum/export/weapon/l6
-	cost = 500
+	cost = 5000
 	unit_name = "law 6 saw"
 	export_types = list(/obj/item/gun/ballistic/automatic/l6_saw)
 
 /datum/export/weapon/m90
-	cost = 400
+	cost = 4800
 	unit_name = "assault class weapon"
 	export_types = list(/obj/item/gun/ballistic/automatic/m90)
 
@@ -305,12 +305,12 @@
 	export_types = list(/obj/item/melee/powerfist)
 
 /datum/export/weapon/sniper
-	cost = 750
+	cost = 7500
 	unit_name = ".50 sniper"
 	export_types = list(/obj/item/gun/ballistic/automatic/sniper_rifle/syndicate)
 
 /datum/export/weapon/ebow
-	cost = 600
+	cost = 1600
 	unit_name = "mini crossbow"
 	export_types = list(/obj/item/gun/energy/kinetic_accelerator/crossbow)
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -4,69 +4,69 @@
 	include_subtypes = FALSE
 
 /datum/export/weapon/makeshift_shield
-	cost = 250
+	cost = 250 //Skyrat edit
 	unit_name = "unknown shield"
 	export_types = list(/obj/item/shield/riot, /obj/item/shield/riot/roman, /obj/item/shield/riot/buckler, /obj/item/shield/makeshift)
 
 /datum/export/weapon/riot_shield
-	cost = 250
+	cost = 250 //Skyrat edit
 	unit_name = "riot shield"
 	export_types = list(/obj/item/shield/riot, /obj/item/shield/riot/tower)
 
 /datum/export/weapon/riot_shield
-	cost = 350
+	cost = 350 //Skyrat edit
 	unit_name = "flash shield"
 	export_types = list(/obj/item/assembly/flash/shield)
 
 /datum/export/weapon/tele_shield
-	cost = 650
+	cost = 650 //Skyrat edit
 	unit_name = "tele shield"
 	export_types = list(/obj/item/shield/riot/tele, /obj/item/shield/energy)
 
 /datum/export/weapon/baton
-	cost = 850
+	cost = 850 //Skyrat edit
 	unit_name = "stun baton"
 	export_types = list(/obj/item/melee/baton)
 	exclude_types = list(/obj/item/melee/baton/cattleprod)
 	include_subtypes = TRUE
 
 /datum/export/weapon/knife
-	cost = 950
+	cost = 950 //Skyrat edit
 	unit_name = "combat knife"
 	export_types = list(/obj/item/kitchen/knife/combat)
 
 /datum/export/weapon/taser
-	cost = 500
+	cost = 500 //Skyrat edit
 	unit_name = "advanced taser"
 	export_types = list(/obj/item/gun/energy/e_gun/advtaser)
 
 /datum/export/weapon/laser
-	cost = 800
+	cost = 800 //Skyrat edit
 	unit_name = "laser gun"
 	export_types = list(/obj/item/gun/energy/laser)
 
 /datum/export/weapon/disabler
-	cost = 300
+	cost = 300 //Skyrat edit
 	unit_name = "disabler"
 	export_types = list(/obj/item/gun/energy/disabler)
 
 /datum/export/weapon/energy_gun
-	cost = 500
+	cost = 500 //Skyrat edit
 	unit_name = "energy gun"
 	export_types = list(/obj/item/gun/energy/e_gun)
 
 /datum/export/weapon/wt550
-	cost = 1250
+	cost = 1250 //Skyrat edit
 	unit_name = "WT-550 automatic rifle"
 	export_types = list(/obj/item/gun/ballistic/automatic/wt550)
 
 /datum/export/weapon/shotgun
-	cost = 4000
+	cost = 4000 //Skyrat edit
 	unit_name = "combat shotgun"
 	export_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
 
 /datum/export/weapon/flashbang
-	cost = 50
+	cost = 50 
 	unit_name = "flashbang grenade"
 	export_types = list(/obj/item/grenade/flashbang)
 
@@ -76,13 +76,13 @@
 	export_types = list(/obj/item/grenade/chem_grenade/teargas)
 
 /datum/export/weapon/flash
-	cost = 10
+	cost = 10 //Skyrat edit
 	unit_name = "handheld flash"
 	export_types = list(/obj/item/assembly/flash)
 	include_subtypes = TRUE
 
 /datum/export/weapon/handcuffs
-	cost = 30
+	cost = 30 //Skyrat edit
 	unit_name = "pair"
 	message = "of handcuffs"
 	export_types = list(/obj/item/restraints/handcuffs)
@@ -92,18 +92,18 @@
 //////////////
 
 /datum/export/weapon/lasercarbine
-	cost = 500
+	cost = 500 //Skyrat edit
 	unit_name = "laser carbine"
 	export_types = list(/obj/item/gun/energy/laser/carbine)
 	include_subtypes = TRUE
 
 /datum/export/weapon/teslagun
-	cost = 900
+	cost = 900 //Skyrat edit
 	unit_name = "tesla revolver"
 	export_types = list(/obj/item/gun/energy/tesla_revolver)
 
 /datum/export/weapon/aeg
-	cost = 1000 //Endless power
+	cost = 1000 //Endless power //Skyrat edit
 	unit_name = "advance engery gun"
 	export_types = list(/obj/item/gun/energy/e_gun/nuclear)
 
@@ -113,7 +113,7 @@
 	export_types = list(/obj/item/gun/energy/decloner)
 
 /datum/export/weapon/ntsniper
-	cost = 1500
+	cost = 1500 //Skyrat edit
 	unit_name = "beam rifle"
 	export_types = list(/obj/item/gun/energy/beam_rifle)
 
@@ -145,7 +145,7 @@
 	export_types = list(/obj/item/gun/energy/ionrifle/carbine)
 
 /datum/export/weapon/largeebow
-	cost = 1500
+	cost = 1500 //Skyrat edit
 	unit_name = "crossbow"
 	export_types = list(/obj/item/gun/energy/kinetic_accelerator/crossbow/large)
 
@@ -174,12 +174,12 @@
 /////////////////
 
 /datum/export/weapon/wtammo
-	cost = 100
+	cost = 100 //Skyrat edit
 	unit_name = "WT-550 automatic rifle ammo"
 	export_types = list(/obj/item/ammo_box/magazine/wt550m9, /obj/item/ammo_box/magazine/wt550m9/wtrubber)
 
 /datum/export/weapon/wtammo/advanced
-	cost = 150
+	cost = 150 //Skyrat edit
 	unit_name = "advanced WT-550 automatic rifle ammo"
 	export_types = list( /obj/item/ammo_box/magazine/wt550m9/wtap,  /obj/item/ammo_box/magazine/wt550m9/wttx, /obj/item/ammo_box/magazine/wt550m9/wtic)
 
@@ -229,23 +229,23 @@
 /////////////////////////
 
 /datum/export/weapon/pistol
-	cost = 1250
+	cost = 1250 //Skyrat edit
 	unit_name = "illegal firearm"
 	export_types = list(/obj/item/gun/ballistic/automatic/pistol)
 
 /datum/export/weapon/revolver
-	cost = 4000
+	cost = 4000 //Skyrat edit
 	unit_name = "large handgun"
 	export_types = list(/obj/item/gun/ballistic/revolver)
 	exclude_types = list(/obj/item/gun/ballistic/revolver/russian, /obj/item/gun/ballistic/revolver/doublebarrel)
 
 /datum/export/weapon/rocketlauncher
-	cost = 8000
+	cost = 8000 //Skyrat edit
 	unit_name = "rocketlauncher"
 	export_types = list(/obj/item/gun/ballistic/rocketlauncher)
 
 /datum/export/weapon/antitank
-	cost = 2500
+	cost = 2500 //Skyrat edit
 	unit_name = "hand cannon"
 	export_types = list(/obj/item/gun/ballistic/automatic/pistol/antitank/syndicate)
 
@@ -255,12 +255,12 @@
 	export_types = list(/obj/item/pneumatic_cannon/pie/selfcharge, /obj/item/shield/energy/bananium, /obj/item/melee/transforming/energy/sword/bananium, )
 
 /datum/export/weapon/bulldog
-	cost = 4500
+	cost = 4500 //Skyrat edit
 	unit_name = "drum loaded shotgun"
 	export_types = list(/obj/item/gun/ballistic/automatic/shotgun/bulldog)
 
 /datum/export/weapon/smg
-	cost = 350
+	cost = 3500 //Skyrat edit
 	unit_name = "automatic c-20r"
 	export_types = list(/obj/item/gun/ballistic/automatic/c20r)
 
@@ -290,12 +290,12 @@
 	export_types = list(/obj/item/clothing/gloves/fingerless/pugilist/rapid)
 
 /datum/export/weapon/l6
-	cost = 5000
+	cost = 5000 //Skyrat edit
 	unit_name = "law 6 saw"
 	export_types = list(/obj/item/gun/ballistic/automatic/l6_saw)
 
 /datum/export/weapon/m90
-	cost = 4800
+	cost = 4800 //Skyrat edit
 	unit_name = "assault class weapon"
 	export_types = list(/obj/item/gun/ballistic/automatic/m90)
 
@@ -305,12 +305,12 @@
 	export_types = list(/obj/item/melee/powerfist)
 
 /datum/export/weapon/sniper
-	cost = 7500
+	cost = 7500 //Skyrat edit
 	unit_name = ".50 sniper"
 	export_types = list(/obj/item/gun/ballistic/automatic/sniper_rifle/syndicate)
 
 /datum/export/weapon/ebow
-	cost = 1600
+	cost = 1600 //Skyrat edit
 	unit_name = "mini crossbow"
 	export_types = list(/obj/item/gun/energy/kinetic_accelerator/crossbow)
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -134,7 +134,7 @@
 	export_types = list(/obj/item/gun/energy/floragun)
 
 /datum/export/weapon/xraygun
-	cost = 1300 //Wall hacks
+	cost = 1300 //Yeah kid, you're banned. //Skyrat edit
 	unit_name = "x ray gun"
 	export_types = list(/obj/item/gun/energy/xray)
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -76,7 +76,7 @@
 	export_types = list(/obj/item/grenade/chem_grenade/teargas)
 
 /datum/export/weapon/flash
-	cost = 50
+	cost = 10
 	unit_name = "handheld flash"
 	export_types = list(/obj/item/assembly/flash)
 	include_subtypes = TRUE
@@ -174,12 +174,12 @@
 /////////////////
 
 /datum/export/weapon/wtammo
-	cost = 500
+	cost = 100
 	unit_name = "WT-550 automatic rifle ammo"
 	export_types = list(/obj/item/ammo_box/magazine/wt550m9, /obj/item/ammo_box/magazine/wt550m9/wtrubber)
 
 /datum/export/weapon/wtammo/advanced
-	cost = 550
+	cost = 150
 	unit_name = "advanced WT-550 automatic rifle ammo"
 	export_types = list( /obj/item/ammo_box/magazine/wt550m9/wtap,  /obj/item/ammo_box/magazine/wt550m9/wttx, /obj/item/ammo_box/magazine/wt550m9/wtic)
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -155,7 +155,7 @@
 	export_types = list(/obj/item/grenade/chem_grenade/large)
 
 /datum/export/weapon/gravworm
-	cost = 1000
+	cost = 1000 //skyrat edit.........
 	unit_name = "bluespace weapon"
 	export_types = list(/obj/item/gun/energy/wormhole_projector, /obj/item/gun/energy/gravity_gun)
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -66,12 +66,12 @@
 	export_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
 
 /datum/export/weapon/flashbang
-	cost = 50 
+	cost = 50 //Skyrat edit
 	unit_name = "flashbang grenade"
 	export_types = list(/obj/item/grenade/flashbang)
 
 /datum/export/weapon/teargas
-	cost = 50
+	cost = 50 //Skyrat edit
 	unit_name = "tear gas grenade"
 	export_types = list(/obj/item/grenade/chem_grenade/teargas)
 


### PR DESCRIPTION
## About The Pull Request
This PR increases a lot of low prices and makes cargo exports more profitable, as to break the crypto and glassworking meta and make the job fun again.

(27/7) This PR also adds some fluff to bounties that fit our lore!

## Why It's Good For The Game

Our cargo system (Citadel Code) has been relentlessly nerfed to no end, while all other departments receive buffs. This results in every job being able to complete their shit one hour into the shift, except cargo though! Unless you abuse glassworking or crypto, you'll be stuck in under a hundred thousand for the entire shift if anyone buys anything!

(27/7) Having bounties not always say "NT this" "NT that" gives the vibe that you're not all NT employed.

## Changelog
:cl:
tweak: Buffed weapon and equipment exports
tweak: Buffed a lot of science bounties
tweak: Buffed reagent bounties
tweak: Changed heart from 3k > 5k
tweak: Changed Adamantine, Documents and Xeno Organ bounties back to pre-nerf value.
tweak: Made material values make more sense.
tweak: Statues are now more expensive.
tweak: REVIEW TWEAK: 4.6x30mm mag 500 > 100 / 4.6x30mm [IN/AP/TX] mag 550 > 150
tweak: Parts are now more expensive, and so are cells.
tweak: Medical research (Robotic organs, limbs) has slightly higher export values.
tweak: Mech weapons and equipment have slightly higher export values.
tweak: Buffed tool exports.
tweak: Changed some descriptions for bounties
/:cl: