### PR TITLE
Fixes terror spiders gibbing randomly

### DIFF
--- a/modular_skyrat/code/modules/mob/living/simple_animal/terror_spiders/terror_spiders.dm
+++ b/modular_skyrat/code/modules/mob/living/simple_animal/terror_spiders/terror_spiders.dm
@@ -288,7 +288,7 @@ GLOBAL_LIST_EMPTY(ts_spiderling_list)
 	handle_dying()
 	return ..()
 
-/mob/living/simple_animal/hostile/poison/terror_spider/Life(seconds, times_fired)
+/mob/living/simple_animal/hostile/poison/terror_spider/PhysicalLife(seconds, times_fired)
 	. = ..()
 	if(!.) // if mob is dead
 		if(prob(2))


### PR DESCRIPTION
## About The Pull Request

The code wasn't adapted for the Life() proc split and this funny happened.

## Why It's Good For The Game

Fuck.

## Changelog
:cl:
fix: Terror spiders no longer get gibbed randomly.
/:cl:
