### PR TITLE
And justice for all (greytides) - Making guncrafting easier and faster

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -27,20 +27,20 @@
 
 /obj/item/weaponcrafting/improvised_parts/rifle_receiver
 	name = "rifle receiver"
-	desc = "A crudely constructed receiver to create an improvised bolt-action breechloaded rifle."  // removed some text implying that the item had more uses than it does
+	desc = "A crudely constructed receiver to create an improvised bolt-action breechloaded rifle. Could probably still be used to create some other weapons."
 	icon_state = "receiver_rifle"
 	w_class = WEIGHT_CLASS_SMALL
 
 
 /obj/item/weaponcrafting/improvised_parts/shotgun_receiver
-	name = "shotgun reciever"
-	desc = "An improvised receiver to create a break-action breechloaded shotgun."  // removed some text implying that the item had more uses than it does
+	name = "shotgun receiver"
+	desc = "An improvised receiver to create a break-action breechloaded shotgun. Could probably still be used to create some other weapons."
 	icon_state = "receiver_shotgun"
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/weaponcrafting/improvised_parts/pistol_receiver	
 	name = "pistol receiver"	
-	desc = "A receiver to connect house and connects all the parts to make an improvised pistol."	
+	desc = "A receiver to connect house and connects all the parts to make an improvised pistol. Could probably still be used to create some other weapons."	
 	icon_state = "receiver_pistol"	
 	w_class = WEIGHT_CLASS_SMALL	
 
@@ -50,7 +50,6 @@
 	icon_state = "laser_assembly"
 
 // MISC
-
 /obj/item/weaponcrafting/improvised_parts/trigger_assembly
 	name = "firearm trigger assembly"
 	desc = "A modular trigger assembly with a firing pin, this can be used to make a whole bunch of improvised firearss."
@@ -66,17 +65,17 @@
 
 /obj/item/weaponcrafting/improvised_parts/barrel_rifle	
 	name = "rifle barrel"	
-	desc = "A pipe with a diameter just the right size to fire 7.62 rounds out of."	
+	desc = "A pipe with a diameter just the right size to fire 7.62 rounds out of. Could probably still be used to create some other weapons."	
 	icon_state = "barrel_rifle"	
 
 /obj/item/weaponcrafting/improvised_parts/barrel_shotgun	
 	name = "shotgun barrel"	
-	desc = "A twenty bore shotgun barrel."	
+	desc = "A twelve gauge bore shotgun barrel. Could probably still be used to create some other weapons."	
 	icon_state = "barrel_shotgun"	
 
 /obj/item/weaponcrafting/improvised_parts/barrel_pistol	
 	name = "pistol barrel"	
-	desc = "A pipe with a small diameter and some holes finely cut into it. It fits .32 ACP bullets. Probably."	
+	desc = "A pipe with a small diameter and some holes finely cut into it. It fits .32 ACP bullets. Probably. Could probably still be used to create some other weapons."	
 	icon_state = "barrel_pistol"	
 	w_class = WEIGHT_CLASS_SMALL
 

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -1,4 +1,4 @@
-k// PARTS //
+// PARTS //
 /obj/item/weaponcrafting
 	icon = 'icons/obj/improvised.dmi'
 
@@ -8,61 +8,33 @@ k// PARTS //
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 6)
 	icon_state = "riflestock"
 
-/obj/item/weaponcrafting/string
-	name = "wound thread"
-	desc = "A long piece of thread with some resemblance to cable coil."
+/obj/item/weaponcrafting/durathread_string
+	name = "durathread string"
+	desc = "A long piece of durathread with some resemblance to cable coil."
 	icon_state = "durastring"
 
 ////////////////////////////////
-// KAT IMPROVISED WEAPON PARTS//
+// IMPROVISED WEAPON PARTS//
 ////////////////////////////////
 
 /obj/item/weaponcrafting/improvised_parts
-	name = "Eerie bunch of coloured dots."
-	desc = "You feel the urge to report to Central that the parent type of guncrafting, which should never appear in this reality, has appeared. Whatever that means."
+	name = "Debug Improvised Gun Part"
+	desc = "A badly coded gun part. You should report coders if you see this."
 	icon = 'icons/obj/guns/gun_parts.dmi'
 	icon_state = "palette"
-
-// BARRELS
-
-/obj/item/weaponcrafting/improvised_parts/barrel_rifle
-	name = "rifle barrel"
-	desc = "A pipe with a diameter just the right size to fire 7.62 rounds out of."
-	icon_state = "barrel_rifle"
-
-/obj/item/weaponcrafting/improvised_parts/barrel_shotgun
-	name = "shotgun barrel"
-	desc = "A twenty bore shotgun barrel."
-	icon_state = "barrel_shotgun"
-
-/obj/item/weaponcrafting/improvised_parts/barrel_pistol
-	name = "pistol barrel"
-	desc = "A pipe with a small diameter and some holes finely cut into it. It fits .32 ACP bullets. Probably."
-	icon_state = "barrel_pistol"
-	w_class = WEIGHT_CLASS_SMALL
 
 // RECEIVERS
 
 /obj/item/weaponcrafting/improvised_parts/rifle_receiver
-	name = "bolt action receiver"
-	desc = "A crudely constructed receiver to create an improvised bolt-action breechloaded rifle. It's generic enough to modify to create other rifles, potentially."
+	name = "rifle receiver"
+	desc = "A crudely constructed receiver to create an improvised bolt-action breechloaded rifle."  // removed some text implying that the item had more uses than it does
 	icon_state = "receiver_rifle"
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/weaponcrafting/improvised_parts/pistol_receiver
-	name = "pistol receiver"
-	desc = "A receiver to connect house and connects all the parts to make an improvised pistol."
-	icon_state = "receiver_pistol"
-	w_class = WEIGHT_CLASS_SMALL
-
-/obj/item/weaponcrafting/improvised_parts/laser_receiver
-	name = "energy emitter assembly"
-	desc = "A mixture of components haphazardly wired together to form an energy emitter."
-	icon_state = "laser_assembly"
 
 /obj/item/weaponcrafting/improvised_parts/shotgun_receiver
-	name = "break-action assembly"
-	desc = "An improvised receiver to create a break-action breechloaded shotgun. Parts of this are still useful if you want to make another type of shotgun, however."
+	name = "shotgun reciever"
+	desc = "An improvised receiver to create a break-action breechloaded shotgun."  // removed some text implying that the item had more uses than it does
 	icon_state = "receiver_shotgun"
 	w_class = WEIGHT_CLASS_SMALL
 
@@ -78,15 +50,3 @@ k// PARTS //
 	name = "wooden firearm body"
 	desc = "A crudely fashioned wooden body to help keep higher calibre improvised weapons from blowing themselves apart."
 	icon_state = "wooden_body"
-
-/obj/item/weaponcrafting/improvised_parts/wooden_grip
-	name = "wooden pistol grip"
-	desc = "A nice wooden grip hollowed out for pistol magazines."
-	icon_state = "wooden_pistolgrip"
-	w_class = WEIGHT_CLASS_SMALL
-
-/obj/item/weaponcrafting/improvised_parts/makeshift_lens
-	name = "makeshift focusing lens"
-	desc = "A properly made lens made with actual glassworking tools would perform much better, but this will have to do."
-	icon_state = "focusing_lens"
-	w_class = WEIGHT_CLASS_TINY

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -38,6 +38,17 @@
 	icon_state = "receiver_shotgun"
 	w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/weaponcrafting/improvised_parts/pistol_receiver	
+	name = "pistol receiver"	
+	desc = "A receiver to connect house and connects all the parts to make an improvised pistol."	
+	icon_state = "receiver_pistol"	
+	w_class = WEIGHT_CLASS_SMALL	
+
+/obj/item/weaponcrafting/improvised_parts/laser_receiver	
+	name = "energy emitter assembly"	
+	desc = "A mixture of components haphazardly wired together to form an energy emitter."	
+	icon_state = "laser_assembly"
+
 // MISC
 
 /obj/item/weaponcrafting/improvised_parts/trigger_assembly
@@ -68,3 +79,16 @@
 	desc = "A pipe with a small diameter and some holes finely cut into it. It fits .32 ACP bullets. Probably."	
 	icon_state = "barrel_pistol"	
 	w_class = WEIGHT_CLASS_SMALL
+
+// Misc
+/obj/item/weaponcrafting/improvised_parts/wooden_grip	
+	name = "wooden pistol grip"	
+	desc = "A nice wooden grip hollowed out for pistol magazines."	
+	icon_state = "wooden_pistolgrip"	
+	w_class = WEIGHT_CLASS_SMALL	
+
+/obj/item/weaponcrafting/improvised_parts/makeshift_lens	
+	name = "makeshift focusing lens"	
+	desc = "A properly made lens made with actual glassworking tools would perform much better, but this will have to do."	
+	icon_state = "focusing_lens"	
+	w_class = WEIGHT_CLASS_TINY

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -50,3 +50,21 @@
 	name = "wooden firearm body"
 	desc = "A crudely fashioned wooden body to help keep higher calibre improvised weapons from blowing themselves apart."
 	icon_state = "wooden_body"
+
+// BARRELS	
+
+/obj/item/weaponcrafting/improvised_parts/barrel_rifle	
+	name = "rifle barrel"	
+	desc = "A pipe with a diameter just the right size to fire 7.62 rounds out of."	
+	icon_state = "barrel_rifle"	
+
+/obj/item/weaponcrafting/improvised_parts/barrel_shotgun	
+	name = "shotgun barrel"	
+	desc = "A twenty bore shotgun barrel."	
+	icon_state = "barrel_shotgun"	
+
+/obj/item/weaponcrafting/improvised_parts/barrel_pistol	
+	name = "pistol barrel"	
+	desc = "A pipe with a small diameter and some holes finely cut into it. It fits .32 ACP bullets. Probably."	
+	icon_state = "barrel_pistol"	
+	w_class = WEIGHT_CLASS_SMALL

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -303,7 +303,7 @@
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/ilaser/upgraded
-	name = "Improvised Energy Carbine Upgrade"
+	name = "Improvised Energy Carbine Upgrade" //Again: from the skyrat one.
 	result = /obj/item/gun/energy/e_gun/old/improvised/upgraded
 	reqs = list(/obj/item/gun/energy/e_gun/old/improvised = 1,
 				///obj/item/glasswork/glass_base/lens = 1, //requiring glasswork is stupid, insane

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -248,7 +248,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/ishotgun
+/datum/crafting_recipe/ishotgun // smaller and more versatile gun requires some better materials
 	name = "Improvised Shotgun"
 	result = /obj/item/gun/ballistic/revolver/doublebarrel/improvised
 	reqs = list(/obj/item/weaponcrafting/improvised_parts/barrel_shotgun = 1,
@@ -262,13 +262,12 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/irifle
+/datum/crafting_recipe/irifle // larger and less versatile gun, but a bit easier to make since it has no body
 	name = "Improvised Rifle (7.62mm)"
 	result = /obj/item/gun/ballistic/shotgun/boltaction/improvised
 	reqs = list(/obj/item/weaponcrafting/improvised_parts/barrel_rifle = 1,
 				/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1,
 				/obj/item/weaponcrafting/improvised_parts/trigger_assembly = 1,
-				/obj/item/weaponcrafting/improvised_parts/wooden_body = 1,
 				/obj/item/weaponcrafting/stock = 1,
 				/obj/item/stack/packageWrap = 5)
 	tools = list(TOOL_SCREWDRIVER)
@@ -276,29 +275,27 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/ipistol
+/datum/crafting_recipe/ipistol //this weapon is dogshit and i did not want to outright remove it, so instead it's just way easier to craft
 	name = "Improvised Pistol (.32)"
-	result = /obj/item/gun/ballistic/automatic/pistol/improvised/nomag
+	result = /obj/item/gun/ballistic/automatic/pistol/improvised //they come with a magazine
 	reqs = list(/obj/item/weaponcrafting/improvised_parts/barrel_pistol = 1,
 				/obj/item/weaponcrafting/improvised_parts/pistol_receiver = 1,
 				/obj/item/weaponcrafting/improvised_parts/trigger_assembly = 1,
 				/obj/item/weaponcrafting/improvised_parts/wooden_grip = 1,
-				/obj/item/stack/sheet/plastic = 15,
-				/obj/item/stack/sheet/plasteel = 1)
+				/obj/item/stack/sheet/metal = 2)//2 iron, not 1 plasteel, from 15 plastic to 0 plastic
 	tools = list(TOOL_SCREWDRIVER, TOOL_WELDER, TOOL_WIRECUTTER)
 	time = 100
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/ilaser
-	name = "Improvised Energy Gun"
+	name = "Improvised Energy Gun" //To differentiate from the skyrat one. It's redundant and useless, but it's to avoid shitting on Kat's work.
 	result = /obj/item/gun/energy/e_gun/old/improvised
 	reqs = list(/obj/item/weaponcrafting/improvised_parts/laser_receiver = 1,
 				/obj/item/weaponcrafting/improvised_parts/trigger_assembly = 1,
 				/obj/item/weaponcrafting/improvised_parts/makeshift_lens = 1,
 				/obj/item/stock_parts/cell = 1,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/sheet/plasteel = 5,
+				/obj/item/stack/sheet/metal = 5, //5 metal instead of 10, no plasteel
 				/obj/item/stack/cable_coil = 10)
 	tools = list(TOOL_SCREWDRIVER)
 	time = 100
@@ -306,13 +303,16 @@
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/ilaser/upgraded
-	name = "Improvised Energy Gun Upgrade"
+	name = "Improvised Energy Gun (Model A) Upgrade"
 	result = /obj/item/gun/energy/e_gun/old/improvised/upgraded
 	reqs = list(/obj/item/gun/energy/e_gun/old/improvised = 1,
-				/obj/item/glasswork/glass_base/lens = 1,
-				/obj/item/stock_parts/capacitor/quadratic = 2,
-				/obj/item/stock_parts/micro_laser/ultra = 1,
-				/obj/item/stock_parts/cell/bluespace = 1,
+				///obj/item/glasswork/glass_base/lens = 1, //requiring glasswork is stupid, insane
+				/obj/item/weaponcrafting/improvised_parts/barrel_rifle = 1, //we just add a barrel and it automatically becomes powerful because reasons
+				//changed from tier 4s to tier 2s, otherwise just not worth it at all
+				/obj/item/stock_parts/capacitor/adv = 1, //2 to 1
+				/obj/item/stock_parts/micro_laser/high = 1,
+				/obj/item/stock_parts/cell/high = 1,
+				//
 				/obj/item/stack/cable_coil = 5)
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL)
 	time = 100
@@ -445,8 +445,7 @@
 /datum/crafting_recipe/m32acp
 	name = ".32ACP Empty Magazine"
 	result = /obj/item/ammo_box/magazine/m32acp/empty
-	reqs = list(/obj/item/stack/sheet/metal = 3,
-				/obj/item/stack/sheet/plasteel = 1,
+	reqs = list(/obj/item/stack/sheet/metal = 4, //changed plasteel for simply more metal
 				/obj/item/stack/packageWrap = 1)
 	tools = list(TOOL_WELDER,TOOL_SCREWDRIVER)
 	time = 5
@@ -481,7 +480,7 @@
 	name = "Improvised Pistol Barrel"
 	result = /obj/item/weaponcrafting/improvised_parts/barrel_pistol
 	reqs = list(/obj/item/pipe = 1,
-				/obj/item/stack/sheet/plasteel = 1)
+				/obj/item/stack/rods = 1) //mo plasteel, just one pipe and a metal rod
 	tools = list(TOOL_WELDER,TOOL_SAW)
 	time = 150
 	category = CAT_WEAPONRY
@@ -492,8 +491,7 @@
 /datum/crafting_recipe/rifle_receiver
 	name = "Improvised Rifle Receiver"
 	result = /obj/item/weaponcrafting/improvised_parts/rifle_receiver
-	reqs = list(/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/sheet/plasteel = 1)
+	reqs = list(/obj/item/stack/sheet/metal = 5) //no plasteel, lowered the metal necessary to 5
 	tools = list(TOOL_SCREWDRIVER, TOOL_WELDER)
 	time = 50
 	category = CAT_WEAPONRY
@@ -502,8 +500,7 @@
 /datum/crafting_recipe/shotgun_receiver
 	name = "Improvised Shotgun Receiver"
 	result = /obj/item/weaponcrafting/improvised_parts/shotgun_receiver
-	reqs = list(/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/sheet/plasteel = 1)
+	reqs = list(/obj/item/stack/sheet/metal = 5) //no plasteel, necessary metal lowered to 5
 	tools = list(TOOL_SCREWDRIVER, TOOL_WELDER) // Dual wielding has been removed, plasteel is a soft timesink to obtain for most to make mass production harder.
 	time = 50
 	category = CAT_WEAPONRY
@@ -513,7 +510,7 @@
 	name = "Improvised Pistol Receiver"
 	result = /obj/item/weaponcrafting/improvised_parts/pistol_receiver
 	reqs = list(/obj/item/stack/sheet/metal = 5,
-				/obj/item/stack/sheet/plasteel = 1)
+				/obj/item/stack/rods = 1) //no plasteel, replaced with a metal rod instead
 	tools = list(TOOL_SCREWDRIVER, TOOL_WELDER, TOOL_SAW)
 	time = 50
 	category = CAT_WEAPONRY
@@ -522,8 +519,8 @@
 /datum/crafting_recipe/laser_receiver
 	name = "Energy Weapon Assembly"
 	result = /obj/item/weaponcrafting/improvised_parts/laser_receiver
-	reqs = list(/obj/item/stack/sheet/metal = 10,
-				/obj/item/stock_parts/capacitor = 2,
+	reqs = list(/obj/item/stack/sheet/metal = 5, //lowered frrom 10 to 5
+				/obj/item/stock_parts/capacitor = 1, //lowered from 2 to 1
 				/obj/item/stock_parts/micro_laser = 1,
 				/obj/item/assembly/prox_sensor = 1)
 	tools = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL, TOOL_WELDER) // Prox sensor and multitool for the circuit board, welder for extremely ghetto soldering.
@@ -547,7 +544,7 @@
 	name = "Makeshift Lens"
 	result = /obj/item/weaponcrafting/improvised_parts/makeshift_lens
 	reqs = list(/obj/item/stack/sheet/metal = 1,
-				/obj/item/stack/sheet/glass = 2)
+				/obj/item/stack/sheet/glass = 1) //lowered from 2 glass to 1 glass
 	tools = list(TOOL_WELDER) // Glassmaking lets you make non-makeshift lenses.
 	time = 50
 	category = CAT_WEAPONRY

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -192,7 +192,7 @@
 	result =  /obj/item/gun/ballistic/bow/pipe
 	reqs = list(/obj/item/pipe = 5,
 	/obj/item/stack/sheet/plastic = 15,
-	/obj/item/weaponcrafting/string = 5)
+	/obj/item/weaponcrafting/durathread_string = 5)
 	time = 150
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -190,8 +190,7 @@
 /datum/crafting_recipe/pipebow
 	name = "Pipe Bow"
 	result =  /obj/item/gun/ballistic/bow/pipe
-	reqs = list(/obj/item/pipe = 5,
-	/obj/item/stack/sheet/plastic = 15,
+	reqs = list(/obj/item/pipe = 3, //removed the requirement for plastic, 3 pipes instead of 5 - skyrat edit
 	/obj/item/weaponcrafting/durathread_string = 5)
 	time = 150
 	category = CAT_WEAPONRY

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -289,7 +289,7 @@
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/ilaser
-	name = "Improvised Energy Gun" //To differentiate from the skyrat one. It's redundant and useless, but it's to avoid shitting on Kat's work.
+	name = "Improvised Energy Carbine" //To differentiate from the skyrat one. It's redundant and useless, but it's to avoid shitting on Kat's work.
 	result = /obj/item/gun/energy/e_gun/old/improvised
 	reqs = list(/obj/item/weaponcrafting/improvised_parts/laser_receiver = 1,
 				/obj/item/weaponcrafting/improvised_parts/trigger_assembly = 1,
@@ -303,7 +303,7 @@
 	subcategory = CAT_WEAPON
 
 /datum/crafting_recipe/ilaser/upgraded
-	name = "Improvised Energy Gun (Model A) Upgrade"
+	name = "Improvised Energy Carbine Upgrade"
 	result = /obj/item/gun/energy/e_gun/old/improvised/upgraded
 	reqs = list(/obj/item/gun/energy/e_gun/old/improvised = 1,
 				///obj/item/glasswork/glass_base/lens = 1, //requiring glasswork is stupid, insane

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -385,7 +385,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("chemistry bag", /obj/item/storage/bag/chemistry, 4), \
 	new/datum/stack_recipe("bio bag", /obj/item/storage/bag/bio, 4), \
 	null, \
-	new/datum/stack_recipe("string", /obj/item/weaponcrafting/string, 1, time = 10), \
+	new/datum/stack_recipe("durathread string", /obj/item/weaponcrafting/durathread_string, 1, time = 10), \
 	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 6), \
 	new/datum/stack_recipe("rag", /obj/item/reagent_containers/rag, 1), \
 	new/datum/stack_recipe("towel", /obj/item/reagent_containers/rag/towel, 3), \

--- a/modular_skyrat/code/datums/components/crafting/crafting_results/energy_carbine.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/energy_carbine.dm
@@ -1,0 +1,5 @@
+/obj/item/gun/energy/e_gun/old/improvised
+	name = "makeshift energy carbine"
+
+/obj/item/gun/energy/e_gun/old/improvised/upgraded
+	name = "upgraded makeshift energy carbine"

--- a/modular_skyrat/code/datums/components/crafting/crafting_results/shotgun.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/shotgun.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/ballistic/revolver/doublebarrel/improvised
+	projectile_damage_multiplier = 1 //no more nerfing bullshit

--- a/modular_skyrat/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/modular_skyrat/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -6,7 +6,7 @@
 	reqs = list(/obj/item/clothing/suit/armor/laserproof = 1,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/stack/sheet/mineral/diamond = 2,
-				/obj/item/stack/sheet/plasmarglass = 3,
+				/obj/item/stack/sheet/plasmaglass = 3, //plasmarglass is just too much
 				/obj/item/clothing/glasses/hud/security/sunglasses = 1,
 				/obj/item/stock_parts/cell/high = 1)
 	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
@@ -39,23 +39,3 @@
 				/obj/item/clothing/glasses/sunglasses = 1)
 	time = 30
 	category = CAT_CLOTHING
-
-//Power armor (no longer used, see mecha_construction_paths.dm)
-/*
-/datum/crafting_recipe/powerarmor
-	name = "Self-Powered Exoskeleton Rig" //I tried to make it a mecha assembly but that went tits up at every turn so now you get this. Fuck modular, and fuck whoever made mech code.
-	result = /obj/item/clothing/suit/space/hardsuit/powerarmor
-	reqs = list(/obj/item/mecha_parts/part/powerarmor_chassis = 1,
-				/obj/item/mecha_parts/part/powerarmor_torso = 1,
-				/obj/item/mecha_parts/part/powerarmor_helmet = 1,
-				/obj/item/mecha_parts/part/powerarmor_left_arm = 1,
-				/obj/item/mecha_parts/part/powerarmor_right_arm = 1,
-				/obj/item/mecha_parts/part/powerarmor_left_leg = 1,
-				/obj/item/mecha_parts/part/powerarmor_right_leg = 1,
-				/obj/item/stack/ore/bluespace_crystal = 5,
-				/obj/item/stack/cable_coil = 5,
-				/obj/item/stock_parts/capacitor/quadratic = 1)
-	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_WRENCH)
-	time = 1200
-	category = CAT_CLOTHING
-*/

--- a/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -9,7 +9,7 @@
 				/obj/item/shard = 1)
 	time = 30
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/halberd
 	name = "Makeshift halberd"
@@ -21,31 +21,31 @@
 				/obj/item/hatchet = 1)
 	time = 60
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/switchblade_ms
 	name = "Switchblade"
 	result = /obj/item/switchblade/crafted
 	reqs = list(/obj/item/weaponcrafting/stock = 1,
-				/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1,
+				/obj/item/weaponcrafting/improvised_parts/pistol_receiver = 1,
 				/obj/item/metal_blade = 1,
 				/obj/item/stack/cable_coil = 2)
 	tools = list(TOOL_WELDER)
 	time = 45
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/balisong
 	name = "Butterfly Knife"
 	result = /obj/item/melee/transforming/butterfly
 	reqs = list(/obj/item/metal_gun_stock = 1,
-				/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1,
+				/obj/item/weaponcrafting/improvised_parts/pistol_receiver = 1,
 				/obj/item/metal_blade = 1,
 				/obj/item/stack/cable_coil = 5)
 	tools = list(TOOL_WELDER)
 	time = 60
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/switchblade_deluxe
 	name = "Deluxe Switchblade"
@@ -62,7 +62,7 @@
 	time = 250
 	tools = list(TOOL_WELDER)
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/trayshield
 	name = "Tray shield"
@@ -72,7 +72,7 @@
 				/obj/item/stack/cable_coil = 5)
 	time = 60
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/shank
 	name = "Shank"
@@ -82,18 +82,20 @@
 				/obj/item/shard = 1)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 //////////////////
 ///GUNS CRAFTING//
 //////////////////
 
 /datum/crafting_recipe/pipepistol
-	name = "Pipe Pistol (10mm)"
+	name = "Makeshift Pistol (10mm)"
 	result = /obj/item/gun/ballistic/automatic/pistol/makeshift
-	reqs = list(/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1,
-				/obj/item/pipe = 2,
-				/obj/item/stack/sheet/mineral/wood = 7,
+	reqs = list(/obj/item/weaponcrafting/improvised_parts/pistol_receiver = 1,
+				/obj/item/weaponcrafting/improvised_parts/barrel_pistol = 1,
+				/obj/item/weaponcrafting/improvised_parts/trigger_assembly = 1,
+				/obj/item/weaponcrafting/improvised_parts/wooden_grip = 1,
+				/obj/item/stack/sheet/metal = 5,
 				/obj/item/stack/packageWrap = 5)
 	tools = list(TOOL_WELDER)
 	time = 400
@@ -120,7 +122,7 @@
 	reqs = list(/obj/item/stack/rods = 2,
 				/obj/item/stack/cable_coil = 5,
 				/obj/item/storage/box = 1,
-				/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1)
+				/obj/item/weaponcrafting/improvised_parts/pistol_receiver = 1)
 	tools = list(TOOL_SCREWDRIVER)
 	time = 60
 	category = CAT_WEAPONRY
@@ -132,7 +134,7 @@
 	reqs = list(/obj/item/stack/sheet/bone = 3,
 				/obj/item/stack/ore/diamond = 5,
 				/obj/item/stack/sheet/sinew = 3,
-				/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1,
+				/obj/item/weaponcrafting/improvised_parts/shotgun_receiver = 1,
 				/obj/item/assembly/igniter = 1,
 				/obj/item/stock_parts/cell/high/plus/argent = 1,
 				/obj/item/stock_parts/capacitor = 4,
@@ -141,15 +143,15 @@
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/makeshiftlasrifle
-	name = "Makeshift laser rifle"
+	name = "Makeshift Laser Rifle"
 	result = /obj/item/gun/energy/laser/makeshiftlasrifle
-	reqs = list(/obj/item/stack/cable_coil = 30,\
+	reqs = list(/obj/item/stack/cable_coil = 15,\
 				/obj/item/weaponcrafting/stock = 1,\
 				/obj/item/pipe = 1,\
-				/obj/item/stack/sheet/mineral/diamond = 3,\
+				/obj/item/stack/sheet/glass = 1,\
 				/obj/item/weaponcrafting/improvised_parts/rifle_receiver = 1,\
 				/obj/item/stock_parts/micro_laser = 1,\
-				/obj/item/stock_parts/capacitor = 2,\
+				/obj/item/stock_parts/capacitor = 1,\
 				/obj/item/assembly/igniter = 1,
 				/obj/item/stock_parts/cell = 1)
 	parts = list(/obj/item/stock_parts/cell = 1)
@@ -181,7 +183,7 @@
 //////////////////
 
 /datum/crafting_recipe/makeshiftmagazine
-	name = "Makeshift pistol magazine (10mm)"
+	name = "Makeshift Pistol Magazine (10mm)"
 	result = /obj/item/ammo_box/magazine/m10mm/makeshift
 	reqs = list(/obj/item/pipe = 1,
 				/obj/item/stack/sheet/metal = 2,
@@ -211,8 +213,7 @@
 	result = /obj/item/melee/baton/staff
 	reqs = list(/obj/item/melee/baton = 2,
 				/obj/item/stack/sheet/metal = 2,
-				/obj/item/stack/cable_coil = 5,
-				/obj/item/stock_parts/cell = 1)
+				/obj/item/stack/cable_coil = 5)
 	parts = list(/obj/item/stock_parts/cell)
 	tools = list(TOOL_WELDER)
 	time = 75
@@ -277,7 +278,7 @@
 	reqs = list(/obj/item/rack_parts = 1)
 	time = 35
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/cylinder
 	name = "Aluminum cylinder"
@@ -286,7 +287,7 @@
 	tools = list(TOOL_WIRECUTTER)
 	time = 35
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/cylinderassembly
 	name = "Cylinder assembly"
@@ -294,7 +295,7 @@
 	reqs = list(/obj/item/aluminum_cylinder = 2)
 	time = 40
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/barrel
 	name = "Makeshift gun barrel"
@@ -303,7 +304,7 @@
 	tools = list(TOOL_WELDER)
 	time = 40
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/reservoir
 	name = "Fuel reservoir"
@@ -312,7 +313,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/blade
 	name = "Metal blade"
@@ -321,7 +322,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/largeblade
 	name = "Large metal blade"
@@ -330,7 +331,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/sword
 	name = "Makeshift sword"
@@ -341,7 +342,7 @@
 	tools = list(TOOL_WELDER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/rails
 	name = "Metal rails"
@@ -351,17 +352,8 @@
 	tools = list(TOOL_WELDER)
 	time = 50
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-/* I don't think porting the revialver is worth it
-/datum/crafting_recipe/beakercylinder
-	name = "Beaker cylinder"
-	result = /obj/item/cylinder
-	reqs = list(/obj/item/reagent_containers/beaker = 1)
-	tools = list(TOOL_SCREWDRIVER)
-	time = 20
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-*/
+	subcategory = CAT_PARTS
+
 /datum/crafting_recipe/assemblygeneral
 	name = "General gun assembly"
 	result = /obj/item/gun_assembly/stock_reservoir_assembly
@@ -370,7 +362,7 @@
 	tools = list(TOOL_WRENCH, TOOL_WELDER)
 	time = 150
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/assemblygeneralbarreled
 	name = "General barreled gun assembly"
@@ -380,7 +372,7 @@
 	tools = list(TOOL_WRENCH)
 	time = 100
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/railgun_assembly
 	name = "Rail gun assembly"
@@ -394,7 +386,7 @@
 	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WRENCH)
 	time = 200
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/railgun
 	name = "Rail gun"
@@ -423,4 +415,4 @@
 				/obj/item/wrench = 1)
 	time = 30
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3538,6 +3538,8 @@
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\blunderbuss.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\cannon.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\railgun.dm"
+#include "modular_skyrat\code\datums\components\crafting\crafting_results\rifle.dm"
+#include "modular_skyrat\code\datums\components\crafting\crafting_results\shotgun.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\swords.dm"
 #include "modular_skyrat\code\datums\components\crafting\recipes\recipes_clothing.dm"
 #include "modular_skyrat\code\datums\components\crafting\recipes\recipes_misc.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3537,6 +3537,7 @@
 #include "modular_skyrat\code\datums\components\crafting\crafting_items.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\blunderbuss.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\cannon.dm"
+#include "modular_skyrat\code\datums\components\crafting\crafting_results\energy_carbine.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\railgun.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\rifle.dm"
 #include "modular_skyrat\code\datums\components\crafting\crafting_results\shotgun.dm"


### PR DESCRIPTION
## About The Pull Request

TLDR Kat's weapon changes have made improv guns completely useless. Too hard to make for little payoff, the biggest joke being the slow firing, 13 damage .32 pistol. This PR remediates the issues not by removing these guns, but making them easier to craft (as it should be). This PR also reorganizes a few of our modular recipes to fit in with the new categories.

This PR is not bobweapons, this is simply repairing broken but existing content.

I will not list every single change i did to recipes, just look at the file changes and comment on them instead please. I don't need to write everything out in bold letters.

## Why It's Good For The Game

The .32 pistol is a travesty, this might make it worthwhile for at least entertainment. I hate to say it, but Kat seemingly only made the improvised weapons update to benefit engineer mains, fucking with everyone that doesn't have plentiful access to materials.

## Changelog
:cl:
balance: Makeshift weapons are now makeshift and don't cost ridiculous amounts of materials to be crafted.
balance: The improvised shotgun no longer has a damage penalty at all.
/:cl: