### PR TITLE
fixes railgun bullet casing bug

### DIFF
--- a/modular_skyrat/code/datums/components/crafting/crafting_results/railgun.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/railgun.dm
@@ -62,7 +62,10 @@
 	if(chambered)
 		user.visible_message("<span class='notice'>[user] removes the [chambered.BB] from the [src].</span>", \
 							"<span class='notice'>You remove the [chambered.BB] from the [src].</span>")
-		user.put_in_inactive_hand(new /obj/item/stack/rods)
+		if(!user.get_inactive_held_item())
+			user.put_in_inactive_hand(new /obj/item/stack/rods)
+		else
+			new /obj/item/stack/rods(user.loc)
 		QDEL_NULL(chambered)
 		playsound(user, insert_sound, 50, 1)
 		update_icon()

--- a/modular_skyrat/code/datums/components/crafting/crafting_results/railgun.dm
+++ b/modular_skyrat/code/datums/components/crafting/crafting_results/railgun.dm
@@ -60,13 +60,13 @@
 /obj/item/gun/ballistic/automatic/railgun/attack_self(mob/living/user)
 	. = ..()
 	if(chambered)
-		if(chambered.BB)
-			user.visible_message("<span class='notice'>[user] removes the [chambered.BB] from the [src].</span>", \
-								"<span class='notice'>You remove the [chambered.BB] from the [src].</span>")
-			user.put_in_hands(new /obj/item/stack/rods)
-			chambered = null
-			playsound(user, insert_sound, 50, 1)
-			update_icon()
+		user.visible_message("<span class='notice'>[user] removes the [chambered.BB] from the [src].</span>", \
+							"<span class='notice'>You remove the [chambered.BB] from the [src].</span>")
+		user.put_in_inactive_hand(new /obj/item/stack/rods)
+		QDEL_NULL(chambered)
+		playsound(user, insert_sound, 50, 1)
+		update_icon()
+		return TRUE
 
 /obj/item/gun/ballistic/automatic/railgun/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

unloading a railgun no longer drops a casing, it just gives you a new stack of metal rods instead

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: Rail guns no longer spawn bullet casings when unloaded
/:cl:
