### PR TITLE
Removes flypeople vomit mechanics.

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -141,6 +141,7 @@
 	. = ..()
 	if(.)
 		return
+	/* Skyrat change - Commented out for being nasty banbait.
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(isflyperson(H))
@@ -153,6 +154,7 @@
 						reagents.del_reagent(R.type)
 			reagents.trans_to(H, reagents.total_volume)
 			qdel(src)
+	*/
 
 /obj/effect/decal/cleanable/vomit/old
 	name = "crusty dried vomit"

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -141,7 +141,6 @@
 	. = ..()
 	if(.)
 		return
-	/* Skyrat change - Commented out for being nasty banbait.
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(isflyperson(H))
@@ -154,7 +153,6 @@
 						reagents.del_reagent(R.type)
 			reagents.trans_to(H, reagents.total_volume)
 			qdel(src)
-	*/
 
 /obj/effect/decal/cleanable/vomit/old
 	name = "crusty dried vomit"

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -23,6 +23,7 @@
 		H.adjustToxLoss(3)
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM)
 		return TRUE
+	/* Skyrat change - no more gross vomit banbait stuff, yucky.
 	else if(istype(chem, /datum/reagent/consumable))
 		var/datum/reagent/consumable/nutri_check = chem
 		if(nutri_check.nutriment_factor > 0)
@@ -35,6 +36,7 @@
 			H.visible_message("<span class='danger'>[H] vomits on the floor!</span>", \
 						"<span class='userdanger'>You throw up on the floor!</span>")
 			return TRUE
+	*/
 	return ..()
 
 /datum/species/fly/check_weakness(obj/item/weapon, mob/living/attacker)


### PR DESCRIPTION
## About The Pull Request

Title. They can still eat gross food and drink vomit, but they don't vomit whenever they eat, just process food as normal. They can still use the *vomit emote, but it has a cooldown and drains more nutrient than it expels, therefore you will starve if you abuse it.

## Why It's Good For The Game

Banbait stuff. It is nasty and exploitable and should be gone.

## Changelog
:cl:
del: Flypeople no longer vomit when eating any food item.
/:cl:
