### PR TITLE
Nerfs manlets

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -678,7 +678,7 @@ BODY_SIZE_MAX 1
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.
 ## To disable, just make sure the value is lower than 'body_size_min'
-THRESHOLD_BODY_SIZE_SLOWDOWN 1
+THRESHOLD_BODY_SIZE_SLOWDOWN 0.99
 
 ## Multiplier used in the smaller strides slowdown calculation.
 ## Doesn't apply to floating or crawling mobs.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -678,7 +678,7 @@ BODY_SIZE_MAX 1
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.
 ## To disable, just make sure the value is lower than 'body_size_min'
-THRESHOLD_BODY_SIZE_SLOWDOWN 0.85
+THRESHOLD_BODY_SIZE_SLOWDOWN 1
 
 ## Multiplier used in the smaller strides slowdown calculation.
 ## Doesn't apply to floating or crawling mobs.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -678,11 +678,11 @@ BODY_SIZE_MAX 1
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.
 ## To disable, just make sure the value is lower than 'body_size_min'
-THRESHOLD_BODY_SIZE_SLOWDOWN 0.99
+THRESHOLD_BODY_SIZE_SLOWDOWN 1
 
 ## Multiplier used in the smaller strides slowdown calculation.
 ## Doesn't apply to floating or crawling mobs.
-BODY_SIZE_SLOWDOWN_MULTIPLIER 0.25
+BODY_SIZE_SLOWDOWN_MULTIPLIER 0.4
 
 ## Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 ALLOW_CUSTOM_SKINTONES


### PR DESCRIPTION
## About The Pull Request

Increased the slowdown multiplier from 0.25 to 0.4

Slowdown threshold changed from below 85 to below 100

## Why It's Good For The Game

TLDR i can join on the server and put 85% sprite size and get no fucking punishment for it, it's an inherent advantage, one which i have used and abused because i can. What are the admins gonna do? Ban me for using a character setup option as it was designed?

The 0.25 slowdown multiplier is just not punishing enough and hardly makes a difference even while <85%. This small increase to 0.4 is significant but necessary if we want to keep giving people such a powerful character setup option.

## Changelog
:cl:
fix: Manlets are no longer a free character setup powergame strategy. Speed maluses always apply when below 100% sprite size.
/:cl: