### PR TITLE
pacify/safezone tiles delete any nonckey living things

### DIFF
--- a/modular_skyrat/code/game/turfs/open/pacifytile.dm
+++ b/modular_skyrat/code/game/turfs/open/pacifytile.dm
@@ -3,7 +3,7 @@
 	icon = 'modular_skyrat/icons/turf/floors/pacifytile.dmi'
 	icon_state = "safezone"
 	baseturfs = /turf/open/pacifytile
-	slowdown = -1
+	CanAtmosPass = ATMOS_PASS_NO
 
 /turf/open/pacifytile/Entered(atom/movable/AM)
 	if(!isliving(AM))
@@ -12,6 +12,7 @@
 
 	var/mob/living/L = AM
 	if(!L.ckey)
+		qdel(L)
 		return
 
 	if(!HAS_TRAIT(L, TRAIT_PACIFISM))
@@ -26,7 +27,7 @@
 	icon = 'modular_skyrat/icons/turf/floors/pacifytile.dmi'
 	icon_state = "killzone"
 	baseturfs = /turf/open/warzonetile
-	slowdown = -1
+	CanAtmosPass = ATMOS_PASS_NO
 
 /turf/open/warzonetile/Entered(atom/movable/AM)
 	if(!isliving(AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
real simple:
delete non-ckey living things (simple_mobs, etc.)
makes atmos not pass the tile.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes the safe zone just a bit safer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: pacify/safezone tiles now delete non-ckey living mobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
