### PR TITLE
Tiger Carp yum yum!

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -26,6 +26,11 @@
 	tastes = list("fish" = 1)
 	foodtype = MEAT
 
+/obj/item/reagent_containers/food/snacks/carpmeat/tcarpmeat
+	name = "tiger carp fillet"
+	desc = "A robust and nutrient filled fillet of carp meat."
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 3)
+
 /obj/item/reagent_containers/food/snacks/carpmeat/Initialize()
 	. = ..()
 	eatverb = pick("bite","chew","choke down","gnaw","swallow","chomp")
@@ -63,7 +68,7 @@
 	filling_color = "#ee7676"
 	tastes = list("fish" = 1, "pan seared vegtables" = 1)
 	foodtype = MEAT | VEGETABLES | FRIED
-	
+
 /obj/item/reagent_containers/food/snacks/sushi_basic
 	name = "funa hosomaki"
 	desc = "A small cylindrical kudzu skin, filled with rice and fish."

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -26,7 +26,7 @@
 	tastes = list("fish" = 1)
 	foodtype = MEAT
 
-/obj/item/reagent_containers/food/snacks/carpmeat/tcarpmeat
+/obj/item/reagent_containers/food/snacks/carpmeat/tcarpmeat  //skyrat edit
 	name = "tiger carp fillet"
 	desc = "A robust and nutrient filled fillet of carp meat."
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/vitamin = 3)

--- a/modular_skyrat/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -17,3 +17,4 @@
 	melee_damage_upper = 17
 	attack_verb_continuous = "thrashes"
 	attack_verb_simple = "thrash"
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/carpmeat/tcarpmeat = 3)


### PR DESCRIPTION
Due to tiger carps being an event only monster, their meat has been altered in accordance to them. For a more active and aggressive fish, there is more nutrients in their meat, as well as just a little bit extra per carp. Carpotoxins are burned off due to their genetic variance from space carp!

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is more nutrients in their meat, as well as just a little bit extra per carp. Carpotoxins are burned off due to their genetic variance from space carp!
<!--  There is more nutrients in their meat, as well as just a little bit extra per carp. Carpotoxins are burned off due to their genetic variance from space carp! -->

## Why It's Good For The Game

Tiger carp are a bit more dangerous to hunt, so they should reward just a little extra. Gives the chefs more ingredients to work with and plus when its crafted, the food is quite nice on the eyes.
<!-- Tiger carp are a bit more dangerous to hunt, so they should reward just a little extra. Gives the chefs more ingredients to work with and plus when its crafted, the food is quite nice on the eyes. -->

## Changelog
:cl:
add: new carp meat subtype for tiger carps.
balance: gives just a tiny more reason to hunt the tiger carps for the good of the station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
