### PR TITLE
Nerfs shotgun PKA mod

### DIFF
--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -114,7 +114,7 @@
 	denied_type = /obj/item/borg/upgrade/modkit/aoe
 	cost = 40
 	modifier = 3
-	var/penalty = 13
+	var/penalty = 6
 
 /obj/item/borg/upgrade/modkit/shotgun/modify_projectile(obj/item/projectile/kinetic/K)
 	..()

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -114,19 +114,23 @@
 	denied_type = /obj/item/borg/upgrade/modkit/aoe
 	cost = 40
 	modifier = 3
+	var/penalty = 13
 
 /obj/item/borg/upgrade/modkit/shotgun/modify_projectile(obj/item/projectile/kinetic/K)
 	..()
 	if(K.kinetic_gun)
+		K.damage -= penalty
 		var/obj/item/gun/energy/kinetic_accelerator/KA = K.kinetic_gun
 		var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1]
 		C.pellets = src.modifier
-		C.variance = 45
+		C.variance = modifier * 15
 		KA.chambered = C
 
 /obj/item/borg/upgrade/modkit/shotgun/uninstall(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	..()
 	var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1]
+	if(C.BB)
+		C.BB.damage = initial(C.BB.damage)
 	C.pellets = initial(C.pellets)
 	C.variance = initial(C.variance)
 	KA.chambered = C


### PR DESCRIPTION
## About The Pull Request

Title. Nerfs the bubblegum pka mod that makes it fire 3 kinetic shots instead of one. Now each shot does 13 damage less, so a normal PKA when using this mod alone does 81 damage instead of 120, assuming all shots land. The capacity cost is still 40%, but this makes the mod less ridiculous and makes it have an obvious drawback, since now you need to land at least 2 of the shots in a burst to make the mod count, which requires getting a bit too intimate with the target.

## Why It's Good For The Game

Too abusable, too damn good.

## Changelog
:cl:
balance: PKA shotgun mod now has a significant damage penalty, making each projectile do 13 less damage.
/:cl:
