### PR TITLE
Nerfs some funny PKA mods

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -504,7 +504,7 @@
 		if(L.stat == DEAD)
 			return
 		L = K.firer
-		L.heal_ordered_damage(modifier/K.pellets, damage_heal_order) //skyrat edit - healing is divided by pellets to prevent shotgun mod memes
+		L.heal_ordered_damage(modifier/(KA?.chambered?.pellets ? KA.chambered.pellets : 1), damage_heal_order) //skyrat edit - healing is divided by pellets to prevent shotgun mod memes
 
 /obj/item/borg/upgrade/modkit/resonator_blasts
 	name = "resonator blast"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -504,7 +504,7 @@
 		if(L.stat == DEAD)
 			return
 		L = K.firer
-		L.heal_ordered_damage(modifier, damage_heal_order)
+		L.heal_ordered_damage(modifier/K.pellets, damage_heal_order) //skyrat edit - healing is divided by pellets to prevent shotgun mod memes
 
 /obj/item/borg/upgrade/modkit/resonator_blasts
 	name = "resonator blast"

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -155,9 +155,9 @@
 /obj/item/borg/upgrade/modkit/wall
 	name = "wall modification kit"
 	desc = "Makes a wall on impact on a living being."
-	cost = 60
+	cost = 50
 	var/cooldown = 0
-	var/cdmultiplier = 1.75
+	var/cdmultiplier = 2.25
 
 /obj/item/borg/upgrade/modkit/wall/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	..()

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -119,16 +119,16 @@
 	..()
 	if(K.kinetic_gun)
 		var/obj/item/gun/energy/kinetic_accelerator/KA = K.kinetic_gun
-		var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1]
-		C.variance += 15 * (modifier + 1)
+		var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1] 
 		C.pellets += modifier
+		C.variance = (C.pellets * 15) + initial(C.variance)
 		KA.chambered = C
 
 /obj/item/borg/upgrade/modkit/shotgun/uninstall(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	..()
 	var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1]
-	C.variance -= 15 * (modifier + 1)
 	C.pellets -= modifier
+	C.variance = ((C.pellets - 1) * 15) + initial(C.variance)
 	KA.chambered = C
 
 //drake

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -155,7 +155,7 @@
 /obj/item/borg/upgrade/modkit/wall
 	name = "wall modification kit"
 	desc = "Makes a wall on impact on a living being."
-	cost = 50
+	cost = 40
 	var/cooldown = 0
 	var/cdmultiplier = 2.25
 

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -111,24 +111,24 @@
 /obj/item/borg/upgrade/modkit/shotgun
 	name = "shotgun blast modification kit"
 	desc = "Makes you fire 3 kinetic shots instead of one."
-	denied_type = /obj/item/borg/upgrade/modkit/aoe
+	denied_type = /obj/item/borg/upgrade/modkit/shotgun
 	cost = 40
-	modifier = 3
+	modifier = 2
 
 /obj/item/borg/upgrade/modkit/shotgun/modify_projectile(obj/item/projectile/kinetic/K)
 	..()
 	if(K.kinetic_gun)
 		var/obj/item/gun/energy/kinetic_accelerator/KA = K.kinetic_gun
 		var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1]
-		C.pellets = src.modifier
-		C.variance = 45
+		C.variance += 15 * (modifier + 1)
+		C.pellets += modifier
 		KA.chambered = C
 
 /obj/item/borg/upgrade/modkit/shotgun/uninstall(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	..()
 	var/obj/item/ammo_casing/energy/kinetic/C = KA.ammo_type[1]
-	C.pellets = initial(C.pellets)
-	C.variance = initial(C.variance)
+	C.variance -= 15 * (modifier + 1)
+	C.pellets -= modifier
 	KA.chambered = C
 
 //drake
@@ -257,9 +257,10 @@
 /obj/item/borg/upgrade/modkit/lifesteal/miner
 	name = "resonant lifesteal crystal"
 	desc = "Causes kinetic accelerator shots to heal the firer on striking a living target."
-	modifier = 3
-	cost = 20
-	denied_type = /obj/item/borg/upgrade/modkit/lifesteal
+	modifier = 4
+	cost = 30
+	denied_type = /obj/item/borg/upgrade/modkit/lifesteal/miner
+	maximum_of_type = 2
 
 //drakeling
 /obj/item/borg/upgrade/modkit/fire

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -257,8 +257,9 @@
 /obj/item/borg/upgrade/modkit/lifesteal/miner
 	name = "resonant lifesteal crystal"
 	desc = "Causes kinetic accelerator shots to heal the firer on striking a living target."
-	modifier = 4
-	cost = 30
+	modifier = 3
+	cost = 20
+	denied_type = /obj/item/borg/upgrade/modkit/lifesteal
 
 //drakeling
 /obj/item/borg/upgrade/modkit/fire

--- a/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/modular_skyrat/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -146,7 +146,7 @@
 		playsound(T, 'sound/magic/fireball.ogg', 20, 1)
 		new /obj/effect/temp_visual/fire(T.loc)
 		step(target, get_dir(K, T))
-		T.adjustFireLoss(burndam, forced = TRUE)
+		T.adjustFireLoss(burndam)
 
 //hierophant
 


### PR DESCRIPTION
## About The Pull Request

Amount of healing from lifesteal is now divided by pellets, therefore preventing triplified healing with the shotgun mod.
A PKA can only have a maximum of two resonant lifesteal crystals.
Shotgun PKA mod can't be stacked with other shotgun pka mods, but it can now accept the AoE mod - the code can support multiple shotgun mods though, each mod adding 2 pellets.
Wall modification modkit now has a cooldoown equal to 2x the duration of the wall, but capacity cost has been lowered to 40.

## Why It's Good For The Game

Cheese bad

## Changelog
:cl:
balance: Resonant lifesteal crystal no longer stacks healing with shotgun mod 
balance: Shotgun PKA mod can no longer be stacked, though the code would support it
balance: Wall PKA modkit now has a cooldoown equal to 2.25x the duration of the wall by the moment a wall is created, but capacity cost has been lowered to 40
/:cl:
