### PR TITLE
Removes broken powergamer quirk that was snuck into the code.

### DIFF
--- a/modular_skyrat/code/datums/traits/negative.dm
+++ b/modular_skyrat/code/datums/traits/negative.dm
@@ -93,19 +93,6 @@
 	mob_trait = TRAIT_ASTHMATIC
 	medical_record_text = "Patient exhibits asthmatic symptoms."
 
-/datum/quirk/paper_skin
-	name = "Paper skin"
-	desc = "Your skin and body are fragile. Damage from most sources is increased by 10%."
-	value = -1
-	medical_record_text = "Patient gets hurt more easily than others."
-
-/datum/quirk/paper_skin/add()
-	. = ..()
-	if(.)
-		var/mob/living/carbon/human/H = quirk_holder
-		if(H && istype(H))
-			H.physiology.armor -= 10
-
 /datum/quirk/allergic
 	name = "Allergic"
 	desc = "You have had terrible allergies for as long as you can remember. Some foods will become toxic to your palate and cause unforeseen consequences."

--- a/modular_skyrat/code/datums/traits/negative.dm
+++ b/modular_skyrat/code/datums/traits/negative.dm
@@ -96,8 +96,8 @@
 /datum/quirk/paper_skin
 	name = "Paper skin"
 	desc = "Your skin and body are fragile. Damage from most sources is increased by 10%."
-	value = -3
-	medical_record_text = "Patient is frail and  tends to be damaged quite easily."
+	value = -1
+	medical_record_text = "Patient gets hurt more easily than others."
 
 /datum/quirk/paper_skin/add()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
• Paper skin quirk removed.

## Why It's Good For The Game
Removed paper skin quirk because it's broken and barely worth a single quirk point, not three.

## Changelog
:cl:
del: paper skin quirk
/:cl:

## Media
![image](https://user-images.githubusercontent.com/53862927/89858032-81a67000-db95-11ea-88af-293d42ef1399.png)
This doesn't even work when you have melee armour.