### PR TITLE
Swarmer Trap Fix

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -646,7 +646,7 @@
 		var/mob/living/L = AM
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
-			L.electrocute_act(100, src, 1, flags = SHOCK_NOGLOVES|SHOCK_ILLUSION)
+			L.electrocute_act(100, src, 1, flags = SHOCK_NOGLOVES|SHOCK_ILLUSION) //skyrat edit even if before I did this it wouldn't stun at all
 			if(iscyborg(L))
 				L.DefaultCombatKnockdown(100)
 			qdel(src)

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -646,7 +646,7 @@
 		var/mob/living/L = AM
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
-			L.electrocute_act(0, src, 1, flags = SHOCK_NOGLOVES|SHOCK_ILLUSION)
+			L.electrocute_act(100, src, 1, flags = SHOCK_NOGLOVES|SHOCK_ILLUSION)
 			if(iscyborg(L))
 				L.DefaultCombatKnockdown(100)
 			qdel(src)


### PR DESCRIPTION
## About The Pull Request

Makes the traps actually work.

## Why It's Good For The Game

I don't even like swarmers very much, but before it was broken and only did anything to cyborgs. I think this is a fair amount, where stepping into one trap will put you right on the edge of stam-crit, and two traps back to back will take you out for a while. If we want to change it at all its just one number. I did some local tests, and this seemed fair, given they can put them down for free. I also said I would do this, so here it is.
## Changelog
:cl:
fix: Fixed swarmer traps not doing anything.
/:cl:


