### PR TITLE
(QoL) Highly controversial huge nerf to robust grass.

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -134,6 +134,7 @@
 	desc = "A patch of overgrown grass."
 	icon = 'icons/obj/flora/snowflora.dmi'
 	gender = PLURAL	//"this is grass" not "this is a grass"
+	max_integrity = 20	// Skyrat Edit - This should be easy to remove in-game.
 
 /obj/structure/flora/grass/brown
 	icon_state = "snowgrass1bb"
@@ -177,6 +178,7 @@
 	desc = "Some kind of plant."
 	icon = 'icons/obj/flora/ausflora.dmi'
 	icon_state = "firstbush_1"
+	max_integrity = 20		//Skyrat Edit - Flowers and bushes should not have 150 health.
 
 /obj/structure/flora/ausbushes/Initialize()
 	if(icon_state == "firstbush_1")
@@ -415,6 +417,7 @@
 	desc = "A wild plant that is found in jungles."
 	icon = 'icons/obj/flora/jungleflora.dmi'
 	icon_state = "busha"
+	max_integrity = 20	// Skyrat Edit
 
 /obj/structure/flora/junglebush/Initialize()
 	icon_state = "[icon_state][rand(1, 3)]"

--- a/modular_skyrat/code/game/objects/structures/flora.dm
+++ b/modular_skyrat/code/game/objects/structures/flora.dm
@@ -4,8 +4,8 @@
 	icon = 'modular_skyrat/icons/obj/flora/jungleflora.dmi'
 	icon_state = "stick"
 	gender = PLURAL
-	light_range = 1.5
-	light_power = 0.5
+	light_range = 0.5
+	light_power = 10
 	max_integrity = 50
 	var/variants = 9
 	var/chosen_light
@@ -48,3 +48,12 @@
 	icon_state = "lamp"
 	variants = 2
 	random_light = list("#6AFF00","#00FFEE", "#D9FF00", "#FFC800")
+
+/obj/structure/flora/biolumi/mine/weaklight
+	light_range = 0.2
+
+/obj/structure/flora/biolumi/flower/weaklight
+	light_range = 0.2
+
+/obj/structure/flora/biolumi/lamp/weaklight
+	light_range = 0.2


### PR DESCRIPTION
## About The Pull Request
• Lowers the max integrity of flowers, bushes and grass from 150 to 20. You should be able to clear plants with ease. This is a QoL fix for planetstation, however, the timelines are erroring and this QoL change is too early for this timeline as this timeline has yet to be blessed by a floofy planetstation.
• Changes luminescent lights to have 0.5 power and 10 range, making them illuminate a large area dimly, much better for mapping.

## Why It's Good For The Game
Decorative flora should be easy to clear out. They're structures, they stay there even if you remove the turf undearneath. What if you wanted to build, but to remove the flowers you have to hit them ten times with a welder? You'd be frustrated. Hitting it two times with a welder or toolbox is much less frustrating. Also, uprooting a bush shouldn't be more difficult than smashing a big glass window.

Bio luminescent plants have amazing potential, making them light a large area very dimly capitalises on said potential.

## Changelog
:cl:
fix: Flowers, bushes and grass missing their own max_integrity variable now have it. They don't inherit an unrealistic level of robustness that the trees have, and flowers/bushes/grass are now as weak as they should be.
/:cl:

## Media
![image](https://user-images.githubusercontent.com/53862927/90333816-c597db80-dfc0-11ea-8410-97c4751fa111.png)
_Before_
![image](https://user-images.githubusercontent.com/53862927/90333806-b2850b80-dfc0-11ea-8b3b-836ab4c57e2f.png)
_After_
