### PR TITLE
Fix fake dogborgs not being able to rest

### DIFF
--- a/modular_skyrat/code/game/objects/items/borg_shapeshifter.dm
+++ b/modular_skyrat/code/game/objects/items/borg_shapeshifter.dm
@@ -21,6 +21,7 @@
 	var/disguise = null
 	var/disguise_icon_override = null
 	var/disguise_pixel_offset = null
+	var/disguise_dogborg = FALSE
 	var/mob/listeningTo
 	var/list/signalCache = list( // list here all signals that should break the camouflage
 			COMSIG_PARENT_ATTACKBY,
@@ -268,18 +269,22 @@
 						disguise = "medihound"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Medihound Dark")
 						disguise = "medihounddark"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Vale")
 						disguise = "valemed"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Drake")
 						disguise = "drakemed"
 						disguise_icon_override = 'icons/mob/cyborg/drakemech.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					else
 						return FALSE
 
@@ -345,14 +350,17 @@
 						disguise = "pupdozer"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Vale")
 						disguise = "valeeng"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Alina")
 						disguise = "alina-eng"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Bootyborg") //Skyrat change
 						disguise = "bootyeng"
 						disguise_icon_override = 'modular_skyrat/icons/mob/moreborgsmodels.dmi'
@@ -369,6 +377,7 @@
 						disguise = "drakeeng"
 						disguise_icon_override = 'icons/mob/cyborg/drakemech.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					else
 						return FALSE
 			if("Security")
@@ -425,18 +434,22 @@
 						disguise = "k9"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Alina")
 						disguise = "alina-sec"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("K9 Dark")
 						disguise = "k9dark"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Vale")
 						disguise = "valesec"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Bootyborg") //Skyrat change
 						disguise = "bootysecurity"
 						disguise_icon_override = 'modular_skyrat/icons/mob/moreborgsmodels.dmi'
@@ -453,6 +466,7 @@
 						disguise = "drakesec"
 						disguise_icon_override = 'icons/mob/cyborg/drakemech.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					else
 						return FALSE
 			if("Service")
@@ -519,14 +533,17 @@
 						disguise = "k50"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("(Service) Vale")
 						disguise = "valeserv"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("(Service) ValeDark")
 						disguise = "valeservdark"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("(Service) Bootyborg")
 						disguise = "bootyservice"
 						disguise_icon_override = 'modular_skyrat/icons/mob/moreborgsmodels.dmi'
@@ -558,6 +575,7 @@
 						disguise = "scrubpup"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("(Janitor) Bootyborg")
 						disguise = "bootyjanitor"
 						disguise_icon_override = 'modular_skyrat/icons/mob/moreborgsmodels.dmi'
@@ -574,6 +592,7 @@
 						disguise = "drakejanit"
 						disguise_icon_override = 'icons/mob/cyborg/drakemech.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					else
 						return FALSE
 			if("Miner")
@@ -630,10 +649,12 @@
 						disguise = "blade"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Vale")
 						disguise = "valemine"
 						disguise_icon_override = 'modular_skyrat/icons/mob/widerobot.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					if("Bootyborg")
 						disguise = "bootyminer"
 						disguise_icon_override = 'modular_skyrat/icons/mob/moreborgsmodels.dmi'
@@ -653,6 +674,7 @@
 						disguise = "drakemine"
 						disguise_icon_override = 'icons/mob/cyborg/drakemech.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					else
 						return FALSE
 			if("Peacekeeper")
@@ -699,6 +721,7 @@
 						disguise = "drakepeace"
 						disguise_icon_override = 'icons/mob/cyborg/drakemech.dmi'
 						disguise_pixel_offset = -16
+						disguise_dogborg = TRUE
 					else
 						return FALSE
 			if("Clown")
@@ -840,6 +863,7 @@
 	user.module.cyborg_base_icon = disguise
 	user.module.cyborg_icon_override = disguise_icon_override
 	user.module.cyborg_pixel_offset = disguise_pixel_offset
+	user.module.dogborg = disguise_dogborg
 	user.bubble_icon = "robot"
 	active = TRUE
 	user.update_icons()
@@ -862,10 +886,12 @@
 	user.module.cyborg_base_icon = savedIcon
 	user.module.cyborg_icon_override = savedOverride
 	user.module.cyborg_pixel_offset = 0
+	user.module.dogborg = FALSE
 	user.bubble_icon = savedBubbleIcon
 	active = FALSE
 	user.update_icons()
 	disguise_pixel_offset = 0
+	disguise_dogborg = FALSE
 	src.user = user
 
 /obj/item/borg_shapeshifter/proc/disrupt(mob/living/silicon/robot/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sleepy Borgo
![image](https://user-images.githubusercontent.com/14105827/90088565-57aaa480-dd73-11ea-85ad-309ffb04a6f0.png)
You can now rest as a dogborg in the Ghost Cafe
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Small Oversight
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Sarmenti and Funce
fix: Dogborgs in the Cafe can now rest in their preferred style. Missed this!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
