### PR TITLE
Fixes sprite accessories not showing proper to the new separated skyrat species

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
@@ -40,7 +40,7 @@
 	color_src = MATRIXED
 	gender_specific = 0
 	icon = 'modular_citadel/icons/mob/mam_markings.dmi'
-	recommended_species = list("mammal", "xeno", "slimeperson", "podweak")
+	recommended_species = list("anthro", "mammal", "aquatic", "avian", "xeno", "slimeperson", "podweak") //skyrat edit
 
 /datum/sprite_accessory/mam_body_markings/none
 	name = "None"

--- a/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
@@ -24,7 +24,7 @@
 	center = TRUE
 	dimension_x = 64
 	color_src = MATRIXED
-	recommended_species = list("human", "lizard", "insect", "mammal", "xeno", "jelly", "slimeperson", "podweak")
+	recommended_species = list("human", "lizard", "insect", "anthro", "mammal", "aquatic", "avian", "xeno", "jelly", "slimeperson", "podweak") //skyrat edit
 	relevant_layers = list(BODY_ADJ_UPPER_LAYER, BODY_FRONT_LAYER)
 	var/taur_mode = NONE //Must be a single specific tauric suit variation bitflag. Don't do FLAG_1|FLAG_2
 	var/alt_taur_mode = NONE //Same as above.

--- a/code/modules/mob/dead/new_player/sprite_accessories/snouts.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/snouts.dm
@@ -153,7 +153,7 @@
 /datum/sprite_accessory/mam_snouts
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_snouts.dmi'
-	recommended_species = list("mammal", "slimeperson", "insect", "podweak")
+	recommended_species = list("anthro", "mammal", "aquatic", "avian", "slimeperson", "insect", "podweak") //Skyrat edit - more species separation
 	mutant_part_string = "snout"
 	relevant_layers = list(BODY_ADJ_LAYER, BODY_FRONT_LAYER)
 

--- a/code/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -535,7 +535,7 @@
 /datum/sprite_accessory/mam_tails
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-	recommended_species = list("mammal", "slimeperson", "podweak", "felinid", "insect")
+	recommended_species = list("anthro", "mammal", "aquatic", "avian", "slimeperson", "podweak", "felinid", "insect") //skyrat edit
 	mutant_part_string = "tail"
 	relevant_layers = list(BODY_BEHIND_LAYER, BODY_FRONT_LAYER)
 


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

Snouts and tails didn't display proper for avians, aquatics and anthros (unlesss you activated mismatched markings) because of this. This fixes the issue.

## Changelog
:cl:
fix: Aquatic, avian and anthro no longer require mismatched markings to work proper with snouts and tails.
/:cl:
