### PR TITLE
[SPEEDMERGE] Fixes punch miss messages, fixes timestop memes

### DIFF
--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -106,8 +106,9 @@
 /obj/effect/abstract/proximity_checker/Destroy()
 	//Skyrat changes
 	if(monitor)
-		monitor.checkers -= src
-		monitor = null
+		if(length(monitor.checkers))
+			monitor.checkers -= src
+			monitor = null
 	//End of skyrat changes
 	return ..()
 

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -108,7 +108,7 @@
 	if(monitor)
 		if(length(monitor.checkers))
 			monitor.checkers -= src
-			monitor = null
+		monitor = null
 	//End of skyrat changes
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1530,7 +1530,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_datums)
 		if(!damage || !affecting || prob(miss_chance))//future-proofing for species that have 0 damage/weird cases where no zone is targeted
 			playsound(target.loc, user.dna.species.miss_sound, 25, TRUE, -1)
 			target.visible_message("<span class='danger'>[user]'s [atk_verb] misses [target]!</span>", \
-							"<span class='danger'>You avoid [user]'s [atk_verb]!</span>", "<span class='hear'>You hear a swoosh!</span>", null, COMBAT_MESSAGE_RANGE, null, \
+							"<span class='danger'>You avoid [user]'s [atk_verb]!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, null, \
 							user, "<span class='warning'>Your [atk_verb] misses [target]!</span>")
 			log_combat(user, target, "attempted to punch")
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

Timestop no longer runtimes, thus freezing all the mobs affected indefinitely
Punch miss messages now work proper
![image](https://user-images.githubusercontent.com/25989101/90392409-309aee00-e065-11ea-8e67-1a46962ea414.png)

## Why It's Good For The Game

d

## Changelog
:cl:
fix: Timestop no longer freezes mobs indefinitely because of a runtime
fix: Punch miss messages no longer appear as if they were an emote done by the target
/:cl:
