### PR TITLE
Let's make the bureaucracy error event not limit the amount of assistants

### DIFF
--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -11,7 +11,9 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	var/datum/job/random_job = SSjob.GetJob(pick(get_all_jobs()))
+	//Skyrat edit -- start
+	var/datum/job/random_job = SSjob.GetJob(pick(get_all_jobs() - "Assistant"))
 	var/cap = rand(0,10)
 	random_job.spawn_positions = cap
 	random_job.total_positions = cap
+	//Skyrat edit -- end

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -13,7 +13,7 @@
 /datum/round_event/bureaucratic_error/start()
 	//Skyrat edit -- start
 	var/datum/job/random_job = SSjob.GetJob(pick(get_all_jobs() - "Assistant"))
-	var/cap = rand(0,10)
+	var/cap = rand(0,15)
 	random_job.spawn_positions = cap
 	random_job.total_positions = cap
 	//Skyrat edit -- end

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -11,4 +11,7 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	SSjob.set_overflow_role(pick(get_all_jobs()))
+	var/datum/job/random_job = SSjob.GetJob(pick(get_all_jobs()))
+	var/cap = rand(0,10)
+	random_job.spawn_positions = cap
+	random_job.total_positions = cap

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -13,7 +13,7 @@
 /datum/round_event/bureaucratic_error/start()
 	//Skyrat edit -- start
 	var/datum/job/random_job = SSjob.GetJob(pick(get_all_jobs() - "Assistant"))
-	var/cap = rand(0,15)
+	var/cap = rand(10,15)
 	random_job.spawn_positions = cap
 	random_job.total_positions = cap
 	//Skyrat edit -- end


### PR DESCRIPTION
## About The Pull Request

It prevents the rare, but significant problem of the bureaucracy event limiting the assistant slots.
It is especially painful if it occurs early in the round.

As a workaround we simply pick a random job other than assistant and set the amount of open slots to a random number from 10 to 15.

## Changelog
:cl:
fix: Bureaucracy error event no longer limits assistant slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
