### PR TITLE
Fixes that one pipe in engineering that was visible for some reason

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -51144,7 +51144,7 @@
 "cpn" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,


### PR DESCRIPTION
## About The Pull Request

Puts this bastard pipe underneath the floor tile where it BELONGS.
https://i.imgur.com/V9g9ZCN.png

## Why It's Good For The Game
Uhhhh, more map consistency? I don't know man it was triggering me.

## Changelog (Does this really even warrant one though?)
:cl: Calibraptor
tweak: Fixed a single pipe on box station.
/:cl:
