### PR TITLE
[Bugfix] Poly properly resets on unbuckle

### DIFF
--- a/modular_skyrat/code/modules/mob/living/simple_animal/parrot.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/parrot.dm
@@ -56,8 +56,8 @@
 	parrot_state = PARROT_WANDER
 	if(buckled)
 		to_chat(src, "<span class='notice'>You are no longer sitting on [buckled].</span>")
-		buckled.unbuckle_mob(src, TRUE)
 		emote("me", EMOTE_VISIBLE, "squawks and hops off of [buckled], flying away.")
+		buckled.unbuckle_mob(src, TRUE)
 	buckled = null
 	buckled_to_human = FALSE
 	pixel_x = initial(pixel_x)

--- a/modular_skyrat/code/modules/mob/living/simple_animal/parrot.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/parrot.dm
@@ -2,6 +2,12 @@
 /mob/living/simple_animal/parrot/proc/check_command() // Skyrat - Poly listens to some of the CE's commands!
 	return FALSE // Simply return false for non-Poly parrots
 
+/mob/living/simple_animal/parrot/Poly/post_unbuckle_mob(mob/living/M)
+	buckled_to_human = FALSE
+	pixel_x = initial(pixel_x)
+	pixel_y = initial(pixel_y)
+	parrot_state = PARROT_WANDER
+
 /mob/living/simple_animal/parrot/Poly/check_command(message, speaker) // Skyrat - Poly listens to some of the CE's commands!
 	var/mob/living/carbon/human/H = speaker
 	if(!istype(H))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When unbuckled without the command it now powerly resets everything. Oops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed unbuckling Poly breaking a variable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
