### PR TITLE
Removes donor hair/hat from monkeyspawn

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -179,7 +179,7 @@
 	aggressive = TRUE
 	verb_say = "criticizes"
 
-/mob/living/carbon/monkey/coder/Initialize()
+/mob/living/carbon/monkey/coder/Initialize() //Skyrats edit, donor hair removed.
 	. = ..()
 	var/list/possible_hats = list(
 		/obj/item/clothing/head/cone = 2,
@@ -188,7 +188,6 @@
 		//obj/item/clothing/head/foilhat = 1, SKYRAT EDIT: This shit creates errors
 		/obj/item/clothing/head/hardhat/cakehat = 1,
 		/obj/item/clothing/head/helmet/justice = 2,
-		/obj/item/clothing/head/mikuhair = 2,
 		/obj/item/clothing/head/papersack = 2,
 		/obj/item/clothing/head/sombrero/shamebrero = 1
 	)


### PR DESCRIPTION

## About The Pull Request

Removes donorhair from the random codemonkey in space.

## Why It's Good For The Game

Donorhair on monkey bad.

## Changelog
:cl:
fix: Donor hair from monkey spawn removed. Dunno why this was added in the first place.
/:cl:


