### PR TITLE
[WORLDSTAR] Ash walkers are no longer able to mark with crushers.

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -101,7 +101,7 @@
 		T.add_to(src, user)
 	if(!wielded)
 		return
-	if(!proximity_flag && charged && !HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))//Mark a target, or mine a tile. //skyrat edit - fuck ashwalkers
+	if(!proximity_flag && charged && !HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))//Mark a target, or mine a tile. //skyrat edit - chunky fingers cannot mark with crushers
 		var/turf/proj_turf = user.loc
 		if(!isturf(proj_turf))
 			return

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -101,7 +101,7 @@
 		T.add_to(src, user)
 	if(!wielded)
 		return
-	if(!proximity_flag && charged)//Mark a target, or mine a tile.
+	if(!proximity_flag && charged && !HAS_TRAIT(user, TRAIT_CHUNKYFINGERS))//Mark a target, or mine a tile. //skyrat edit - fuck ashwalkers
 		var/turf/proj_turf = user.loc
 		if(!isturf(proj_turf))
 			return


### PR DESCRIPTION
## About The Pull Request

Title. Nothing else to say.

## Why It's Good For The Game

Why are they unable to use PKAs but able to use crushers, which are just as good and let them easily kill megafauna thus just becoming a redundant miner role? Fuck that. Return to tradition.

## Changelog
:cl:
balance: Ash walkers are no longer able to mark mobs with crushers. Go genocide the necropolis' gods now, heretic.
/:cl:
