### PR TITLE
Fixes stinky genital appearance code, properly respects measurement preferences of the viewer

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -299,8 +299,12 @@ GENETICS SCANNER
 			else if(istype(O, /obj/item/organ/genital/penis))
 				var/obj/item/organ/genital/penis/P = O
 				if(P.length>20)
-					temp_message += " <span class='info'>Subject has a sizeable gentleman's organ at [P.length] inches.</span>"
-
+					//skyrat edit
+					if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
+						temp_message += " <span class='info'>Subject has a sizeable gentleman's organ at [round(P.length * 2.54, 0.1)] inches.</span>"
+					else
+						temp_message += " <span class='info'>Subject has a sizeable gentleman's organ at [round(P.length, 0.1)] inches.</span>"
+					//
 			else if(istype(O, /obj/item/organ/genital/breasts))
 				var/obj/item/organ/genital/breasts/Br = O
 				if(Br.cached_size>5)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -301,7 +301,7 @@ GENETICS SCANNER
 				if(P.length>20)
 					//skyrat edit
 					if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
-						temp_message += " <span class='info'>Subject has a sizeable gentleman's organ at [round(P.length * 2.54, 0.1)] inches.</span>"
+						temp_message += " <span class='info'>Subject has a sizeable gentleman's organ at [round(P.length * 2.54, 0.1)] centimeters.</span>"
 					else
 						temp_message += " <span class='info'>Subject has a sizeable gentleman's organ at [round(P.length, 0.1)] inches.</span>"
 					//

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -49,6 +49,13 @@
 	if(linked_organ_slot || (linked_organ && !owner))
 		update_link()
 
+/obj/item/organ/genital/examine(mob/user)
+	. = ..()
+	. |= genital_examine(user)
+
+/obj/item/organ/genital/proc/genital_examine(mob/user)
+	return
+
 //exposure and through-clothing code
 /mob/living/carbon
 	var/list/exposed_genitals = list() //Keeping track of them so we don't have to iterate through every genitalia and see if exposed

--- a/code/modules/arousal/organs/breasts.dm
+++ b/code/modules/arousal/organs/breasts.dm
@@ -30,28 +30,6 @@
 
 /obj/item/organ/genital/breasts/update_appearance()
 	. = ..()
-	var/lowershape = lowertext(shape)
-	switch(lowershape)
-		if("pair")
-			desc = "You see a pair of breasts."
-		if("quad")
-			desc = "You see two pairs of breast, one just under the other."
-		if("sextuple")
-			desc = "You see three sets of breasts, running from their chest to their belly."
-		else
-			desc = "You see some breasts, they seem to be quite exotic."
-	if(size == "huge")
-		desc = "You see [pick("some serious honkers", "a real set of badonkers", "some dobonhonkeros", "massive dohoonkabhankoloos", "two big old tonhongerekoogers", "a couple of giant bonkhonagahoogs", "a pair of humongous hungolomghnonoloughongous")]. Their volume is way beyond cupsize now, measuring in about [round(cached_size)]cm in diameter."
-	else
-		if (size == "flat")
-			desc += " They're very small and flatchested, however."
-		else
-			desc += " You estimate that they're [uppertext(size)]-cups."
-
-	if(CHECK_BITFIELD(genital_flags, GENITAL_FUID_PRODUCTION) && aroused_state)
-		var/datum/reagent/R = GLOB.chemical_reagents_list[fluid_id]
-		if(R)
-			desc += " They're leaking [lowertext(R.name)]."
 	var/datum/sprite_accessory/S = GLOB.breasts_shapes_list[shape]
 	var/icon_shape = S ? S.icon_state : "pair"
 	var/icon_size = clamp(breast_values[size], BREASTS_ICON_MIN_SIZE, BREASTS_ICON_MAX_SIZE)
@@ -65,6 +43,33 @@
 					icon_state += "_s"
 		else
 			color = "#[owner.dna.features["breasts_color"]]"
+
+/obj/item/organ/genital/breasts/genital_examine(mob/user)
+	. = list()
+	var/lowershape = lowertext(shape)
+	var/txt = "<span class='notice'>"
+	switch(lowershape)
+		if("pair")
+			txt += "You see a pair of breasts."
+		if("quad")
+			txt += "You see two pairs of breast, one just under the other."
+		if("sextuple")
+			txt += "You see three sets of breasts, running from their chest to their belly."
+		else
+			txt += "You see some breasts, they seem to be quite exotic."
+	if(size == "huge")
+		txt = "<span class='notice'>You see [pick("some serious honkers", "a real set of badonkers", "some dobonhonkeros", "massive dohoonkabhankoloos", "two big old tonhongerekoogers", "a couple of giant bonkhonagahoogs", "a pair of humongous hungolomghnonoloughongous")]. Their volume is way beyond cupsize now, measuring in about [round(cached_size)]cm in diameter."
+	else
+		if (size == "flat")
+			txt += " They're very small and flatchested, however."
+		else
+			txt += " You estimate that they're [uppertext(size)]-cups."
+	if(CHECK_BITFIELD(genital_flags, GENITAL_FUID_PRODUCTION) && aroused_state)
+		var/datum/reagent/R = GLOB.chemical_reagents_list[fluid_id]
+		if(R)
+			txt += " They're leaking [lowertext(R.name)]."
+	txt += "</span>"
+	. |= txt
 
 //Allows breasts to grow and change size, with sprite changes too.
 //maximum wah

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -78,7 +78,6 @@
 	var/datum/sprite_accessory/S = GLOB.cock_shapes_list[shape]
 	var/icon_shape = S ? S.icon_state : "human"
 	icon_state = "penis_[icon_shape]_[size]"
-	var/lowershape = lowertext(shape)
 
 	if(owner)
 		if(owner.dna.species.use_skintones && owner.dna.features["genitals_use_skintone"])
@@ -96,6 +95,7 @@
 
 /obj/item/organ/genital/penis/genital_examine(mob/user)
 	. = list()
+	var/lowershape = lowertext(shape)
 	if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
 		. += "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length * 2.54, 0.1)] centimeter[round(length * 2.54, 0.1) != 1 ? "s" : ""] long and [round(diameter, 0.1)] centimeter[round(diameter, 0.1) != 1 ? "s" : ""] in diameter.</span>"
 	else

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -97,9 +97,9 @@
 	. = list()
 	var/lowershape = lowertext(shape)
 	if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
-		. += "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length * 2.54, 0.1)] centimeter[round(length * 2.54, 0.1) != 1 ? "s" : ""] long and [round(diameter, 0.1)] centimeter[round(diameter, 0.1) != 1 ? "s" : ""] in diameter.</span>"
+		. |= "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length * 2.54, 0.1)] centimeter[round(length * 2.54, 0.1) != 1 ? "s" : ""] long and [round(diameter, 0.1)] centimeter[round(diameter, 0.1) != 1 ? "s" : ""] in diameter.</span>"
 	else
-		. += "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length, 0.1)] inch[round(length, 0.1) != 1 ? "es" : ""] long and [round(diameter, 0.1)] inch[round(diameter, 0.1) != 1 ? "es" : ""] in diameter.</span>"
+		. |= "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length, 0.1)] inch[round(length, 0.1) != 1 ? "es" : ""] long and [round(diameter, 0.1)] inch[round(diameter, 0.1) != 1 ? "es" : ""] in diameter.</span>"
 
 /obj/item/organ/genital/penis/get_features(mob/living/carbon/human/H)
 	var/datum/dna/D = H.dna

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -66,9 +66,19 @@
 
 	if(owner)
 		if (round(length) > round(prev_length))
-			to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("swells up to", "flourishes into", "expands into", "bursts forth into", "grows eagerly into", "amplifys into")] a [uppertext(round(length))] inch penis.</b></span>")
+			//Skyrat edit
+			if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
+				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("swells up to", "flourishes into", "expands into", "bursts forth into", "grows eagerly into", "amplifys into")] a [round(length * 2.54, 0.1)] centimeter penis.</b></span>")
+			else
+				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("swells up to", "flourishes into", "expands into", "bursts forth into", "grows eagerly into", "amplifys into")] a [round(length, 0.1)] inch penis.</b></span>")
+			//
 		else if ((round(length) < round(prev_length)) && (length > 0.5))
-			to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("shrinks down to", "decreases into", "diminishes into", "deflates into", "shrivels regretfully into", "contracts into")] a [uppertext(round(length))] inch penis.</b></span>")
+			//skyrat edit
+			if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
+				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("shrinks down to", "decreases into", "diminishes into", "deflates into", "shrivels regretfully into", "contracts into")] a [round(length * 2.54, 0.1)] centimeter penis.</b></span>")
+			else
+				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("shrinks down to", "decreases into", "diminishes into", "deflates into", "shrivels regretfully into", "contracts into")] a [round(length, 0.1)] inch penis.</b></span>")
+			//
 	icon_state = sanitize_text("penis_[shape]_[size]")
 	diameter = (length * diameter_ratio)//Is it just me or is this ludicous, why not make it exponentially decay?
 

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -67,14 +67,14 @@
 	if(owner)
 		if (round(length) > round(prev_length))
 			//Skyrat edit
-			if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
+			if(owner?.client?.prefs?.toggles & METRIC_OR_BUST)
 				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("swells up to", "flourishes into", "expands into", "bursts forth into", "grows eagerly into", "amplifys into")] a [round(length * 2.54, 0.1)] centimeter penis.</b></span>")
 			else
 				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("swells up to", "flourishes into", "expands into", "bursts forth into", "grows eagerly into", "amplifys into")] a [round(length, 0.1)] inch penis.</b></span>")
 			//
 		else if ((round(length) < round(prev_length)) && (length > 0.5))
 			//skyrat edit
-			if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
+			if(owner?.client?.prefs?.toggles & METRIC_OR_BUST)
 				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("shrinks down to", "decreases into", "diminishes into", "deflates into", "shrivels regretfully into", "contracts into")] a [round(length * 2.54, 0.1)] centimeter penis.</b></span>")
 			else
 				to_chat(owner, "<span class='warning'>Your [pick(GLOB.dick_nouns)] [pick("shrinks down to", "decreases into", "diminishes into", "deflates into", "shrivels regretfully into", "contracts into")] a [round(length, 0.1)] inch penis.</b></span>")

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -93,12 +93,13 @@
 			var/datum/sprite_accessory/taur/T = GLOB.taur_list[owner.dna.features["taur"]]
 			if(T.taur_mode & S.accepted_taurs) //looks out of place on those.
 				lowershape = "taur, [lowershape]"
-	
-	desc = "You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length, 0.25)] inch[round(length, 0.25) != 1 ? "es" : ""] long and [round(diameter, 0.25)] inch[round(diameter, 0.25) != 1 ? "es" : ""] in diameter."
-	//Skyrat edit - Metric is based, imperial is cringe
-	if(owner?.client?.prefs?.toggles & METRIC_OR_BUST)
-		desc = "You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length * 2.54, 0.5)] centimeter[round(length * 2.54, 0.5) != 1 ? "s" : ""] long and [round(diameter, 0.5)] centimeter[round(diameter, 0.5) != 1 ? "s" : ""] in diameter."
-	//
+
+/obj/item/organ/genital/penis/genital_examine(mob/user)
+	. = list()
+	if(user?.client?.prefs?.toggles & METRIC_OR_BUST)
+		. += "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length * 2.54, 0.1)] centimeter[round(length * 2.54, 0.1) != 1 ? "s" : ""] long and [round(diameter, 0.1)] centimeter[round(diameter, 0.1) != 1 ? "s" : ""] in diameter.</span>"
+	else
+		. += "<span class='notice'>You see [aroused_state ? "an erect" : "a flaccid"] [lowershape] [name]. You estimate it's about [round(length, 0.1)] inch[round(length, 0.1) != 1 ? "es" : ""] long and [round(diameter, 0.1)] inch[round(diameter, 0.1) != 1 ? "es" : ""] in diameter.</span>"
 
 /obj/item/organ/genital/penis/get_features(mob/living/carbon/human/H)
 	var/datum/dna/D = H.dna

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -78,7 +78,7 @@
 	var/datum/sprite_accessory/S = GLOB.cock_shapes_list[shape]
 	var/icon_shape = S ? S.icon_state : "human"
 	icon_state = "penis_[icon_shape]_[size]"
-
+	var/lowershape = lowertext(shape)
 	if(owner)
 		if(owner.dna.species.use_skintones && owner.dna.features["genitals_use_skintone"])
 			if(ishuman(owner)) // Check before recasting type, although someone fucked up if you're not human AND have use_skintones somehow...

--- a/code/modules/arousal/organs/testicles.dm
+++ b/code/modules/arousal/organs/testicles.dm
@@ -40,7 +40,6 @@
 
 /obj/item/organ/genital/testicles/update_appearance()
 	. = ..()
-	desc = "You see an [size_name] pair of testicles."
 	var/datum/sprite_accessory/S = GLOB.balls_shapes_list[shape]
 	var/icon_shape = S ? S.icon_state : "single"
 	icon_state = "testicles_[icon_shape]_[size]"
@@ -53,6 +52,10 @@
 					icon_state += "_s"
 		else
 			color = "#[owner.dna.features["balls_color"]]"
+
+/obj/item/organ/genital/testicles/genital_examine(mob/user)
+	. = list()
+	. |= "<span class='notice'>You see an [size_name] pair of testicles.</span>"
 
 /obj/item/organ/genital/testicles/get_features(mob/living/carbon/human/H)
 	var/datum/dna/D = H.dna

--- a/code/modules/arousal/organs/vagina.dm
+++ b/code/modules/arousal/organs/vagina.dm
@@ -24,9 +24,23 @@
 /obj/item/organ/genital/vagina/update_appearance()
 	. = ..()
 	icon_state = "vagina"
-	var/lowershape = lowertext(shape)
-	var/details
+	if(owner)
+		if(owner.dna.species.use_skintones && owner.dna.features["genitals_use_skintone"])
+			if(ishuman(owner)) // Check before recasting type, although someone fucked up if you're not human AND have use_skintones somehow...
+				var/mob/living/carbon/human/H = owner // only human mobs have skin_tone, which we need.
+				color = SKINTONE2HEX(H.skin_tone)
+				if(!H.dna.skin_tone_override)
+					icon_state += "_s"
+		else
+			color = "#[owner.dna.features["vag_color"]]"
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			H.update_genitals()
 
+/obj/item/organ/genital/vagina/genital_examine(mob/user)
+	. = list()
+	var/lowershape = lowertext(shape)
+	var/details = ""
 	switch(lowershape)
 		if("tentacle")
 			details = "Its opening is lined with several tentacles and "
@@ -48,21 +62,7 @@
 		details += "is slick with female arousal."
 	else
 		details += "seems to be dry."
-
-	desc = "You see a vagina. [details]"
-
-	if(owner)
-		if(owner.dna.species.use_skintones && owner.dna.features["genitals_use_skintone"])
-			if(ishuman(owner)) // Check before recasting type, although someone fucked up if you're not human AND have use_skintones somehow...
-				var/mob/living/carbon/human/H = owner // only human mobs have skin_tone, which we need.
-				color = SKINTONE2HEX(H.skin_tone)
-				if(!H.dna.skin_tone_override)
-					icon_state += "_s"
-		else
-			color = "#[owner.dna.features["vag_color"]]"
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.update_genitals()
+	. |= "<span class='notice'>You see a vagina. [details]</span>"
 
 /obj/item/organ/genital/vagina/get_features(mob/living/carbon/human/H)
 	var/datum/dna/D = H.dna

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2694,11 +2694,11 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 					if(toggles & METRIC_OR_BUST)
 						new_length = input(user, "Penis length in centimeters:\n([min_D_m]-[max_D_m])", "Character Preference") as num|null
 						if(new_length)
-							features["cock_length"] = clamp(round(new_length/2.54, 1), min_D, max_D)
+							features["cock_length"] = clamp(round(new_length/2.54, 0.1), min_D, max_D)
 					else
 						new_length = input(user, "Penis length in inches:\n([min_D]-[max_D])", "Character Preference") as num|null
 						if(new_length)
-							features["cock_length"] = clamp(round(new_length, 1), min_D, max_D)
+							features["cock_length"] = clamp(round(new_length, 0.1), min_D, max_D)
 					//Skyrat edit end
 
 				if("cock_shape")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -134,12 +134,12 @@
 	if(LAZYLEN(internal_organs))
 		for(var/obj/item/organ/genital/dicc in internal_organs)
 			if(istype(dicc) && dicc.is_exposed())
-				. += "[dicc.desc]"
+				. |= dicc.genital_examine(user)
 
 	var/cursed_stuff = attempt_vr(src,"examine_bellies",args) //vore Code
 	if(cursed_stuff)
 		. += cursed_stuff
-//END OF CIT CHANGES
+	//END OF CIT CHANGES
 
 	//Jitters
 	switch(jitteriness)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -633,9 +633,19 @@
 			qdel(X)
 		var/min_D = CONFIG_GET(number/penis_min_inches_prefs)
 		var/max_D = CONFIG_GET(number/penis_max_inches_prefs)
-		var/new_length = input(owner, "Penis length in inches:\n([min_D]-[max_D])", "Genital Alteration") as num|null
-		if(new_length)
-			H.dna.features["cock_length"] = clamp(round(new_length), min_D, max_D)
+		//Skyrat edit
+		var/min_D_m = round(min_D * 2.54, 1)
+		var/max_D_m = round(max_D * 2.54, 1)
+		var/new_length
+		if(owner?.client?.prefs?.toggles & METRIC_OR_BUST)
+			new_length = input(owner, "Penis length in inches:\n([min_D_m]-[max_D_m])", "Genital Alteration") as num|null
+			if(new_length)
+				H.dna.features["cock_length"] = clamp(round(new_length/2.54, 0.1), min_D, max_D)
+		else
+			new_length = input(owner, "Penis length in inches:\n([min_D]-[max_D])", "Genital Alteration") as num|null
+			if(new_length)
+				H.dna.features["cock_length"] = clamp(round(new_length, 0.1), min_D, max_D)
+		//Skyrat edit end
 		H.update_genitals()
 		H.apply_overlay()
 		H.give_genital(/obj/item/organ/genital/testicles)


### PR DESCRIPTION
## About The Pull Request

Changing the desc itself instead of doing a proper examine proc is beyond insane - i've fixed that, which allows us to actually respect preferences on measurements of the viewer, instead of just using whatever the wielder of the genital has chosen.

## Why It's Good For The Game

1. Respects preferences for metric/imperial
2. Fixes up dumb code

## Changelog
:cl:
fix: Genitals now actually respect the measurement preferences of the viewer, and not the owner of the genital.
tweak: Genital sizes don't round down to 0 decimals anymore, now it's 1 (e.g. 1.85 becomes 1.9 instead of 2)
/:cl: