### PR TITLE
FIXES THE FUCKING PRESCRIPTION LOADOUT TO WORK FOR BLUESHIELD PLEASE SPEEDMERGE THIS FUCK

### DIFF
--- a/modular_skyrat/code/modules/client/loadout/_security.dm
+++ b/modular_skyrat/code/modules/client/loadout/_security.dm
@@ -2,5 +2,5 @@
 	name = "Prescription Security Hud"
 	category = SLOT_GLASSES
 	path = /obj/item/clothing/glasses/hud/security/prescription
-	restricted_roles = list("Security Officer", "Warden", "Head of Security")
+	restricted_roles = list("Security Officer", "Warden", "Head of Security", "Blueshield")
 	restricted_desc = "Security"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
MAKES PRESCRIPTION SEC HUD WORK FOR BLUE SHIELD GOD AAAAAAAAAAAAAAAAAAA
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Blueshields have finally gotten their shipment of prescription Security HUD glasses, after reports indicated being able to see improved performance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
