### PR TITLE
[Ready] Three oneline changes

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -777,7 +777,8 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
 	new /datum/stack_recipe("shower curtain", /obj/structure/curtain, 10, time = 10, one_per_turf = 1, on_floor = 1), \
 	new /datum/stack_recipe("laser pointer case", /obj/item/glasswork/glass_base/laserpointer_shell, 30), \
-	new /datum/stack_recipe("wet floor sign", /obj/item/caution, 2)))
+	new /datum/stack_recipe("wet floor sign", /obj/item/caution, 2), \
+	new /datum/stack_recipe("warning cone", /obj/item/clothing/head/cone, 1))) // Skyrat change: cone
 
 /obj/item/stack/sheet/plastic
 	name = "plastic"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -268,6 +268,12 @@
 		new/obj/structure/alien/resin/flower_bud_enemy(get_turf(holder))
 
 /datum/spacevine_mutation/flowering/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
+	if(istype(crosser, /mob/living/simple_animal/hostile/venus_human_trap)) //skyrat change: flowering vines heal flytraps 10% on cross
+		if(crosser.health == crosser.maxHealth)
+			return
+		crosser.health = clamp((crosser.health + crosser.maxHealth * 0.1), crosser.health, crosser.maxHealth)
+		to_chat(crosser, "<span class='notice'>The flowering vines attempt to regenerate some of your wounds!</span>")
+		return
 	if(prob(25))
 		holder.entangle(crosser)
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -391,6 +391,7 @@
 	playsound(src, 'sound/machines/warning-buzzer.ogg', 50)
 	user.visible_message("<span class='danger'>[user] tips over [src]!</span>", "<span class='danger'>You tip [src] over!</span>")
 	mode = BOT_TIPPED
+	tipper_name = user.name // Skyrat fix
 	var/matrix/mat = transform
 	transform = mat.Turn(180)
 

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -98,6 +98,8 @@
 	var/playable_plant = FALSE //Normal plants can **not** have players.
 
 /mob/living/simple_animal/hostile/venus_human_trap/ghost_playable
+	health = 100 // Skyrat change: slight health buff
+	maxHealth = 100
 	playable_plant = TRUE //For admins that want to buss some harmless plants
 
 /mob/living/simple_animal/hostile/venus_human_trap/BiologicalLife(seconds, times_fired)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -98,8 +98,8 @@
 	var/playable_plant = FALSE //Normal plants can **not** have players.
 
 /mob/living/simple_animal/hostile/venus_human_trap/ghost_playable
-	health = 100 // Skyrat change: slight health buff
-	maxHealth = 100
+	health = 75 // Skyrat change: slight health buff
+	maxHealth = 75
 	playable_plant = TRUE //For admins that want to buss some harmless plants
 
 /mob/living/simple_animal/hostile/venus_human_trap/BiologicalLife(seconds, times_fired)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -40,7 +40,7 @@
   */
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
 	visible_message("<span class='danger'>The plant has borne fruit!</span>")
-	new /mob/living/simple_animal/hostile/venus_human_trap(get_turf(src))
+	new /mob/living/simple_animal/hostile/venus_human_trap/ghost_playable(get_turf(src)) // Skyrat change: slight vine buff, rarely happens anyway!
 	qdel(src)
 
 /obj/effect/ebeam/vine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Warning cones can be crafted with plastic (request by Hogberg)
2. (bugfix) Medibot actually remembers the one who tipped them
3. Venus Human Traps from kudzu now spawn ghost-controlled. The regular variant is pretty stupid, and they die in 3 hits. It's also rather rare to see them anyway. This pleases the bloodthirsty ghost mains.

edit: also gave player traps a slight health buff, and gave them a way to actually heal their wounds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

/shrug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Warning cones can be crafted from plastic sheets
tweak: Venus human traps from Kudzu are now ghost controllable. Click them as ghost! You can cross the flowering vines to regenerate some health.
fix: Medibots now actually remember the person who bullies them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
