### PR TITLE
Ghost cafe is finally fixed, hopefully, and removes adamantine from the stack spawner

### DIFF
--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -2113,7 +2113,7 @@
 "fy" = (
 /obj/machinery/light,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "fz" = (
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
@@ -2944,7 +2944,7 @@
 	},
 /obj/machinery/prize_counter/upgraded,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3711,6 +3711,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"jA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "jB" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -4197,7 +4203,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "kw" = (
 /turf/open/floor/plasteel/yellowsiding,
 /area/centcom/supply)
@@ -4367,10 +4373,6 @@
 	icon_state = "alien19"
 	},
 /area/abductor_ship)
-"kR" = (
-/obj/effect/light_emitter,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
 "kS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4809,7 +4811,7 @@
 	name = "Dorm 1"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -4878,7 +4880,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "mb" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5440,8 +5442,10 @@
 /obj/item/melee/roastingstick,
 /obj/item/melee/roastingstick,
 /obj/item/melee/roastingstick,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "ni" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/indestructible/riveted,
@@ -6505,7 +6509,11 @@
 /obj/item/ammo_box/n762,
 /obj/item/ammo_box/n762,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
+"oV" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "oW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -6884,7 +6892,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "pz" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -6897,7 +6905,7 @@
 	dir = 8
 	},
 /turf/open/warzonetile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "pB" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien8";
@@ -6905,16 +6913,15 @@
 	},
 /area/bluespace_locker)
 "pC" = (
-/obj/machinery/chem_heater,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "pD" = (
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "pE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7062,7 +7069,7 @@
 "pS" = (
 /obj/structure/fans/tiny/invisible,
 /turf/closed/indestructible/fakeglass,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "pT" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/podStorage)
@@ -7083,7 +7090,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "pW" = (
 /obj/effect/landmark/ai_multicam_room,
 /turf/open/ai_visible,
@@ -7463,7 +7470,7 @@
 	},
 /obj/structure/rack,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "qH" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -7472,7 +7479,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/benedict,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "qI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -7500,7 +7507,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "qM" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -7519,7 +7526,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/bearsteak,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "qO" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Bar Access"
@@ -7533,7 +7540,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "qQ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
@@ -7646,12 +7653,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "ri" = (
 /obj/item/storage/belt/utility/servant,
 /obj/item/storage/belt/utility/servant,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "rk" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -8149,7 +8156,7 @@
 	pixel_y = 24
 	},
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "rZ" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -8157,10 +8164,6 @@
 /obj/item/disk/surgery/debug,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
-"sa" = (
-/obj/item/hilbertshotel/ghostdojo,
-/turf/open/floor/carpet/red,
-/area/centcom/holding)
 "sb" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -8169,7 +8172,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/cornedbeef,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "sc" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership/control;
@@ -8194,7 +8197,7 @@
 "se" = (
 /obj/machinery/pool/drain,
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "sf" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -8244,7 +8247,7 @@
 "sk" = (
 /obj/machinery/computer/arcade/tetris,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "sm" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mineral/titanium/white,
@@ -8262,7 +8265,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "sq" = (
 /obj/machinery/computer/shuttle/white_ship{
 	dir = 4
@@ -8658,7 +8661,7 @@
 "sY" = (
 /mob/living/simple_animal/parrot,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "sZ" = (
 /obj/structure/sign/map/left{
 	pixel_y = -32
@@ -8678,7 +8681,7 @@
 "tc" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "td" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -8715,8 +8718,10 @@
 "th" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/brown,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "ti" = (
 /obj/structure/table,
 /obj/structure/window{
@@ -8727,11 +8732,11 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "tj" = (
 /mob/living/simple_animal/chicken/rabbit,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "tk" = (
 /obj/structure/table,
 /obj/item/clothing/mask/luchador/tecnicos,
@@ -8805,14 +8810,16 @@
 /area/centcom/ferry)
 "tv" = (
 /mob/living/simple_animal/pet/penguin/emperor,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "tw" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -9076,7 +9083,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "tT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9147,14 +9154,14 @@
 	pixel_y = -8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "tZ" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ua" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/hypospraykit/toxin{
@@ -9195,10 +9202,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
-"ue" = (
-/obj/structure/flora/grass/brown,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
 "uf" = (
 /obj/machinery/light{
 	dir = 4
@@ -9221,7 +9224,7 @@
 	name = "Dorm 2"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ui" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9525,6 +9528,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"uI" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/holding/cafewar)
 "uJ" = (
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/closed/indestructible/riveted,
@@ -9845,7 +9851,7 @@
 "vq" = (
 /obj/machinery/pool/controller,
 /turf/open/floor/plasteel/yellowsiding,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "vs" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -9859,7 +9865,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "vt" = (
 /turf/closed/indestructible/wood,
 /area/centcom/holding)
@@ -9900,7 +9906,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "vy" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -10276,10 +10282,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"wf" = (
-/obj/effect/light_emitter,
-/turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
 "wg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -10322,7 +10324,7 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "wj" = (
 /obj/machinery/light{
 	dir = 8
@@ -10607,6 +10609,12 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"wR" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "wS" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -10885,12 +10893,12 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/steak,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "xD" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 8
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "xE" = (
 /obj/structure/table,
 /obj/item/clothing/mask/luchador,
@@ -10940,7 +10948,7 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "xM" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -10957,7 +10965,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "xP" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien2";
@@ -11072,6 +11080,14 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"yc" = (
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
+"yd" = (
+/obj/structure/mineral_door/paperframe,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "yf" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -11080,7 +11096,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "yg" = (
 /obj/structure/chair,
 /turf/open/floor/mineral/titanium,
@@ -11101,7 +11117,7 @@
 	},
 /obj/structure/table,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "yi" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plating/beach/sand,
@@ -11386,11 +11402,15 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "yN" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
+"yO" = (
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "yP" = (
 /obj/machinery/light{
 	dir = 4
@@ -11416,7 +11436,7 @@
 	name = "Dorm 7"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "yT" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/centcom/evac)
@@ -11446,11 +11466,11 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "yX" = (
 /obj/item/target/syndicate,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "yY" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -11670,6 +11690,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership)
+"zt" = (
+/obj/machinery/light,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "zu" = (
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
@@ -11683,7 +11707,7 @@
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "zx" = (
 /obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/stripes/line{
@@ -11889,7 +11913,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "zU" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/plasteel/cafeteria,
@@ -11904,14 +11928,14 @@
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "zW" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "Ninja5";
 	name = "Dorm 5"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "zX" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -11919,7 +11943,7 @@
 	},
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "zY" = (
 /obj/item/bedsheet/wiz{
 	desc = "A glow in the dark blue bedsheet.";
@@ -11927,7 +11951,11 @@
 	},
 /obj/structure/bed,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"zZ" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/indestructible,
+/area/centcom/holding/cafewar)
 "Aa" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/syndicate_mothership)
@@ -12188,7 +12216,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "AD" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Leader's Room";
@@ -12418,6 +12446,12 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"Bb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "Bc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -12462,6 +12496,10 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"Bj" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "Bk" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -12482,6 +12520,11 @@
 /obj/structure/bookcase/random,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
+"Bo" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "Bp" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -12495,12 +12538,12 @@
 "Br" = (
 /obj/machinery/recharger,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Bs" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Bt" = (
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
@@ -12774,7 +12817,7 @@
 "BP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "BQ" = (
 /obj/effect/landmark/abductor/scientist{
 	team_number = 3
@@ -12822,7 +12865,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "BX" = (
 /obj/structure/chair/sofa,
 /obj/machinery/light{
@@ -12886,7 +12929,7 @@
 "Cd" = (
 /mob/living/simple_animal/pet/redpanda,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ce" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -12894,8 +12937,13 @@
 /area/fabric_of_reality)
 "Cf" = (
 /obj/structure/bonfire/prelit,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
+"Cg" = (
+/turf/open/floor/grass,
+/area/centcom/holding/cafepark)
 "Ch" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/mineral/titanium/blue,
@@ -12934,7 +12982,7 @@
 	dir = 4
 	},
 /turf/open/warzonetile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Cn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -13327,16 +13375,16 @@
 "CP" = (
 /obj/structure/pool/ladder,
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "CQ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"CR" = (
-/turf/closed/indestructible/rock/glacierrock,
-/area/centcom/holding)
+"CS" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding/cafevox)
 "CT" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
@@ -13349,15 +13397,18 @@
 /obj/item/storage/box/silver_ids,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"CU" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding/cafebotany)
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "CW" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -13473,7 +13524,7 @@
 "Dh" = (
 /obj/machinery/chem_heater,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Di" = (
 /turf/closed/indestructible/riveted,
 /area/ai_multicam_room)
@@ -13491,7 +13542,7 @@
 /area/centcom/holding)
 "Dm" = (
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Dn" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -13576,7 +13627,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Dx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/kirbyplants/random,
@@ -13595,11 +13646,13 @@
 	pixel_y = -24
 	},
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "DA" = (
 /obj/structure/flora/rock/icy,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "DB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plasteel/dark,
@@ -14068,7 +14121,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "EE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/neutral{
@@ -14270,19 +14323,25 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"EZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "Fa" = (
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
 /obj/item/instrument/guitar,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Fb" = (
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
 "Fc" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "Fd" = (
 /obj/structure/reagent_dispensers/beerkeg{
 	reagent_id = /datum/reagent/consumable/ethanol/beer/light
@@ -14306,10 +14365,10 @@
 /area/syndicate_mothership)
 "Fh" = (
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Fi" = (
 /turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Fj" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -14333,10 +14392,22 @@
 "Fl" = (
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"Fm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "Fn" = (
 /turf/open/floor/plating,
 /area/fabric_of_reality)
+"Fo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "Fp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14411,7 +14482,7 @@
 "Fy" = (
 /mob/living/simple_animal/pet/fox,
 /turf/open/indestructible/cobble,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Fz" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -14443,11 +14514,21 @@
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 4
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
+"FD" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafevox)
 "FE" = (
 /obj/effect/light_emitter,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
+"FF" = (
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "FG" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -14544,7 +14625,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "FT" = (
 /obj/structure/destructible/cult/forge{
 	desc = "An engine used in powering the wizard's ship";
@@ -14569,10 +14650,10 @@
 	},
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "FX" = (
 /turf/open/floor/plasteel/stairs,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "FY" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -14752,7 +14833,7 @@
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Gu" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -14804,7 +14885,11 @@
 "GC" = (
 /obj/structure/barricade/security/murderdome,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
+"GD" = (
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "GE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15103,7 +15188,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ha" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -15117,7 +15202,7 @@
 	},
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Hb" = (
 /obj/machinery/processor,
 /turf/open/floor/wood,
@@ -15173,14 +15258,14 @@
 "Hi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Hj" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/musician/piano,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Hk" = (
 /obj/structure/table/wood,
 /obj/item/camera/detective{
@@ -15191,7 +15276,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Hl" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -15209,7 +15294,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ho" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -15352,6 +15437,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"HA" = (
+/turf/open/floor/plasteel/white,
+/area/centcom/holding/cafedorms)
 "HB" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -15425,7 +15513,7 @@
 /area/centcom/holding)
 "HI" = (
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "HJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/chef,
@@ -15523,7 +15611,7 @@
 "HQ" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "HR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -15806,7 +15894,7 @@
 "In" = (
 /mob/living/simple_animal/parrot,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Io" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -16052,7 +16140,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "IP" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -16255,7 +16343,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Jk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -16408,7 +16496,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "JF" = (
 /obj/machinery/computer/camera_advanced/abductor{
 	team_number = 1
@@ -16603,7 +16691,7 @@
 /obj/item/cookiesynth,
 /obj/item/cookiesynth,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "JW" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien12";
@@ -16624,7 +16712,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "JZ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -16699,14 +16787,14 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Kf" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -16732,7 +16820,7 @@
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Kj" = (
 /obj/machinery/door/airlock/external{
 	name = "Backup Emergency Escape Shuttle"
@@ -16797,16 +16885,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
-"Kp" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/turf/open/indestructible,
-/area/centcom/holding)
 "Kq" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "Kr" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -16921,7 +17005,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Kx" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating,
@@ -17071,7 +17155,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "KU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/blue,
@@ -17155,7 +17239,7 @@
 /obj/item/reagent_containers/food/snacks/meat/steak,
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Lg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17202,19 +17286,19 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Lm" = (
 /obj/machinery/shower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ln" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Lo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -17237,12 +17321,12 @@
 	pixel_y = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Lr" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ls" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -17259,7 +17343,7 @@
 /area/centcom/evac)
 "Lu" = (
 /turf/open/floor/plasteel/yellowsiding/corner,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Lv" = (
 /obj/structure/bed,
 /turf/open/floor/mineral/titanium/blue,
@@ -17298,6 +17382,9 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"LD" = (
+/turf/open/floor/plating,
+/area/centcom/holding/cafevox)
 "LE" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -17310,7 +17397,7 @@
 /obj/item/melee/rapier,
 /obj/item/melee/rapier,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "LG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/mineral/titanium/blue,
@@ -17543,7 +17630,7 @@
 /area/centcom/supplypod/loading/four)
 "Mm" = (
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Mn" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/purple,
@@ -17570,7 +17657,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Mv" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -17622,7 +17709,7 @@
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "MA" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien3";
@@ -17632,6 +17719,26 @@
 "MB" = (
 /turf/open/indestructible/binary,
 /area/fabric_of_reality)
+"MC" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/tile/wood{
+	amount = 24
+	},
+/obj/item/stack/tile/carpet/black/fifty,
+/obj/item/stack/tile/carpet/blackred/fifty,
+/obj/item/stack/tile/carpet/blue/fifty,
+/obj/item/stack/tile/carpet/cyan/fifty,
+/obj/item/stack/tile/carpet/fifty,
+/obj/item/stack/tile/carpet/green/fifty,
+/obj/item/stack/tile/carpet/monochrome/fifty,
+/obj/item/stack/tile/carpet/orange/fifty,
+/obj/item/stack/tile/carpet/purple/fifty,
+/obj/item/stack/tile/carpet/red/fifty,
+/obj/item/stack/tile/carpet/royalblack/fifty,
+/obj/item/stack/tile/carpet/royalblue/fifty,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "MD" = (
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -17665,7 +17772,7 @@
 	name = "Animal Pen"
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "MH" = (
 /obj/structure/ladder/unbreakable/binary/unlinked,
 /turf/open/indestructible/airblock,
@@ -17679,17 +17786,19 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "MK" = (
 /obj/item/storage/belt/utility/servant,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "ML" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "MM" = (
 /obj/item/reagent_containers/spray/spraytan,
 /obj/effect/turf_decal/sand,
@@ -17728,6 +17837,10 @@
 /obj/item/reagent_containers/food/condiment/enzyme,
 /turf/open/floor/plasteel/cafeteria,
 /area/syndicate_mothership)
+"MT" = (
+/obj/structure/flora/tree/pine,
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "MU" = (
 /obj/item/flashlight/lantern,
 /obj/machinery/light/small{
@@ -17736,8 +17849,9 @@
 /turf/open/floor/plating,
 /area/fabric_of_reality)
 "MV" = (
+/obj/structure/fans/tiny/invisible,
 /turf/open/water/lavaland_jungle,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "MW" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -17745,13 +17859,20 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/fabric_of_reality)
+"MX" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafebotany)
 "MY" = (
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "MZ" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien23";
@@ -17775,13 +17896,13 @@
 /obj/item/reagent_containers/food/snacks/beefnoodle,
 /obj/item/reagent_containers/food/snacks/beefnoodle,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Nc" = (
 /obj/machinery/atm{
 	pixel_x = -30
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Nd" = (
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
@@ -17801,7 +17922,7 @@
 "Nf" = (
 /obj/machinery/autolathe/toy,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ng" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17813,7 +17934,7 @@
 "Nh" = (
 /obj/structure/window/plasma/reinforced,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ni" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -17839,10 +17960,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
-"Nl" = (
-/obj/machinery/chem_master,
-/turf/open/indestructible,
-/area/centcom/holding)
 "Nm" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -17877,7 +17994,7 @@
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Nq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/window/reinforced/spawner{
@@ -17897,11 +18014,11 @@
 "Ns" = (
 /obj/machinery/vending/donksofttoyvendor,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Nt" = (
 /obj/structure/bedsheetbin/color,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Nu" = (
 /turf/open/floor/wood,
 /area/syndicate_mothership)
@@ -17921,14 +18038,14 @@
 "Nw" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Nx" = (
 /obj/machinery/processor,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ny" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/nuclear{
@@ -17941,7 +18058,7 @@
 	pixel_y = -3
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Nz" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -17980,7 +18097,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "NF" = (
 /obj/structure/ladder/unbreakable/binary,
 /turf/open/indestructible/airblock,
@@ -18025,7 +18142,7 @@
 "NL" = (
 /obj/item/target/clown,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "NM" = (
 /turf/closed/indestructible/abductor{
 	opacity = 0
@@ -18034,7 +18151,7 @@
 "NN" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "NO" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/hypospray/combat{
@@ -18055,16 +18172,24 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
+"NQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "NR" = (
 /obj/structure/fans/tiny/invisible,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "NS" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/toy/poolnoodle/blue,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "NT" = (
 /obj/structure/window/paperframe{
 	CanAtmosPass = 0
@@ -18106,7 +18231,7 @@
 "NY" = (
 /obj/structure/pool/Lboard,
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "NZ" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/bag/money/c5000,
@@ -18114,16 +18239,15 @@
 /obj/item/storage/bag/money/c5000,
 /obj/item/key/janitor,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Oa" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/syndicate_mothership)
 "Ob" = (
 /obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Oc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -18139,17 +18263,17 @@
 "Od" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Oe" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/syndicate_mothership)
 "Of" = (
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Og" = (
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Oh" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/automatic/combat{
@@ -18165,7 +18289,7 @@
 	pixel_y = 5
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Oi" = (
 /obj/item/tank/internals/nitrogen/belt/full,
 /obj/item/clothing/mask/breath/vox,
@@ -18210,14 +18334,14 @@
 "Ol" = (
 /obj/structure/table/wood/fancy,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Om" = (
 /turf/closed/indestructible/rock/glacierrock,
-/area/space)
+/area/centcom/holding/cafepark)
 "On" = (
 /obj/machinery/rnd/production/cafe_circuit_imprinter,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Oo" = (
 /obj/machinery/light{
 	dir = 8
@@ -18240,7 +18364,17 @@
 	},
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"Oq" = (
+/obj/machinery/chem_master,
+/turf/open/indestructible,
+/area/centcom/holding/cafewar)
+"Or" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "Os" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -18249,11 +18383,11 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ot" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ou" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Cold Storage"
@@ -18268,7 +18402,7 @@
 	name = "Cryo"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Oy" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/tequila,
@@ -18287,7 +18421,7 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "OB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Barracks";
@@ -18303,7 +18437,7 @@
 /area/centcom/holding)
 "OD" = (
 /turf/open/floor/plasteel/yellowsiding,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "OE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -18345,12 +18479,12 @@
 	},
 /obj/machinery/rnd/production/techfab/department/engineering,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "OH" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/toy/poolnoodle/red,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "OI" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18364,6 +18498,10 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/centcom/evac)
+"OK" = (
+/obj/structure/chair/stool,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "OL" = (
 /obj/structure/mineral_door/paperframe{
 	name = "Dodgeball Court"
@@ -18374,7 +18512,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "ON" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
@@ -18387,7 +18525,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "OP" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -18431,7 +18569,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "OX" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Bar Storage"
@@ -18453,7 +18591,7 @@
 /obj/structure/flora/tree/pine,
 /obj/structure/flora/grass/brown,
 /turf/open/floor/grass/snow,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Pc" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -18473,7 +18611,7 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/item/book/manual/hydroponics_pod_people,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Pd" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -18504,7 +18642,7 @@
 "Ph" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Pi" = (
 /obj/structure/chair{
 	dir = 1
@@ -18575,7 +18713,7 @@
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ps" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/structure/extinguisher_cabinet{
@@ -18585,8 +18723,10 @@
 /area/centcom/evac)
 "Pt" = (
 /obj/structure/chair/wood,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Pu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark,
@@ -18598,7 +18738,7 @@
 	pixel_x = 32
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Pw" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -18666,7 +18806,7 @@
 "PG" = (
 /mob/living/simple_animal/pet/redpanda,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "PH" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
@@ -18687,7 +18827,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18703,13 +18843,13 @@
 "PL" = (
 /obj/machinery/autolathe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PM" = (
 /obj/machinery/vending/clothing{
 	extended_inventory = 1
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "PO" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -18723,7 +18863,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PP" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -18734,7 +18874,7 @@
 /obj/structure/closet/secure_closet,
 /obj/item/coin/silver,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "PR" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/toolbox/mechanical,
@@ -18752,7 +18892,7 @@
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PS" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /obj/effect/turf_decal/tile/bar,
@@ -18768,7 +18908,7 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "PU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18803,7 +18943,7 @@
 "PX" = (
 /obj/machinery/computer/arcade/battle,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "PY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -18816,11 +18956,11 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PZ" = (
 /mob/living/simple_animal/sloth,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Qa" = (
 /obj/machinery/sleeper/centcom{
 	dir = 4
@@ -18841,6 +18981,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"Qd" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/holding/cafebuild)
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
@@ -18888,7 +19031,7 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ql" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18897,8 +19040,10 @@
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Qm" = (
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Qn" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/mineral/titanium/white,
@@ -18909,7 +19054,7 @@
 "Qp" = (
 /obj/structure/bedsheetbin,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Qq" = (
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
@@ -18924,8 +19069,10 @@
 /area/centcom/holding)
 "Qs" = (
 /mob/living/simple_animal/deer,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Qt" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
@@ -18940,7 +19087,7 @@
 	name = "Dorms"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Qv" = (
 /obj/structure/chair{
 	dir = 1
@@ -18952,7 +19099,7 @@
 /area/centcom/evac)
 "Qw" = (
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Qx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -18984,11 +19131,11 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QB" = (
 /obj/machinery/computer/telecrystals/uplinker,
 /obj/effect/turf_decal/stripes/line{
@@ -19001,7 +19148,7 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QD" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -19033,7 +19180,7 @@
 	pixel_x = 9
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "QF" = (
 /obj/machinery/button/door{
 	id = "Ninja3";
@@ -19043,12 +19190,19 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QG" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
 /area/fabric_of_reality)
+"QH" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/grass/brown,
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "QI" = (
 /obj/structure/closet{
 	name = "coat closet"
@@ -19080,17 +19234,17 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QK" = (
 /obj/structure/rack,
 /obj/item/melee/transforming/cleaving_saw,
 /obj/item/melee/transforming/cleaving_saw,
 /obj/item/crucible,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "QL" = (
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "QM" = (
 /turf/open/floor/plating/beach/sand,
 /area/fabric_of_reality)
@@ -19099,7 +19253,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QO" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -19134,7 +19288,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QU" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -19156,7 +19310,7 @@
 	locked = 0
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -19214,7 +19368,7 @@
 "Re" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Rf" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -19230,19 +19384,19 @@
 	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Rh" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ri" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Rj" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/tile/green{
@@ -19256,7 +19410,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Rk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
@@ -19274,7 +19428,7 @@
 	dir = 3
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Rn" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien7";
@@ -19316,7 +19470,7 @@
 	light_color = "#cee5d2"
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Rr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19341,15 +19495,17 @@
 "Ru" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Rv" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Rw" = (
 /obj/structure/chair/stool,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Rx" = (
 /obj/structure/displaycase/trophy,
 /turf/open/indestructible/hotelwood,
@@ -19359,7 +19515,7 @@
 	pixel_y = 22
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Rz" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating,
@@ -19385,7 +19541,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/beefnoodle,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "RD" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -19442,7 +19598,7 @@
 "RL" = (
 /obj/machinery/vending/cola,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RM" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -19464,7 +19620,7 @@
 	},
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "RO" = (
 /obj/machinery/shower{
 	dir = 1
@@ -19474,14 +19630,14 @@
 	},
 /obj/structure/curtain,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RP" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "Ninja4";
 	name = "Dorm 4"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RQ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -19489,7 +19645,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "RR" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -19514,7 +19670,7 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/item/toy/poolnoodle/yellow,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "RU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19554,11 +19710,11 @@
 	color = "#596479"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RY" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "RZ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -19603,7 +19759,7 @@
 	},
 /obj/structure/rack,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Sf" = (
 /obj/structure/chair{
 	dir = 4;
@@ -19642,7 +19798,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Sk" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/vending/snack/random,
@@ -19651,15 +19807,15 @@
 "Sl" = (
 /obj/structure/bed,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Sm" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Sn" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "So" = (
 /obj/structure/chair/sofa/right,
 /obj/machinery/light{
@@ -19681,7 +19837,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Sr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -19733,7 +19889,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Sx" = (
 /obj/machinery/button/door{
 	id = "CCD2";
@@ -19764,7 +19920,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "SC" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -19795,7 +19951,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/bearsteak,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "SG" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -19803,7 +19959,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "SH" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -19849,7 +20005,7 @@
 "SL" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "SM" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -19860,7 +20016,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "SO" = (
 /obj/structure/destructible/cult/tome,
 /turf/open/indestructible/hotelwood,
@@ -19883,7 +20039,7 @@
 	name = "Dorm 7"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "SS" = (
 /obj/structure/table,
 /obj/structure/window{
@@ -19891,14 +20047,14 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "ST" = (
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "SU" = (
 /obj/structure/fans/tiny/invisible,
 /turf/closed/indestructible/rock/snow,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "SV" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -19920,7 +20076,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "SX" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
@@ -19940,7 +20096,7 @@
 	name = "Dorm 3"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ta" = (
 /obj/machinery/door/airlock{
 	id_tag = "CCD3"
@@ -19963,7 +20119,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Td" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
@@ -19976,7 +20132,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Tg" = (
 /obj/effect/mob_spawn/human/ghostcafe{
 	dir = 8
@@ -19992,7 +20148,7 @@
 "Ti" = (
 /mob/living/simple_animal/pet/redpanda,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Tj" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -20025,10 +20181,14 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "To" = (
 /turf/open/indestructible/airblock,
 /area/fabric_of_reality)
+"Tp" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "Tq" = (
 /obj/structure/table/wood/bar,
 /obj/item/stack/sheet/glass/fifty,
@@ -20037,11 +20197,11 @@
 /obj/item/stack/sheet/plastic/fifty,
 /obj/item/multitool,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Tr" = (
 /obj/structure/closet/chefcloset,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ts" = (
 /obj/machinery/button/door{
 	id = "CCD1";
@@ -20062,7 +20222,7 @@
 	icon_state = "twindow"
 	},
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Tu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -20070,11 +20230,11 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Tv" = (
 /obj/structure/flora/ausbushes,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Tw" = (
 /obj/effect/mob_spawn/robot/ghostcafe,
 /turf/open/indestructible/hotelwood,
@@ -20093,11 +20253,13 @@
 	},
 /obj/structure/table,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ty" = (
 /mob/living/simple_animal/pet/penguin/baby,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Tz" = (
 /obj/effect/light_emitter,
 /turf/open/floor/plating/asteroid/snow/airless,
@@ -20111,11 +20273,11 @@
 "TB" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "TC" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "TD" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -20155,7 +20317,7 @@
 	},
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "TH" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien16";
@@ -20172,7 +20334,7 @@
 /area/centcom/holding)
 "TK" = (
 /turf/closed/indestructible/rock,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "TL" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -20240,6 +20402,10 @@
 /obj/item/toy/plush/carpplushie,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"TV" = (
+/obj/machinery/vending/snack/random,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "TW" = (
 /turf/open/floor/carpet/royalblack,
 /area/centcom/evac)
@@ -20272,7 +20438,7 @@
 	pixel_y = -2
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "TY" = (
 /obj/machinery/light{
 	dir = 1
@@ -20283,7 +20449,7 @@
 /obj/item/janiupgrade,
 /obj/vehicle/ridden/janicart,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "TZ" = (
 /obj/item/storage/backpack/duffelbag,
 /turf/open/floor/plating/beach/sand,
@@ -20317,6 +20483,12 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/plating/beach/water,
 /area/fabric_of_reality)
+"Uf" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "Ug" = (
 /obj/machinery/door/poddoor/shuttledock{
 	checkdir = 1;
@@ -20357,7 +20529,7 @@
 /obj/item/vending_refill/snack,
 /obj/item/vending_refill/snack,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ul" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -20385,7 +20557,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Un" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -20395,10 +20567,17 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Uo" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafedorms)
 "Up" = (
 /mob/living/simple_animal/pet/cat,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Uq" = (
 /obj/structure/table/wood,
 /obj/item/soap,
@@ -20409,10 +20588,10 @@
 /obj/item/storage/bag/trash,
 /obj/item/storage/bag/trash,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ur" = (
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Us" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -20458,7 +20637,7 @@
 /obj/structure/table,
 /obj/machinery/dish_drive,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "UA" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
@@ -20489,11 +20668,11 @@
 /obj/item/coin/silver,
 /obj/item/coin/silver,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UF" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/mineral/titanium/blue,
@@ -20522,7 +20701,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UK" = (
 /obj/machinery/door/airlock{
 	id_tag = "CCD1"
@@ -20557,7 +20736,7 @@
 	},
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -20597,24 +20776,24 @@
 "US" = (
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "UT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UU" = (
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "UV" = (
 /obj/machinery/computer/arcade,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UW" = (
 /obj/machinery/light,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "UX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -20626,11 +20805,11 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UZ" = (
 /obj/item/target,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Va" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20648,17 +20827,17 @@
 	dir = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Vd" = (
 /mob/living/simple_animal/kiwi,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Ve" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Vf" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
@@ -20676,6 +20855,9 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"Vh" = (
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "Vi" = (
 /obj/structure/table/reinforced,
 /obj/item/binoculars{
@@ -20722,7 +20904,7 @@
 "Vn" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Vo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/toxin,
@@ -20785,12 +20967,12 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Vv" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Vw" = (
 /obj/structure/table,
 /obj/item/kitchen/fork,
@@ -20823,7 +21005,7 @@
 	use_power = 0
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "VA" = (
 /obj/effect/landmark/holding_facility,
 /mob/living/simple_animal/bot/medbot{
@@ -20852,7 +21034,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "VE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/fire,
@@ -20890,11 +21072,15 @@
 /area/centcom/holding)
 "VG" = (
 /turf/closed/indestructible/rock/snow,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "VH" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"VI" = (
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "VJ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -20905,7 +21091,7 @@
 "VK" = (
 /mob/living/simple_animal/pet/dog/cheems,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "VL" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumGhostDojo";
@@ -20914,7 +21100,7 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "VN" = (
 /obj/structure/rack,
 /obj/item/shield/riot/tele{
@@ -20973,7 +21159,7 @@
 /obj/item/clothing/suit/space/hardsuit/syndi,
 /obj/item/clothing/suit/space/hardsuit/syndi,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "VO" = (
 /turf/closed/indestructible/fakedoor,
 /area/centcom/evac)
@@ -20992,6 +21178,9 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"VS" = (
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "VT" = (
 /obj/structure/table/wood,
 /obj/item/syndicatedetonator{
@@ -21009,7 +21198,7 @@
 /obj/item/storage/box/lethalslugs,
 /obj/structure/closet,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "VV" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/red,
@@ -21034,7 +21223,7 @@
 "VZ" = (
 /mob/living/simple_animal/pet/dog/corgi,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Wb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -21079,14 +21268,14 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Wh" = (
 /obj/machinery/jukebox/disco{
 	req_access = null;
 	req_one_access = null
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Wi" = (
 /turf/open/warzonetile,
 /area/centcom/holding)
@@ -21097,10 +21286,13 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Wk" = (
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "Wl" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Wm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -21112,7 +21304,7 @@
 "Wn" = (
 /obj/machinery/vending/tool,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Wp" = (
 /turf/open/floor/carpet/royalblue,
 /area/centcom/evac)
@@ -21136,7 +21328,7 @@
 	name = "Dorm 6"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/healthanalyzer/advanced{
@@ -21168,7 +21360,7 @@
 	id = "crematoriumGhostDojo"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Wx" = (
 /obj/machinery/light{
 	dir = 8
@@ -21181,7 +21373,7 @@
 "Wy" = (
 /mob/living/simple_animal/pet/fox,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Wz" = (
 /obj/item/defibrillator/compact/loaded,
 /obj/item/defibrillator/compact/loaded,
@@ -21218,19 +21410,23 @@
 	pixel_y = 28
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "WE" = (
 /obj/machinery/vending/kink{
 	extended_inventory = 1
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "WF" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Lavatory"
 	},
 /turf/open/floor/plating,
 /area/fabric_of_reality)
+"WG" = (
+/obj/machinery/light,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "WH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -21241,7 +21437,7 @@
 /obj/item/storage/box/beakers/variety,
 /obj/item/storage/box/beakers/variety,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "WJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
@@ -21273,7 +21469,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "WN" = (
 /obj/machinery/button/door{
 	id = "Ninja6";
@@ -21283,12 +21479,17 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"WO" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "WP" = (
 /obj/structure/flora/grass/brown,
-/obj/effect/light_emitter,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "WQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -21335,7 +21536,7 @@
 	name = "red bedsheet"
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "WW" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -21349,11 +21550,16 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "WZ" = (
 /obj/structure/flora/tree/pine,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
+"Xa" = (
+/turf/open/water/lavaland_jungle,
+/area/centcom/holding/cafepark)
 "Xb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box{
@@ -21376,11 +21582,11 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Xe" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Xf" = (
 /obj/structure/table/wood/bar,
 /obj/structure/mirror{
@@ -21396,7 +21602,7 @@
 /obj/item/construction/rld,
 /obj/item/construction/rld,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Xg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -21440,11 +21646,11 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Xo" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Xp" = (
 /obj/structure/rack,
 /obj/item/chameleon{
@@ -21498,7 +21704,7 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Xq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21513,7 +21719,7 @@
 "Xs" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Xt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -21543,13 +21749,13 @@
 "Xw" = (
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Xx" = (
 /obj/machinery/turnstile{
 	dir = 4
 	},
 /turf/open/pacifytile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Xy" = (
 /obj/machinery/door/airlock/external{
 	name = "Ferry Airlock"
@@ -21574,7 +21780,7 @@
 	pixel_y = 24
 	},
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "XB" = (
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/white,
@@ -21600,7 +21806,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "XE" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Kitchen";
@@ -21637,16 +21843,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"XK" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding/cafewar)
 "XL" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XM" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
+"XN" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafe)
 "XO" = (
 /obj/machinery/light{
 	dir = 4
@@ -21678,7 +21894,7 @@
 "XR" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "XS" = (
 /obj/structure/closet/secure_closet/hydroponics{
 	locked = 0
@@ -21698,12 +21914,12 @@
 /obj/item/seeds/pumpkin/blumpkin,
 /obj/item/seeds/pumpkin/blumpkin,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/sashimi,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XU" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -21713,12 +21929,18 @@
 "XV" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
+"XW" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "XX" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/sake,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XY" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "nukeop_ready";
@@ -21739,7 +21961,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Yb" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -21766,7 +21988,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chawanmushi,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Yg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -21778,7 +22000,7 @@
 	pixel_x = -27
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Yi" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/dark,
@@ -21829,7 +22051,7 @@
 "Ym" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Yn" = (
 /obj/item/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
@@ -21839,7 +22061,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Yp" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -21854,7 +22076,7 @@
 "Yr" = (
 /mob/living/simple_animal/opossum,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ys" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red,
@@ -21875,7 +22097,7 @@
 	locked = 0
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Yv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -21907,7 +22129,7 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "YA" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -21943,7 +22165,7 @@
 "YE" = (
 /obj/item/target/alien,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "YF" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -21958,7 +22180,7 @@
 /obj/item/storage/firstaid/tactical/nukeop,
 /obj/item/storage/firstaid/tactical/nukeop,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "YH" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien13";
@@ -21976,7 +22198,7 @@
 /obj/item/book/granter/action/drink_fling,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "YK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
@@ -21984,24 +22206,24 @@
 "YL" = (
 /obj/machinery/vending/clothing,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "YM" = (
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "YN" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "YO" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "YP" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -22022,7 +22244,7 @@
 /obj/item/stack/tile/carpet/royalblue/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "YQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -22034,7 +22256,7 @@
 	dir = 8
 	},
 /turf/open/pacifytile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "YS" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supply";
@@ -22071,7 +22293,7 @@
 "YX" = (
 /mob/living/simple_animal/pet/dog/pug,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "YY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -22089,7 +22311,7 @@
 	id_tag = "lmrestroom"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Zb" = (
 /obj/machinery/sleeper/centcom{
 	dir = 4
@@ -22128,7 +22350,7 @@
 	icon_state = "plant-10"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Zi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -22142,10 +22364,10 @@
 /obj/item/flashlight/lamp/bananalamp,
 /obj/structure/table/wood,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Zl" = (
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafebuild)
 "Zm" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -22155,7 +22377,7 @@
 /obj/item/storage/box/firingpins,
 /obj/structure/closet,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Zn" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -22169,7 +22391,7 @@
 /area/centcom/evac)
 "Zq" = (
 /turf/open/indestructible/cobble,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Zr" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -22211,7 +22433,7 @@
 	stationary_mode = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Zy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -22254,7 +22476,7 @@
 	pixel_x = 28
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ZF" = (
 /obj/effect/turf_decal/trimline/red/end{
 	dir = 1
@@ -22325,15 +22547,19 @@
 /obj/item/stack/tile/carpet/royalblack/fifty,
 /obj/item/stack/tile/carpet/royalblue/fifty,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "ZM" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ZN" = (
 /obj/machinery/vending/snack,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"ZO" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "ZP" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -22348,7 +22574,7 @@
 "ZR" = (
 /obj/structure/bed/dogbed,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ZS" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/red,
@@ -22356,7 +22582,7 @@
 "ZT" = (
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "ZU" = (
 /turf/open/floor/material,
 /area/centcom/holding)
@@ -22404,7 +22630,7 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 
 (1,1,1) = {"
 aa
@@ -46467,71 +46693,71 @@ hh
 hh
 aa
 aa
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
 aa
 aa
 aa
@@ -46724,7 +46950,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -46743,7 +46969,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 SW
 PO
 PO
@@ -46752,12 +46978,12 @@ PO
 PO
 PO
 PO
-Nd
+Uo
 Tt
 Tt
 TG
 Op
-Nd
+Uo
 Wh
 QL
 Fi
@@ -46765,30 +46991,30 @@ QL
 Fi
 QL
 Fi
-NT
+Uf
 sk
-CV
-Sd
-Nd
+OK
+VS
+Uo
 OW
 Ln
-Nd
+Uo
 Lm
 Lm
 Lm
-Nd
+Uo
 PQ
-Sd
+FF
 ZR
-Nd
+Uo
 RL
-Yo
+NQ
 Uq
-Nd
+Uo
 VL
 Ww
 NN
-Nd
+Uo
 aa
 aa
 aa
@@ -46955,33 +47181,33 @@ aa
 aa
 aa
 aa
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
 Zl
 Zl
 Zl
@@ -47000,7 +47226,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Pc
 PY
 PY
@@ -47009,43 +47235,43 @@ PY
 PY
 PY
 PY
-Nd
-ZW
-ZW
-ZW
-ZW
+Uo
+HA
+HA
+HA
+HA
 Za
-Sd
+VS
 Fi
 QL
 Fi
 QL
 Fi
 QL
-NT
+Uf
 RQ
-Sd
-HH
-Nd
+VS
+WG
+Uo
 UN
 ST
-Nd
+Uo
 zS
 Qw
 TC
-Nd
+Uo
 MJ
-Sd
-Sd
-Nd
-AE
-Sd
-Ph
-Nd
-ZL
-Sd
-HH
-Nd
+FF
+FF
+Uo
+VI
+FF
+GD
+Uo
+MC
+FF
+zt
+Uo
 aa
 aa
 aa
@@ -47212,7 +47438,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -47257,7 +47483,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 ZZ
 PY
 PY
@@ -47266,43 +47492,43 @@ PY
 PY
 PY
 RN
-Nd
+Uo
 SB
-ZW
-ZW
-ZW
-Nd
-Sd
+HA
+HA
+HA
+Uo
+VS
 QL
 Fi
 QL
 Fi
 QL
 Fi
-NT
+Uf
 UV
-CV
-Sd
-Nd
+OK
+VS
+Uo
 Ot
 ST
-Nd
+Uo
 Tf
 Qw
 Tf
-Nd
+Uo
 ma
-Sd
-Sd
-Nd
+FF
+FF
+Uo
 ZN
-Sd
-Sd
-Nd
-ZL
-Sd
-Lr
-Nd
+FF
+FF
+Uo
+MC
+FF
+Bo
+Uo
 aa
 aa
 aa
@@ -47469,7 +47695,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -47514,7 +47740,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 PI
 PY
 Ha
@@ -47523,43 +47749,43 @@ PY
 PY
 PY
 Rj
-Nd
+Uo
 SB
 NE
 Fl
 Nw
-Nd
-Sd
+Uo
+VS
 Fi
 QL
 Fi
 QL
 Fi
 QL
-Nd
+XN
 hH
-Sd
-Sd
-Nd
-Nd
-Wl
-Nd
-Nd
-Wl
-Nd
-Nd
-Nd
+VS
+VS
+Uo
+Uo
+Tp
+Uo
+Uo
+Tp
+Uo
+Uo
+Uo
 yS
-Nd
-Nd
+Uo
+Uo
 WD
-Sd
-HH
-Nd
-Nd
+FF
+zt
+Uo
+Uo
 Ox
-Nd
-Nd
+Uo
+Uo
 aa
 aa
 aa
@@ -47726,7 +47952,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -47771,7 +47997,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Tx
 PY
 yh
@@ -47780,23 +48006,23 @@ Um
 XS
 PY
 vs
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Gs
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Fo
 QL
 Fi
 QL
 Fi
 QL
 Fi
-NT
+Uf
 PX
-CV
-Sd
+OK
+VS
 NT
 Sd
 Sd
@@ -47804,7 +48030,7 @@ Sd
 Sd
 Sd
 Sd
-Nd
+Uo
 Of
 Of
 Of
@@ -47816,7 +48042,7 @@ Yr
 Of
 Of
 WE
-Nd
+Uo
 aa
 aa
 aa
@@ -47983,7 +48209,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48028,32 +48254,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Nd
-Nd
-FR
+MX
+MX
+MX
+CU
 XL
-FR
-Nd
+CU
+MX
 py
-Nd
-Nd
+MX
+XN
 Yh
-Sd
-Yo
-Sd
-Wl
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-NT
+VS
+Bb
+VS
+ZO
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+Uf
 Zh
-Sd
-Sd
+VS
+VS
 Dl
 Sd
 Sd
@@ -48073,7 +48299,7 @@ Of
 Of
 Of
 Sj
-Nd
+Uo
 aa
 aa
 aa
@@ -48240,7 +48466,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48285,32 +48511,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Lr
-Sd
+Vh
 Yo
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Nd
-Nd
-Nd
-Nd
-Gs
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-NT
+Vh
+Vh
+Vh
+Vh
+Vh
+Vh
+Vh
+MX
+MX
+MX
+XN
+Fo
+VS
+VS
+VS
+VS
+VS
+VS
+Uf
 Ym
-CV
-Sd
+OK
+VS
 NT
 Sd
 MR
@@ -48318,7 +48544,7 @@ Sd
 Sd
 MR
 Sd
-Nd
+Uo
 Of
 Of
 Of
@@ -48330,7 +48556,7 @@ Of
 Cd
 Of
 PM
-Nd
+Uo
 aa
 aa
 aa
@@ -48497,7 +48723,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48542,32 +48768,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 PR
-Sd
+Vh
 MG
 YN
-Nd
+MX
 US
 Fh
 Fh
 zV
-Nd
-Nd
+MX
+MX
 Hj
 Fa
 KT
-Sd
-Sd
+VS
+VS
 zw
 Yz
 UY
-Sd
-HH
-Nd
-Sd
-Sd
-Sd
+VS
+WG
+XN
+VS
+VS
+VS
 Nd
 Nd
 Nd
@@ -48575,19 +48801,19 @@ FR
 FR
 Nd
 Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
 Rq
 Of
 ZM
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
 aa
 aa
 aa
@@ -48754,7 +48980,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48799,32 +49025,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Ry
-Sd
+Vh
 Rh
 Mm
-Nd
+MX
 Nx
 Fh
 Fh
 Yu
-Nd
-AE
+MX
+yc
 CV
-Sd
+Vh
 KT
-Sd
-Sd
+VS
+VS
 Nh
 tw
 UY
-Sd
-Sd
+VS
+VS
 Re
-Sd
-Sd
-HH
+VS
+VS
+WG
 TE
 Sd
 YV
@@ -48832,19 +49058,19 @@ RS
 RS
 RS
 VF
-Nd
+Uo
 UD
 tZ
-SY
-Nd
+oV
+Uo
 Of
 Of
 Of
-Nd
-SY
+Uo
+oV
 Os
 UD
-Nd
+Uo
 aa
 aa
 aa
@@ -49011,7 +49237,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49056,32 +49282,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 On
-Sd
+Vh
 yW
 ZT
-Nd
+MX
 Pr
 Fh
 Fh
 QW
-Nd
+MX
 QJ
-Sd
-Sd
+Vh
+Vh
 KT
-Sd
-Sd
+VS
+VS
 Nh
 tw
 UY
-Sd
-Sd
-Nd
-Gs
+VS
+VS
+XN
+Fo
 Zx
-Sd
+VS
 OL
 Wi
 Po
@@ -49089,19 +49315,19 @@ ZU
 ZU
 ZU
 fR
-Nd
-Sd
-Sd
-Sd
+Uo
+FF
+FF
+FF
 lS
 Of
 Of
 Of
 RP
-Sd
-Sd
-Sd
-Nd
+FF
+FF
+FF
+Uo
 aa
 aa
 aa
@@ -49268,7 +49494,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49313,32 +49539,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Nd
+MX
+MX
 XL
-Nd
-Nd
-Nd
+MX
+MX
+MX
 JE
 Fh
 Fh
 Vv
-Nd
-Sd
-Sd
-Sd
+MX
+Vh
+Vh
+Vh
 FW
-Sd
-Sd
+VS
+VS
 zw
 tw
 UY
-Sd
-Sd
+VS
+VS
 Re
-Sd
+VS
 pD
-Sd
+VS
 SJ
 So
 Po
@@ -49346,19 +49572,19 @@ ZU
 Nv
 ZU
 fR
-Nd
+Uo
 Xn
-Sd
+FF
 Ya
-Nd
+Uo
 Of
 Of
 Of
-Nd
+Uo
 XD
-Sd
+FF
 Xn
-Nd
+Uo
 aa
 aa
 aa
@@ -49525,7 +49751,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49570,32 +49796,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 NZ
-Sd
+Vh
 Yo
 PL
-Nd
+MX
 SG
 Fh
 Fh
 Fh
 Wl
-Sd
-MR
-Sd
+Vh
+jA
+Vh
 FX
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-HH
-Nd
+VS
+VS
+VS
+VS
+VS
+VS
+WG
+XN
 WM
-Sd
-Sd
+VS
+VS
 SJ
 YU
 Po
@@ -49603,19 +49829,19 @@ ZU
 Nv
 ZU
 fR
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
 Of
 Of
 Up
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
 aa
 aa
 aa
@@ -49782,7 +50008,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49827,32 +50053,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 OG
-Sd
-Sd
+Vh
+Vh
 Tq
-Nd
+MX
 zX
 Fh
 Fh
 JV
-Nd
-Dl
-Nd
-Nd
-Nd
-Gs
-Sd
+MX
+yd
+MX
+MX
+XN
+Fo
+VS
 XM
 Tu
-Sd
-Sd
+VS
+VS
 XM
-NT
-Sd
-Sd
-Sd
+Uf
+VS
+VS
+VS
 SJ
 YU
 Po
@@ -49860,19 +50086,19 @@ ZU
 ZU
 ZU
 fR
-Nd
+Uo
 UD
 tZ
-SY
-Nd
+oV
+Uo
 Of
 Of
 Of
-Nd
-SY
+Uo
+oV
 Os
 UD
-Nd
+Uo
 aa
 aa
 aa
@@ -50039,7 +50265,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50084,32 +50310,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Xf
-Sd
-Sd
+Vh
+Vh
 Nf
-Nd
+MX
 QA
 Fh
 Fh
 Uz
 ED
-Sd
+Vh
 Yo
 Yf
 UE
-Sd
-Sd
+VS
+VS
 Tn
 Xd
-Sd
-Sd
+VS
+VS
 NP
-NT
-Sd
-Sd
-Sd
+Uf
+VS
+VS
+VS
 SJ
 BX
 TM
@@ -50117,19 +50343,19 @@ TM
 TM
 TM
 TM
-Nd
-Sd
-Sd
-Sd
+Uo
+FF
+FF
+FF
 uh
 Of
 Of
 Of
 zW
-Sd
-Sd
-Sd
-Nd
+FF
+FF
+FF
+Uo
 aa
 aa
 aa
@@ -50296,7 +50522,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50341,32 +50567,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 YL
-Sd
-Sd
+Vh
+Vh
 Uk
-Nd
+MX
 Xo
 Fh
 Fh
 Fh
 py
-Sd
-Sd
-SY
+Vh
+Vh
+WO
 UE
-Sd
-Sd
+VS
+VS
 GY
 Tu
-Sd
-Sd
+VS
+VS
 GY
-NT
-Sd
-Sd
-Sd
+Uf
+VS
+VS
+VS
 SJ
 YU
 PA
@@ -50374,19 +50600,19 @@ ZU
 ZU
 ZU
 FY
-Nd
+Uo
 Xn
-Sd
+FF
 Tc
-Nd
+Uo
 Of
 Of
 Of
-Nd
+Uo
 AC
-Sd
+FF
 Xn
-Nd
+Uo
 aa
 aa
 aa
@@ -50553,7 +50779,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50598,32 +50824,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Xe
-Sd
-Sd
+Vh
+Vh
 ZL
-Nd
+MX
 TB
 Fh
 Fh
 Fh
 BV
-Sd
-Sd
+Vh
+Vh
 XT
 UE
-Sd
-Sd
-Sd
-Ph
-Sd
+VS
+VS
+VS
+yO
+VS
 Qk
 Vu
-Nd
-Gs
-Sd
-Sd
+XN
+Fo
+VS
+VS
 SJ
 YU
 PA
@@ -50631,19 +50857,19 @@ ZU
 re
 ZU
 FY
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
 Rq
 Of
 ZM
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
 aa
 aa
 aa
@@ -50810,7 +51036,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50855,32 +51081,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 TY
-Sd
-Sd
+Vh
+Vh
 Wn
-Nd
+MX
 Vz
 Fh
 Fh
 YJ
 QT
-Sd
-Sd
-SY
+Vh
+Vh
+WO
 UE
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
+VS
+VS
 XM
-NT
-Sd
-Sd
-Sd
+Uf
+VS
+VS
+VS
 SJ
 Ye
 PA
@@ -50888,19 +51114,19 @@ ZU
 re
 ZU
 FY
-Nd
+Uo
 Xs
 Ol
 YO
-Nd
+Uo
 Of
 Of
 Of
-Nd
+Uo
 RX
 Xw
 qP
-Nd
+Uo
 aa
 aa
 aa
@@ -51067,7 +51293,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51112,32 +51338,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Bs
 Ri
-Sd
-Sd
+Vh
+Vh
 XL
 Fh
 Fh
 Fh
 Fh
 XL
-Sd
-Sd
+Vh
+Vh
 XX
 Pv
-Sd
-Sd
-Sd
+VS
+VS
+VS
 Tu
-Sd
-Sd
+VS
+VS
 NP
-NT
-Sd
-Sd
-Sd
+Uf
+VS
+VS
+VS
 OL
 Wi
 PA
@@ -51145,19 +51371,19 @@ ZU
 ZU
 ZU
 FY
-Nd
-Gs
-Sd
-Sd
+Uo
+Fm
+FF
+FF
 SZ
 Of
 Of
 Of
 Ws
-Sd
-Sd
-HH
-Nd
+FF
+FF
+zt
+Uo
 aa
 aa
 aa
@@ -51324,7 +51550,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51369,32 +51595,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+MX
 Hk
-Sd
-MR
+Vh
+jA
 Mz
-Nd
+MX
 SN
 pV
 pV
 Tr
-Nd
+MX
 WY
 Ph
-Nd
-Nd
+MX
+XN
 Rm
 Tn
 UT
 Hm
-Sd
-Sd
+VS
+VS
 GY
-NT
-Sd
-Sd
-HH
+Uf
+VS
+VS
+WG
 TE
 Sd
 Mx
@@ -51402,19 +51628,19 @@ Uh
 Uh
 Uh
 tW
-Nd
+Uo
 Ru
 Of
 QF
-Nd
+Uo
 Of
 Of
 Of
-Nd
+Uo
 WN
 Ur
 Ki
-Nd
+Uo
 aa
 aa
 aa
@@ -51581,7 +51807,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51626,28 +51852,28 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Gs
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+MX
+XN
+XN
+Fo
+VS
+VS
+VS
+VS
+VS
+VS
 Nd
 Nd
 Te
@@ -51659,19 +51885,19 @@ TT
 TT
 FR
 Nd
-Nd
+Uo
 Kf
 WV
-Sd
-Nd
-sa
+FF
+Uo
 Of
 Of
-Nd
-Sd
+Of
+Uo
+FF
 zY
 Rv
-Nd
+Uo
 aa
 aa
 aa
@@ -51838,7 +52064,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51883,28 +52109,28 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Gs
+XN
+Fo
 Gt
 Gt
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-yQ
-yQ
-Sd
+VS
+VS
+VS
+VS
+VS
+VS
+TV
+TV
+VS
 Nc
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Nd
 Qj
 Sd
@@ -51916,19 +52142,19 @@ ZW
 ZW
 px
 Lk
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
 QC
-Nd
-Nd
+Uo
+Uo
 SR
-Nd
-Nd
+Uo
+Uo
 QC
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
 aa
 aa
 aa
@@ -52095,7 +52321,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -52141,7 +52367,7 @@ Zl
 Zl
 Zl
 Mu
-Sd
+VS
 Lu
 IO
 IO
@@ -52149,10 +52375,10 @@ IO
 IO
 IO
 FC
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
 Ve
 Ve
 Ve
@@ -52160,8 +52386,8 @@ Ve
 Ve
 Ve
 Ve
-Sd
-Sd
+VS
+VS
 Nd
 Gs
 Sd
@@ -52173,19 +52399,19 @@ ZW
 ZW
 ZW
 OT
-Nd
+Uo
 Ln
 ST
 ST
-Nd
+Uo
 Qp
-Sd
+FF
 Nt
-Nd
+Uo
 ST
 ST
 Ln
-Nd
+Uo
 aa
 YB
 aa
@@ -52352,7 +52578,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -52397,8 +52623,8 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Gs
+XN
+Fo
 OD
 rY
 Og
@@ -52406,10 +52632,10 @@ CP
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
 Nb
 VD
 xC
@@ -52417,8 +52643,8 @@ qN
 sb
 Wg
 vx
-Sd
-Sd
+VS
+VS
 Nd
 Tw
 Tg
@@ -52430,19 +52656,19 @@ ZW
 ZW
 FV
 Wz
-Nd
+Uo
 xO
 QN
 ZE
-Nd
+Uo
 Qp
 Qz
 Nt
-Nd
+Uo
 ZE
 QN
 RO
-Nd
+Uo
 aa
 aa
 aa
@@ -52609,7 +52835,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -52654,8 +52880,8 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Sd
+XN
+VS
 OD
 Og
 Og
@@ -52663,10 +52889,10 @@ Og
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
 SF
 RC
 yf
@@ -52674,8 +52900,8 @@ Lf
 kv
 qH
 yM
-Sd
-HH
+VS
+WG
 Nd
 Nd
 Nd
@@ -52687,19 +52913,19 @@ XG
 FR
 Nd
 Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
+Uo
 aa
 aa
 aa
@@ -52866,53 +53092,53 @@ aa
 aa
 aa
 aa
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-Nd
-Sd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+XN
+VS
 OD
 XA
 Og
@@ -52920,10 +53146,10 @@ Og
 Og
 Dz
 CW
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
 Ll
 Ll
 Ll
@@ -52931,8 +53157,8 @@ Ll
 Ll
 Ll
 Ll
-Sd
-Sd
+VS
+VS
 Rx
 Bn
 TJ
@@ -52947,22 +53173,22 @@ Fx
 AE
 pY
 Qg
-Nd
-Zl
-Zl
+FD
+LD
+LD
 MY
-Zl
-Zl
+LD
+LD
 MY
-Zl
-Zl
-Nd
-CR
-CR
-CR
-CR
-CR
-CR
+LD
+LD
+FD
+Om
+Om
+Om
+Om
+Om
+Om
 Om
 aa
 aa
@@ -53168,8 +53394,8 @@ aa
 aa
 aa
 aa
-Nd
-Sd
+XN
+VS
 OD
 Og
 Og
@@ -53177,6 +53403,19 @@ Og
 Og
 Og
 CW
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Sd
 Sd
 Sd
@@ -53191,36 +53430,23 @@ Sd
 Sd
 Sd
 Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Nd
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+FD
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+FD
 Qm
 WZ
 Qm
 Qm
 WZ
 Qm
-CR
+Om
 Om
 aa
 aa
@@ -53425,8 +53651,8 @@ aa
 aa
 aa
 aa
-Nd
-Sd
+XN
+VS
 vq
 Og
 Og
@@ -53434,19 +53660,19 @@ se
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Rx
 Bn
 Bn
@@ -53461,24 +53687,24 @@ Sd
 Sd
 Sd
 Sd
-FR
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
+CS
+LD
+LD
+LD
+LD
+LD
+LD
+LD
 Fc
-Nd
+FD
 Qm
-ue
-Qm
-Qm
+WP
 Qm
 Qm
 Qm
-CR
+Qm
+Wk
+Om
 Om
 aa
 aa
@@ -53682,8 +53908,8 @@ aa
 aa
 aa
 aa
-Nd
-Gs
+XN
+Fo
 OD
 Og
 Og
@@ -53691,6 +53917,19 @@ Og
 Og
 Og
 CW
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Sd
 Sd
 Sd
@@ -53705,38 +53944,25 @@ Sd
 Sd
 Sd
 Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-FR
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+CS
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+FD
 Qm
 Qm
-ue
+WP
 Qm
 WZ
 Qm
-Qm
-Qm
-CR
+Wk
+Wk
+Om
 Om
 aa
 aa
@@ -53939,7 +54165,7 @@ aa
 aa
 aa
 aa
-Nd
+XN
 NS
 OD
 XA
@@ -53948,19 +54174,19 @@ Og
 Og
 Dz
 CW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Sd
 Sd
 SO
@@ -53976,25 +54202,25 @@ Sd
 Sd
 Sd
 OO
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+FD
 Qm
 WZ
-ue
-ue
+WP
+WP
 Qm
 Qm
-WZ
-Qm
-Qm
-CR
+MT
+Wk
+Wk
+Om
 Om
 aa
 aa
@@ -54196,7 +54422,7 @@ aa
 aa
 aa
 aa
-Nd
+XN
 OH
 OD
 Og
@@ -54205,6 +54431,19 @@ Og
 Og
 Og
 CW
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Sd
 Sd
 Sd
@@ -54219,40 +54458,27 @@ Sd
 Sd
 Sd
 Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-FR
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+CS
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+FD
 Qm
 Qm
 Qm
-ue
-ue
+WP
+WP
 Qm
-Qm
-ue
-Qm
-Qm
-CR
+Wk
+Bj
+Wk
+Wk
+Om
 Om
 aa
 aa
@@ -54453,7 +54679,7 @@ aa
 aa
 aa
 aa
-Nd
+XN
 RT
 OD
 Og
@@ -54462,19 +54688,19 @@ NY
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
+VS
 Rx
 Bn
 Bn
@@ -54489,28 +54715,28 @@ Sd
 Sd
 Sd
 Sd
-FR
+CS
 YP
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
+LD
+LD
+LD
+LD
+LD
+LD
 Fc
-Nd
+FD
 Qm
 WZ
 Qm
 Qm
 WZ
 Qm
-Qm
+Wk
 Pb
 Pb
-Qm
-Qm
-CR
+Wk
+Wk
+Om
 Om
 aa
 aa
@@ -54710,7 +54936,7 @@ aa
 aa
 aa
 aa
-Nd
+XN
 Gt
 xD
 Sq
@@ -54719,19 +54945,19 @@ UJ
 Sq
 Sq
 Np
-Sd
-Sd
-Sd
-MR
-Sd
-MR
-Sd
-MR
-Sd
-MR
-Sd
-Sd
-Sd
+VS
+VS
+VS
+EZ
+VS
+EZ
+VS
+EZ
+VS
+EZ
+VS
+VS
+VS
 Sd
 Sd
 Sd
@@ -54746,16 +54972,16 @@ Sd
 Sd
 Sd
 Sd
-Nd
+FD
 BP
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+LD
+LD
+LD
+LD
+LD
+LD
+LD
+FD
 Qm
 Qm
 WZ
@@ -54768,7 +54994,7 @@ Qm
 Qm
 WZ
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -54967,25 +55193,25 @@ aa
 aa
 aa
 aa
-Nd
-Gs
+XN
+Fo
 NS
 OH
 Sl
 Sl
 Sl
 Sl
-Sd
-OC
-Vp
-Bk
-FR
+VS
+wR
+XW
+Or
+XK
 YR
-FR
+XK
 Xx
-FR
+XK
 YR
-FR
+XK
 OC
 Vp
 Bk
@@ -55003,16 +55229,16 @@ QI
 tQ
 Sd
 HH
-Nd
+FD
 BP
-Zl
+LD
 Kq
-Zl
-Zl
+LD
+LD
 Kq
-Zl
-Zl
-Nd
+LD
+LD
+FD
 Qm
 Qm
 Qm
@@ -55020,12 +55246,12 @@ Qm
 Qm
 Qm
 Qm
-ue
+WP
 Qm
 WZ
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -55224,32 +55450,32 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-OY
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+XN
+uI
 pS
 pS
 pS
-FR
+XK
 pA
-FR
+XK
 Cm
-FR
+XK
 pA
-FR
+XK
 pS
 pS
 pS
-FR
-FR
-OY
-OY
+XK
+XK
+uI
+uI
 Nd
 Nd
 Nd
@@ -55260,29 +55486,29 @@ Nd
 Nd
 VB
 VB
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Qm
-Qm
-kR
+FD
+FD
+FD
+FD
+FD
+FD
+FD
+FD
+FD
+FD
 Qm
 Qm
 Qm
 Qm
-ue
-ue
+Qm
+Qm
+Qm
+WP
+WP
 Qm
 Qm
 WZ
-CR
+Om
 aa
 aa
 aa
@@ -55489,7 +55715,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 OA
 Dw
 qG
@@ -55499,22 +55725,22 @@ Vc
 HI
 Vc
 HI
-OY
+uI
 pC
 Dh
-Nl
-Kp
-Nl
-Kp
-OY
+UU
+UU
+Oq
+zZ
+uI
 TK
-wf
-Mm
-Mm
+Dm
+Cg
+Cg
 sp
 Vn
-Mm
-Mm
+Cg
+Cg
 Zq
 Zq
 Dm
@@ -55535,11 +55761,11 @@ Qm
 Qm
 WZ
 Qm
-ue
-ue
+WP
+WP
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -55746,7 +55972,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 PT
 MK
 HI
@@ -55763,14 +55989,14 @@ WI
 UU
 WI
 fy
-OY
+uI
 TK
-Mm
+Cg
 Dm
 Dm
 Vn
 sp
-Mm
+Cg
 Dm
 Zq
 Zq
@@ -55782,12 +56008,6 @@ Dm
 rg
 Hi
 VG
-kR
-Qm
-Qm
-Qm
-Qm
-WZ
 Qm
 Qm
 Qm
@@ -55795,8 +56015,14 @@ Qm
 Qm
 WZ
 Qm
+Qm
+Qm
+Qm
+Qm
 WZ
-CR
+Qm
+WZ
+Om
 aa
 aa
 aa
@@ -56003,7 +56229,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 Ny
 MK
 Br
@@ -56020,14 +56246,14 @@ WI
 UU
 WI
 fy
-OY
+uI
 TK
 Dm
-Mm
+Cg
 Dm
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 YM
 Zq
 Zq
@@ -56046,14 +56272,14 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
 Qm
-ue
 Qm
-CR
+WP
+Qm
+Om
 aa
 aa
 aa
@@ -56260,7 +56486,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 xL
 MK
 HI
@@ -56270,14 +56496,14 @@ HI
 HI
 HI
 HI
-OY
+uI
 pC
 Dh
-Nl
-Kp
-Nl
-Kp
-OY
+UU
+UU
+Oq
+zZ
+uI
 TK
 Dm
 Vd
@@ -56308,9 +56534,9 @@ Qs
 Qm
 Qm
 WZ
-Pb
-ue
-CR
+QH
+WP
+Om
 aa
 aa
 aa
@@ -56517,7 +56743,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 Zm
 HI
 HI
@@ -56527,31 +56753,31 @@ HI
 HI
 HI
 HI
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+uI
+uI
+uI
+uI
+uI
+uI
+uI
+uI
 TK
 Dm
 Dm
 Dm
 Dm
-Mm
+Cg
 Dm
 Dm
 Zq
 Zq
 Dm
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
@@ -56566,8 +56792,8 @@ Qm
 Qm
 Qm
 Qm
-ue
-CR
+WP
+Om
 aa
 aa
 aa
@@ -56774,7 +57000,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 Jj
 HI
 HI
@@ -56791,10 +57017,10 @@ HI
 Vc
 HI
 UZ
-OY
+uI
 TK
-Mm
-Mm
+Cg
+Cg
 Dm
 Dm
 Dm
@@ -56802,13 +57028,13 @@ Dm
 Dm
 Zq
 Zq
-Mm
+Cg
 Dm
-Mm
+Cg
 Dm
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
@@ -56823,8 +57049,8 @@ Qm
 Qm
 Qm
 WZ
-ue
-CR
+WP
+Om
 aa
 aa
 aa
@@ -57031,7 +57257,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 oU
 MK
 HI
@@ -57048,20 +57274,20 @@ HI
 HI
 HI
 UZ
-OY
+uI
 TK
-Mm
+Cg
 Dm
 Dm
 Dm
-FE
+Cg
 YM
 Dm
 Zq
 Zq
 YM
-Mm
-wf
+Cg
+Dm
 Dm
 Dm
 Dm
@@ -57079,9 +57305,9 @@ Qm
 Qm
 Qm
 Qm
-Pb
+QH
 th
-CR
+Om
 aa
 aa
 aa
@@ -57288,7 +57514,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 VU
 MK
 HI
@@ -57305,40 +57531,40 @@ HI
 HI
 HI
 YE
-OY
+uI
 TK
-Mm
+Cg
 Dm
 Dm
-Mm
+Cg
 Dm
 Dm
 Dm
 Zq
 Zq
-Mm
+Cg
 Dm
 Dm
 Dm
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
-kR
+Qm
+Qm
 Qm
 Qm
 Qm
 WZ
 Qm
-Pb
-ue
-CR
+QH
+WP
+Om
 aa
 aa
 aa
@@ -57545,7 +57771,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 TX
 ri
 HI
@@ -57562,9 +57788,9 @@ HI
 HI
 HI
 YE
-OY
+uI
 TK
-Mm
+Cg
 Vd
 Dm
 Dm
@@ -57574,12 +57800,12 @@ Dm
 Zq
 Zq
 Zq
-Mm
+Cg
 Dm
 Dm
 Dm
-Mm
-FE
+Cg
+Cg
 VG
 Qm
 Qm
@@ -57591,11 +57817,11 @@ Qm
 Qm
 Qm
 Qm
-ue
-ue
-ue
-ue
-CR
+WP
+WP
+WP
+WP
+Om
 aa
 aa
 aa
@@ -57802,7 +58028,7 @@ aa
 aa
 aa
 aa
-OY
+uI
 Oh
 tS
 tY
@@ -57819,10 +58045,10 @@ HI
 HI
 HI
 yX
-OY
+uI
 TK
 RY
-Mm
+Cg
 Dm
 Dm
 Dm
@@ -57831,14 +58057,14 @@ Zk
 Zq
 Zq
 Zq
-Mm
-Mm
+Cg
+Cg
 Wy
 Dm
 Dm
 Dm
 SU
-kR
+Qm
 Qm
 Qm
 Qm
@@ -57848,11 +58074,11 @@ Qm
 Qm
 Qm
 WP
-ue
+WP
 Qm
-Pb
-ue
-CR
+QH
+WP
+Om
 aa
 aa
 aa
@@ -58058,16 +58284,16 @@ aa
 aa
 aa
 aa
-ab
-OY
-OY
-FR
-FR
-FR
-FR
-FR
-OY
-OY
+uI
+uI
+uI
+XK
+XK
+XK
+XK
+XK
+uI
+uI
 HI
 HI
 HI
@@ -58076,11 +58302,11 @@ HI
 HI
 HI
 yX
-OY
+uI
 TK
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
 Dm
@@ -58088,9 +58314,9 @@ Dm
 Dm
 Zq
 Zq
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
 Dm
@@ -58104,25 +58330,25 @@ Cf
 Rw
 Qm
 Qm
-Pb
-ue
+QH
+WP
 Qm
 Qm
 Qm
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 aa
 aa
 aa
@@ -58315,7 +58541,7 @@ aa
 aa
 aa
 aa
-ab
+uI
 Vc
 HI
 HI
@@ -58324,7 +58550,7 @@ HI
 HI
 HI
 Vc
-OY
+uI
 HI
 HI
 Rg
@@ -58333,23 +58559,23 @@ HI
 Rg
 HI
 NL
-OY
+uI
 TK
-Mm
+Cg
 yN
 PZ
 Dm
-FE
+Cg
 Dm
-Mm
-Mm
+Cg
+Cg
 Fy
 Zq
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
-Mm
+Cg
 Dm
 SU
 Qm
@@ -58362,26 +58588,26 @@ Qm
 Qm
 Qm
 Qm
-Pb
+QH
 Qm
-ue
+WP
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
-CR
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
+Om
+Om
 aa
 aa
 aa
@@ -58572,7 +58798,7 @@ oe
 mD
 mD
 aa
-OY
+uI
 HI
 HI
 GC
@@ -58581,33 +58807,33 @@ HI
 HI
 HI
 HI
-OY
+uI
 XR
 XR
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+uI
+uI
+uI
+uI
+uI
+uI
+uI
 TK
 Dm
 Dm
 Dm
 Dm
 Dm
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 Zq
 Zq
 FE
-Mm
-Mm
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
+Cg
+Cg
 SU
 Qm
 Qm
@@ -58620,25 +58846,25 @@ Qm
 Qm
 Qm
 Qm
-ue
-ue
+WP
+WP
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -58829,7 +59055,7 @@ BZ
 Cq
 mD
 aa
-OY
+uI
 Br
 HI
 HI
@@ -58849,14 +59075,14 @@ aa
 aa
 aa
 TK
-Mm
+Cg
 Sm
-Mm
+Cg
 yN
 PZ
 Dm
-Mm
-Mm
+Cg
+Cg
 Zq
 Zq
 Zq
@@ -58883,19 +59109,19 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -59086,7 +59312,7 @@ pg
 Cr
 mD
 aa
-OY
+uI
 HI
 HI
 HI
@@ -59106,14 +59332,14 @@ aa
 aa
 aa
 TK
-Mm
+Cg
 In
 Dm
-Mm
-Mm
-Mm
-Mm
-FE
+Cg
+Cg
+Cg
+Cg
+Cg
 Zq
 Zq
 Zq
@@ -59130,7 +59356,7 @@ Qm
 Qm
 Qm
 Qm
-kR
+Qm
 Qm
 Ty
 Qm
@@ -59140,19 +59366,19 @@ Qm
 Qm
 Pt
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -59343,7 +59569,7 @@ pg
 Cs
 qR
 aa
-OY
+uI
 Kw
 HI
 HI
@@ -59366,19 +59592,19 @@ TK
 Dm
 Dm
 Dm
-Mm
+Cg
 RY
 sY
 Dm
-Mm
-Zq
-Zq
-wf
-Mm
-Mm
+Cg
+Cg
+Cg
+Dm
+Cg
+Cg
 Dm
 Dm
-Mm
+Cg
 SU
 Qm
 Qm
@@ -59392,24 +59618,24 @@ tv
 tv
 Ty
 Qm
-kR
+Qm
 Qm
 Qm
 Pt
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -59600,7 +59826,7 @@ pg
 Ct
 nT
 aa
-OY
+uI
 HI
 HI
 HI
@@ -59624,20 +59850,20 @@ Dm
 Sm
 Dm
 Dm
-Mm
+Cg
 Tv
-Mm
-Mm
-Zq
-Zq
-Mm
-Mm
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
 Dm
-FE
+Cg
 Dm
-Mm
+Cg
 SU
-kR
+Qm
 Qm
 Qm
 Qm
@@ -59655,18 +59881,18 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -59857,7 +60083,7 @@ zA
 Cu
 nU
 aa
-OY
+uI
 HI
 HI
 HI
@@ -59877,22 +60103,22 @@ aa
 aa
 aa
 TK
-Mm
+Cg
 Dm
 Dm
 In
 Dm
-Mm
-Mm
+Cg
+Cg
 RY
-Zq
-Zq
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
@@ -59913,17 +60139,17 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -60114,7 +60340,7 @@ sw
 Cv
 mD
 aa
-OY
+uI
 HI
 GC
 GC
@@ -60135,25 +60361,25 @@ aa
 aa
 TK
 FE
-Mm
-Mm
+Cg
+Cg
 Sn
-Mm
+Cg
 RY
-Mm
-Mm
-Zq
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
+Cg
+Cg
+Cg
 Dm
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
-kR
+Qm
 Qm
 Qm
 Qm
@@ -60171,16 +60397,16 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -60371,7 +60597,7 @@ Ca
 Cw
 mD
 aa
-OY
+uI
 HI
 HI
 HI
@@ -60399,14 +60625,14 @@ Iv
 Iv
 Iv
 Iv
-Zq
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
-Mm
+Cg
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
@@ -60430,14 +60656,14 @@ Qm
 Qm
 MV
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -60628,7 +60854,7 @@ Cb
 Cx
 mD
 aa
-OY
+uI
 HI
 HI
 HI
@@ -60656,14 +60882,14 @@ IR
 Jd
 Jn
 Iv
-Zq
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
@@ -60672,7 +60898,6 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
@@ -60680,21 +60905,22 @@ Qm
 Qm
 Qm
 Qm
-WZ
-kR
 Qm
 WZ
 Qm
 Qm
+WZ
+Qm
+Qm
 Qm
 MV
 MV
-MV
-MV
-MV
-MV
-MV
-CR
+Xa
+Xa
+Xa
+Xa
+Xa
+Om
 aa
 aa
 aa
@@ -60885,7 +61111,7 @@ Ca
 Cy
 mD
 aa
-OY
+uI
 HI
 HI
 HI
@@ -60913,13 +61139,13 @@ Iv
 IR
 IR
 Iv
-Zq
-Mm
+Cg
+Cg
 Ti
 Dm
 Dm
-Mm
-Mm
+Cg
+Cg
 Dm
 VG
 Qm
@@ -60933,7 +61159,7 @@ WZ
 Qm
 Qm
 Qm
-kR
+Qm
 Qm
 Qm
 Qm
@@ -60949,9 +61175,9 @@ Qm
 MV
 MV
 MV
-CR
-CR
-CR
+Om
+Om
+Om
 aa
 aa
 aa
@@ -61142,7 +61368,7 @@ sw
 Cz
 mD
 aa
-OY
+uI
 Kw
 HI
 GC
@@ -61170,14 +61396,14 @@ IS
 JG
 JG
 Iv
-Zq
-Mm
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
+Cg
+Cg
 Dm
 Dm
-Mm
+Cg
 VG
 Qm
 Qm
@@ -61206,7 +61432,7 @@ Qm
 ML
 ML
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -61399,7 +61625,7 @@ zA
 CA
 mD
 aa
-OY
+uI
 HI
 HI
 HI
@@ -61427,13 +61653,13 @@ IS
 JG
 JG
 Iv
-Cj
+Iv
 Iv
 Dm
 Dm
 PG
 Dm
-Mm
+Cg
 Dm
 VG
 Qm
@@ -61456,14 +61682,14 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
 Qm
 Qm
 Qm
-CR
+Qm
+Om
 aa
 aa
 aa
@@ -61656,7 +61882,7 @@ rz
 nU
 mD
 aa
-OY
+uI
 Br
 HI
 Rg
@@ -61686,21 +61912,21 @@ JG
 JG
 JG
 Iv
-Mm
+Cg
 Dm
 Dm
 Dm
-Mm
+Cg
 Dm
 VG
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
-kR
+Qm
+Qm
 Qm
 Qm
 Qm
@@ -61720,7 +61946,7 @@ Qm
 Qm
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -61913,9 +62139,9 @@ zD
 CB
 mD
 aa
-OY
-OY
-OY
+uI
+uI
+uI
 Ep
 Ep
 Ep
@@ -61943,14 +62169,14 @@ JO
 JG
 JG
 Iv
-Mm
-Mm
+Cg
+Cg
 Dm
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 VG
-kR
+Qm
 Qm
 Qm
 Qm
@@ -61966,7 +62192,6 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
@@ -61977,7 +62202,8 @@ Qm
 Qm
 Qm
 Qm
-CR
+Qm
+Om
 aa
 aa
 aa
@@ -62200,12 +62426,12 @@ Iv
 RH
 RH
 Iv
-Mm
-Mm
-Mm
+Cg
+Cg
+Cg
 Dm
 Dm
-FE
+Cg
 VG
 Qm
 Qm
@@ -62234,7 +62460,7 @@ Qm
 WZ
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -62459,23 +62685,18 @@ JG
 Iv
 Iv
 Iv
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
 Qm
 Qm
 Qm
 Qm
 Qm
 Qm
-kR
 Qm
-Qm
-Qm
-Qm
-WZ
 Qm
 Qm
 Qm
@@ -62483,6 +62704,11 @@ Qm
 WZ
 Qm
 Qm
+Qm
+Qm
+WZ
+Qm
+Qm
 WZ
 Qm
 Qm
@@ -62491,7 +62717,7 @@ Qm
 Qm
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -62720,7 +62946,7 @@ aa
 aa
 aa
 aa
-CR
+Om
 Qm
 Qm
 Qm
@@ -62748,7 +62974,7 @@ Qm
 Qm
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -62977,8 +63203,8 @@ aa
 aa
 aa
 aa
-CR
-CR
+Om
+Om
 Qm
 Qm
 Qm
@@ -62991,21 +63217,21 @@ Qm
 Qm
 Qm
 Qm
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 Qm
 Qm
 Qm
 Qm
 WZ
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -63235,34 +63461,34 @@ aa
 aa
 aa
 aa
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 aa
 aa
 aa
 aa
 aa
 aa
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -2112,7 +2112,7 @@
 /area/space)
 "fy" = (
 /obj/machinery/light,
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible,
 /area/centcom/holding)
 "fz" = (
 /turf/open/floor/plasteel,
@@ -5434,6 +5434,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"nh" = (
+/obj/item/storage/box/marshmallow,
+/obj/item/melee/roastingstick,
+/obj/item/melee/roastingstick,
+/obj/item/melee/roastingstick,
+/obj/item/melee/roastingstick,
+/turf/open/floor/grass/snow,
+/area/centcom/holding)
 "ni" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/indestructible/riveted,
@@ -6901,7 +6909,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible,
 /area/centcom/holding)
 "pD" = (
 /mob/living/simple_animal/bot/cleanbot,
@@ -7640,10 +7648,8 @@
 /turf/open/floor/plating/smooth/grass,
 /area/centcom/holding)
 "ri" = (
-/obj/structure/rack,
-/obj/item/melee/transforming/cleaving_saw,
-/obj/item/melee/transforming/cleaving_saw,
-/obj/item/crucible,
+/obj/item/storage/belt/utility/servant,
+/obj/item/storage/belt/utility/servant,
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "rk" = (
@@ -8153,7 +8159,7 @@
 /area/centcom/evac)
 "sa" = (
 /obj/item/hilbertshotel/ghostdojo,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "sb" = (
 /obj/structure/table/wood/fancy,
@@ -8669,10 +8675,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/pacifytile,
 /area/centcom/evac)
-"tb" = (
-/obj/effect/smportalexit,
-/turf/open/floor/plating/beach/sand,
-/area/fabric_of_reality)
 "tc" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/smooth/grass,
@@ -9069,18 +9071,9 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/evac)
 "tS" = (
-/obj/structure/rack,
-/obj/item/melee/baseball_bat/ablative/syndi{
-	pixel_x = 2
-	},
-/obj/item/melee/baseball_bat/ablative/syndi{
-	pixel_x = 2
-	},
-/obj/item/melee/baseball_bat{
-	pixel_x = -4
-	},
-/obj/item/melee/baseball_bat{
-	pixel_x = -4
+/obj/item/storage/belt/utility/servant,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
@@ -9128,8 +9121,32 @@
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "tY" = (
-/mob/living/simple_animal/sloth,
-/turf/open/indestructible/hotelwood,
+/obj/structure/rack,
+/obj/item/melee/baseball_bat/ablative/syndi{
+	pixel_x = 2
+	},
+/obj/item/melee/baseball_bat/ablative/syndi{
+	pixel_x = 2
+	},
+/obj/item/melee/baseball_bat{
+	pixel_x = -4
+	},
+/obj/item/melee/baseball_bat{
+	pixel_x = -4
+	},
+/obj/item/fireaxe{
+	pixel_y = -8
+	},
+/obj/item/fireaxe{
+	pixel_y = -8
+	},
+/obj/item/fireaxe{
+	pixel_y = -8
+	},
+/obj/item/fireaxe{
+	pixel_y = -8
+	},
+/turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "tZ" = (
 /obj/structure/chair/wood/normal,
@@ -10273,8 +10290,38 @@
 /turf/open/floor/carpet/royalblue,
 /area/centcom/evac)
 "wi" = (
-/mob/living/simple_animal/chicken/rabbit,
-/turf/open/indestructible/hotelwood,
+/obj/structure/rack,
+/obj/item/melee/baton{
+	pixel_x = -6
+	},
+/obj/item/melee/baton{
+	pixel_x = -6
+	},
+/obj/item/melee/baton{
+	pixel_x = -6
+	},
+/obj/item/melee/baton{
+	pixel_x = -6
+	},
+/obj/item/melee/baton{
+	pixel_x = -6
+	},
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = 6
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = 6
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = 6
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = 6
+	},
+/turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "wj" = (
 /obj/machinery/light{
@@ -12769,7 +12816,7 @@
 /turf/open/floor/carpet/purple,
 /area/centcom/evac)
 "BV" = (
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
 	icon_state = "wood";
@@ -12838,13 +12885,17 @@
 /area/centcom/evac)
 "Cd" = (
 /mob/living/simple_animal/pet/redpanda,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "Ce" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/fabric_of_reality)
+"Cf" = (
+/obj/structure/bonfire/prelit,
+/turf/open/floor/grass/snow,
+/area/centcom/holding)
 "Ch" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/mineral/titanium/blue,
@@ -13298,14 +13349,6 @@
 /obj/item/storage/box/silver_ids,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"CU" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/mob/living/simple_animal/babyKiwi,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding)
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/hotelwood,
@@ -13429,7 +13472,7 @@
 /area/fabric_of_reality)
 "Dh" = (
 /obj/machinery/chem_heater,
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible,
 /area/centcom/holding)
 "Di" = (
 /turf/closed/indestructible/riveted,
@@ -14291,8 +14334,8 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
-"Fo" = (
-/turf/open/floor/plating/beach/coastline_t/sandwater_inner,
+"Fn" = (
+/turf/open/floor/plating,
 /area/fabric_of_reality)
 "Fp" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -14367,7 +14410,7 @@
 /area/centcom/holding)
 "Fy" = (
 /mob/living/simple_animal/pet/fox,
-/turf/open/floor/plating/smooth/dirt,
+/turf/open/indestructible/cobble,
 /area/centcom/holding)
 "Fz" = (
 /obj/structure/chair/comfy/brown{
@@ -16557,6 +16600,8 @@
 /obj/structure/table,
 /obj/item/stack/packageWrap,
 /obj/item/reagent_containers/glass/beaker,
+/obj/item/cookiesynth,
+/obj/item/cookiesynth,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "JW" = (
@@ -16640,7 +16685,20 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "Ke" = (
-/turf/closed/indestructible/opshuttle,
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/sniper_rifle{
+	pixel_x = -4
+	},
+/obj/item/gun/ballistic/automatic/sniper_rifle{
+	pixel_x = -6
+	},
+/obj/item/gun/energy/beam_rifle{
+	pixel_x = 4
+	},
+/obj/item/gun/energy/beam_rifle{
+	pixel_x = 6
+	},
+/turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "Kf" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -16741,7 +16799,7 @@
 /area/tdome/tdomeadmin)
 "Kp" = (
 /obj/machinery/chem_dispenser/fullupgrade,
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible,
 /area/centcom/holding)
 "Kq" = (
 /obj/machinery/light{
@@ -17170,9 +17228,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "Lq" = (
-/obj/item/storage/belt/utility/servant,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/ar,
+/obj/item/gun/ballistic/automatic/ar{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/automatic/ar{
+	pixel_y = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
@@ -17242,9 +17304,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "LF" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/beach/sand,
-/area/fabric_of_reality)
+/obj/structure/rack,
+/obj/item/melee/powerfist,
+/obj/item/melee/powerfist,
+/obj/item/melee/rapier,
+/obj/item/melee/rapier,
+/turf/open/indestructible/clock_spawn_room,
+/area/centcom/holding)
 "LG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/mineral/titanium/blue,
@@ -17768,7 +17834,7 @@
 /area/tdome/tdomeobserve)
 "Nl" = (
 /obj/machinery/chem_master,
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible,
 /area/centcom/holding)
 "Nm" = (
 /obj/structure/chair/comfy/brown{
@@ -18079,12 +18145,17 @@
 /area/centcom/holding)
 "Oh" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/ar,
-/obj/item/gun/ballistic/automatic/ar{
-	pixel_y = 6
+/obj/item/gun/ballistic/shotgun/automatic/combat{
+	pixel_y = -6
 	},
-/obj/item/gun/ballistic/automatic/ar{
+/obj/item/gun/ballistic/shotgun/automatic/combat{
+	pixel_y = -4
+	},
+/obj/item/gun/ballistic/automatic/shotgun/bulldog/unrestricted{
 	pixel_y = 8
+	},
+/obj/item/gun/ballistic/automatic/shotgun/bulldog/unrestricted{
+	pixel_y = 5
 	},
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
@@ -18133,6 +18204,9 @@
 /obj/structure/table/wood/fancy,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
+"Om" = (
+/turf/closed/indestructible/rock/glacierrock,
+/area/space)
 "On" = (
 /obj/machinery/rnd/production/cafe_circuit_imprinter,
 /turf/open/indestructible/hotelwood,
@@ -18511,38 +18585,12 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "Pv" = (
-/obj/structure/rack,
-/obj/item/melee/baton{
-	pixel_x = -6
+/obj/structure/chair/stool/bar,
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
 	},
-/obj/item/melee/baton{
-	pixel_x = -6
-	},
-/obj/item/melee/baton{
-	pixel_x = -6
-	},
-/obj/item/melee/baton{
-	pixel_x = -6
-	},
-/obj/item/melee/baton{
-	pixel_x = -6
-	},
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = 6
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = 6
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = 6
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = 6
-	},
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "Pw" = (
 /obj/machinery/light/small,
@@ -18653,7 +18701,7 @@
 /obj/machinery/vending/clothing{
 	extended_inventory = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "PO" = (
 /obj/machinery/hydroponics/constructable,
@@ -18942,12 +18990,24 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "QE" = (
-/obj/machinery/defibrillator_mount/loaded,
-/turf/closed/indestructible{
-	icon = 'icons/turf/walls/wood_wall.dmi';
-	icon_state = "wood";
-	smooth = 1
+/obj/structure/rack,
+/obj/item/melee/transforming/energy/sword,
+/obj/item/melee/transforming/energy/sword,
+/obj/item/switchblade,
+/obj/item/switchblade,
+/obj/item/claymore{
+	pixel_x = 9
 	},
+/obj/item/claymore{
+	pixel_x = 9
+	},
+/obj/item/claymore{
+	pixel_x = 9
+	},
+/obj/item/claymore{
+	pixel_x = 9
+	},
+/turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "QF" = (
 /obj/machinery/button/door{
@@ -18965,7 +19025,9 @@
 /turf/open/floor/wood,
 /area/fabric_of_reality)
 "QI" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	name = "coat closet"
+	},
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -18996,8 +19058,9 @@
 /area/centcom/holding)
 "QK" = (
 /obj/structure/rack,
-/obj/item/melee/transforming/energy/sword,
-/obj/item/melee/transforming/energy/sword,
+/obj/item/melee/transforming/cleaving_saw,
+/obj/item/melee/transforming/cleaving_saw,
+/obj/item/crucible,
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "QL" = (
@@ -19040,7 +19103,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "QT" = (
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
 	icon_state = "wood";
@@ -19227,7 +19290,7 @@
 	dir = 1;
 	light_color = "#cee5d2"
 	},
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "Rr" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -19257,6 +19320,10 @@
 "Rv" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
+/area/centcom/holding)
+"Rw" = (
+/obj/structure/chair/stool,
+/turf/open/floor/grass/snow,
 /area/centcom/holding)
 "Rx" = (
 /obj/structure/displaycase/trophy,
@@ -19498,19 +19565,18 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "Se" = (
+/obj/item/clockwork/weapon/ratvarian_spear,
+/obj/item/clockwork/weapon/ratvarian_spear,
+/obj/item/clockwork/weapon/ratvarian_spear,
+/obj/item/storage/box/syndie_kit/throwing_weapons{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/storage/box/syndie_kit/throwing_weapons{
+	pixel_x = 5;
+	pixel_y = -5
+	},
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/automatic/combat{
-	pixel_y = -6
-	},
-/obj/item/gun/ballistic/shotgun/automatic/combat{
-	pixel_y = -4
-	},
-/obj/item/gun/ballistic/automatic/shotgun/bulldog/unrestricted{
-	pixel_y = 8
-	},
-/obj/item/gun/ballistic/automatic/shotgun/bulldog/unrestricted{
-	pixel_y = 5
-	},
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "Sf" = (
@@ -19550,7 +19616,7 @@
 	extended_inventory = 1
 	},
 /obj/machinery/light,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "Sk" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -19756,19 +19822,8 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "SL" = (
-/obj/item/clockwork/weapon/ratvarian_spear,
-/obj/item/clockwork/weapon/ratvarian_spear,
-/obj/item/clockwork/weapon/ratvarian_spear,
-/obj/item/storage/box/syndie_kit/throwing_weapons{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/storage/box/syndie_kit/throwing_weapons{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/structure/rack,
-/turf/open/indestructible/clock_spawn_room,
+/obj/structure/fans/tiny/invisible,
+/turf/open/indestructible,
 /area/centcom/holding)
 "SM" = (
 /obj/machinery/computer/cloning{
@@ -20165,17 +20220,31 @@
 /area/centcom/evac)
 "TX" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/sniper_rifle{
-	pixel_x = -4
-	},
-/obj/item/gun/ballistic/automatic/sniper_rifle{
-	pixel_x = -6
-	},
-/obj/item/gun/energy/beam_rifle{
+/obj/item/gun/ballistic/automatic/mini_uzi{
 	pixel_x = 4
 	},
-/obj/item/gun/energy/beam_rifle{
-	pixel_x = 6
+/obj/item/gun/ballistic/automatic/mini_uzi{
+	pixel_x = 2
+	},
+/obj/item/gun/ballistic/automatic/mini_uzi,
+/obj/item/gun/ballistic/automatic/mini_uzi{
+	pixel_x = -4
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/gun/ballistic/automatic/pistol{
+	pixel_x = 4;
+	pixel_y = -2
 	},
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
@@ -20303,7 +20372,7 @@
 /area/tdome/tdomeobserve)
 "Up" = (
 /mob/living/simple_animal/pet/cat,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "Uq" = (
 /obj/structure/table/wood,
@@ -20511,20 +20580,14 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "UU" = (
-/obj/structure/rack,
-/obj/item/melee/powerfist,
-/obj/item/melee/powerfist,
-/obj/item/melee/rapier,
-/obj/item/melee/rapier,
-/turf/open/indestructible/clock_spawn_room,
+/turf/open/indestructible,
 /area/centcom/holding)
 "UV" = (
 /obj/machinery/computer/arcade,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "UW" = (
-/obj/item/storage/belt/utility/servant,
-/obj/item/storage/belt/utility/servant,
+/obj/machinery/light,
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "UX" = (
@@ -20816,7 +20879,7 @@
 /area/centcom/supplypod/loading/one)
 "VK" = (
 /mob/living/simple_animal/pet/dog/cheems,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/royalblue,
 /area/centcom/holding)
 "VL" = (
 /obj/machinery/button/crematorium{
@@ -20826,6 +20889,65 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /turf/open/indestructible/hotelwood,
+/area/centcom/holding)
+"VN" = (
+/obj/structure/rack,
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/shield/riot/tele{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 9
+	},
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "VO" = (
 /turf/closed/indestructible/fakedoor,
@@ -20886,7 +21008,7 @@
 /area/centcom/evac)
 "VZ" = (
 /mob/living/simple_animal/pet/dog/corgi,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/royalblue,
 /area/centcom/holding)
 "Wb" = (
 /obj/structure/table/wood,
@@ -20934,7 +21056,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/centcom/holding)
 "Wh" = (
-/obj/machinery/jukebox/disco/indestructible,
+/obj/machinery/jukebox/disco{
+	req_access = null;
+	req_one_access = null
+	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "Wi" = (
@@ -21037,6 +21162,9 @@
 /obj/item/defibrillator/compact/loaded,
 /obj/item/defibrillator/compact/loaded,
 /obj/structure/table/greyscale,
+/obj/item/gun/medbeam,
+/obj/item/gun/medbeam,
+/obj/item/gun/medbeam,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "WA" = (
@@ -21070,7 +21198,7 @@
 /obj/machinery/vending/kink{
 	extended_inventory = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "WF" = (
 /obj/machinery/door/airlock/sandstone{
@@ -21085,10 +21213,9 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "WI" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/indestructible/hotelwood,
+/obj/item/storage/box/beakers/variety,
+/obj/item/storage/box/beakers/variety,
+/turf/open/indestructible,
 /area/centcom/holding)
 "WJ" = (
 /obj/machinery/door/airlock/centcom{
@@ -21295,13 +21422,56 @@
 /area/centcom/holding)
 "Xp" = (
 /obj/structure/rack,
-/obj/item/uplink/debug{
+/obj/item/chameleon{
+	pixel_x = -8;
 	pixel_y = 8
 	},
-/obj/item/uplink/debug{
-	pixel_y = 4
+/obj/item/chameleon{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/item/uplink/debug,
+/obj/item/chameleon{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/chameleon{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/laser_pointer/upgraded,
+/obj/item/laser_pointer/upgraded,
+/obj/item/laser_pointer/upgraded,
+/obj/item/laser_pointer/upgraded,
+/obj/item/laser_pointer/upgraded,
+/obj/item/laser_pointer/upgraded,
+/obj/item/laser_pointer/upgraded,
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/traitor{
+	pixel_y = 8
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = 6
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = 6
+	},
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding)
 "Xq" = (
@@ -21658,7 +21828,7 @@
 /area/centcom/evac)
 "Yr" = (
 /mob/living/simple_animal/opossum,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "Ys" = (
 /obj/structure/table/reinforced,
@@ -21756,8 +21926,14 @@
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
 "YG" = (
-/turf/open/floor/plating,
-/area/fabric_of_reality)
+/obj/structure/rack,
+/obj/item/storage/firstaid/tactical/nukeop,
+/obj/item/storage/firstaid/tactical/nukeop,
+/obj/item/storage/firstaid/tactical/nukeop,
+/obj/item/storage/firstaid/tactical/nukeop,
+/obj/item/storage/firstaid/tactical/nukeop,
+/turf/open/indestructible/clock_spawn_room,
+/area/centcom/holding)
 "YH" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien13";
@@ -21869,7 +22045,7 @@
 /area/fabric_of_reality)
 "YX" = (
 /mob/living/simple_animal/pet/dog/pug,
-/turf/open/indestructible/hotelwood,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "YY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -21938,34 +22114,9 @@
 /turf/open/floor/wood,
 /area/centcom/evac)
 "Zk" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/mini_uzi{
-	pixel_x = 4
-	},
-/obj/item/gun/ballistic/automatic/mini_uzi{
-	pixel_x = 2
-	},
-/obj/item/gun/ballistic/automatic/mini_uzi,
-/obj/item/gun/ballistic/automatic/mini_uzi{
-	pixel_x = -4
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/gun/ballistic/automatic/pistol{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/turf/open/indestructible/clock_spawn_room,
+/obj/item/flashlight/lamp/bananalamp,
+/obj/structure/table/wood,
+/turf/open/floor/plating/smooth/grass,
 /area/centcom/holding)
 "Zl" = (
 /turf/open/floor/plating,
@@ -21992,7 +22143,7 @@
 /turf/open/floor/carpet/red,
 /area/centcom/evac)
 "Zq" = (
-/turf/open/floor/plating/smooth/dirt,
+/turf/open/indestructible/cobble,
 /area/centcom/holding)
 "Zr" = (
 /obj/machinery/light,
@@ -22151,10 +22302,8 @@
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "ZM" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/turf/open/indestructible/hotelwood,
+/obj/machinery/light,
+/turf/open/floor/carpet/red,
 /area/centcom/holding)
 "ZN" = (
 /obj/machinery/vending/snack,
@@ -46781,16 +46930,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
 OY
 OY
 OY
@@ -47038,17 +47187,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -47295,17 +47444,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -47552,17 +47701,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -47624,23 +47773,23 @@ PX
 CV
 Sd
 NT
-WI
 Sd
-WI
-WI
 Sd
-WI
+Sd
+Sd
+Sd
+Sd
 Nd
-Sd
-Sd
-Sd
-Sd
-Sd
+Of
+Of
+Of
+Of
+Ur
 VK
-Sd
+Ur
 Yr
-Sd
-Sd
+Of
+Of
 WE
 Nd
 aa
@@ -47809,16 +47958,6 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
 Zl
 Zl
@@ -47854,12 +47993,22 @@ Zl
 Zl
 Zl
 Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Nd
 Nd
 Nd
-Nd
+FR
 XL
-Nd
+FR
 Nd
 py
 Nd
@@ -47888,16 +48037,16 @@ Sd
 Sd
 Sd
 Qu
-Sd
-Sd
-Sd
+Of
+Of
+Of
 YX
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+Ur
+Ur
+Ur
+Of
+Of
+Of
 Sj
 Nd
 aa
@@ -48066,17 +48215,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -48138,23 +48287,23 @@ Ym
 CV
 Sd
 NT
-ZM
+Sd
 MR
-ZM
-ZM
+Sd
+Sd
 MR
-ZM
+Sd
 Nd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+Of
+Of
+Of
+Of
+Ur
+Ur
 VZ
-Sd
+Of
 Cd
-Sd
+Of
 PM
 Nd
 aa
@@ -48323,17 +48472,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -48397,6 +48546,8 @@ Sd
 Nd
 Nd
 Nd
+FR
+FR
 Nd
 Nd
 Nd
@@ -48404,11 +48555,9 @@ Nd
 Nd
 Nd
 Nd
-Nd
-Nd
-CU
-Sd
-HH
+Rq
+Of
+ZM
 Nd
 Nd
 Nd
@@ -48580,17 +48729,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -48663,9 +48812,9 @@ UD
 tZ
 SY
 Nd
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Nd
 SY
 Os
@@ -48837,17 +48986,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -48920,9 +49069,9 @@ Sd
 Sd
 Sd
 lS
-Sd
-wi
-Sd
+Of
+Of
+Of
 RP
 Sd
 Sd
@@ -49094,17 +49243,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -49177,9 +49326,9 @@ Xn
 Sd
 Ya
 Nd
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Nd
 XD
 Sd
@@ -49351,17 +49500,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -49434,8 +49583,8 @@ Nd
 Nd
 Nd
 Nd
-tY
-Sd
+Of
+Of
 Up
 Nd
 Nd
@@ -49608,17 +49757,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -49691,9 +49840,9 @@ UD
 tZ
 SY
 Nd
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Nd
 SY
 Os
@@ -49865,17 +50014,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -49948,9 +50097,9 @@ Sd
 Sd
 Sd
 uh
-Sd
-Sd
-Sd
+Of
+Of
+Of
 zW
 Sd
 Sd
@@ -50122,17 +50271,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -50205,9 +50354,9 @@ Xn
 Sd
 Tc
 Nd
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Nd
 AC
 Sd
@@ -50379,17 +50528,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -50463,8 +50612,8 @@ Nd
 Nd
 Nd
 Rq
-Sd
-HH
+Of
+ZM
 Nd
 Nd
 Nd
@@ -50636,17 +50785,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -50719,9 +50868,9 @@ Xs
 Ol
 YO
 Nd
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Nd
 RX
 Xw
@@ -50893,17 +51042,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -50952,7 +51101,7 @@ XL
 Sd
 Sd
 XX
-UE
+Pv
 Sd
 Sd
 Sd
@@ -50976,9 +51125,9 @@ Gs
 Sd
 Sd
 SZ
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Ws
 Sd
 Sd
@@ -51150,17 +51299,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -51233,9 +51382,9 @@ Ru
 Of
 QF
 Nd
-Sd
-Sd
-Sd
+Of
+Of
+Of
 Nd
 WN
 Ur
@@ -51407,17 +51556,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -51480,10 +51629,10 @@ Te
 Nd
 Nd
 Nd
-Nd
+FR
 TT
 TT
-Nd
+FR
 Nd
 Nd
 Kf
@@ -51491,8 +51640,8 @@ WV
 Sd
 Nd
 sa
-Sd
-Sd
+Of
+Of
 Nd
 Sd
 zY
@@ -51664,17 +51813,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -51921,17 +52070,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -52178,33 +52327,33 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -52435,33 +52584,33 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 OY
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -52508,9 +52657,9 @@ Nd
 Nd
 Nd
 Nd
-Nd
+FR
 XG
-QE
+FR
 Nd
 Nd
 Nd
@@ -52692,32 +52841,32 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
+OY
 OY
 OY
 OY
@@ -52789,7 +52938,7 @@ CR
 CR
 CR
 CR
-aa
+Om
 aa
 aa
 aa
@@ -53045,9 +53194,9 @@ WZ
 Qm
 Qm
 WZ
+Qm
 CR
-CR
-aa
+Om
 aa
 aa
 aa
@@ -53303,9 +53452,9 @@ Qm
 Qm
 Qm
 Qm
+Qm
 CR
-CR
-aa
+Om
 aa
 aa
 aa
@@ -53561,9 +53710,9 @@ Qm
 WZ
 Qm
 Qm
+Qm
 CR
-CR
-aa
+Om
 aa
 aa
 aa
@@ -53819,9 +53968,9 @@ Qm
 Qm
 WZ
 Qm
+Qm
 CR
-CR
-aa
+Om
 aa
 aa
 aa
@@ -54077,9 +54226,9 @@ Qm
 Qm
 ue
 Qm
+Qm
 CR
-CR
-aa
+Om
 aa
 aa
 aa
@@ -54335,9 +54484,9 @@ Qm
 Pb
 Pb
 Qm
+Qm
 CR
-CR
-aa
+Om
 aa
 aa
 aa
@@ -54593,7 +54742,7 @@ Qm
 Qm
 Qm
 WZ
-CR
+Qm
 CR
 aa
 aa
@@ -54805,13 +54954,13 @@ Sd
 OC
 Vp
 Bk
-Ke
+FR
 YR
-Ke
+FR
 Xx
-Ke
+FR
 YR
-OY
+FR
 OC
 Vp
 Bk
@@ -55062,18 +55211,18 @@ OY
 pS
 pS
 pS
-Ke
+FR
 pA
-Ke
+FR
 Cm
-Ke
+FR
 pA
-OY
+FR
 pS
 pS
 pS
-OY
-OY
+FR
+FR
 OY
 OY
 Nd
@@ -55582,12 +55731,12 @@ HI
 HI
 HI
 HI
-XR
-HI
-HI
-HI
-HI
-HI
+SL
+UU
+UU
+WI
+UU
+WI
 fy
 OY
 TK
@@ -55839,12 +55988,12 @@ HI
 HI
 HI
 HI
-XR
-HI
-HI
-HI
-HI
-HI
+SL
+UU
+UU
+WI
+UU
+WI
 fy
 OY
 TK
@@ -56604,8 +56753,8 @@ OY
 Jj
 HI
 HI
-Ns
-HI
+YG
+Ke
 HI
 HI
 HI
@@ -56859,10 +57008,10 @@ aa
 aa
 OY
 oU
+MK
 HI
-HI
-Ns
-HI
+VN
+Lq
 HI
 HI
 HI
@@ -57116,7 +57265,7 @@ aa
 aa
 OY
 VU
-HI
+MK
 HI
 Ns
 HI
@@ -57373,7 +57522,7 @@ aa
 aa
 OY
 TX
-MK
+ri
 HI
 HI
 HI
@@ -57630,13 +57779,13 @@ aa
 aa
 OY
 Oh
-MK
-HI
-HI
-HI
-HI
-HI
-HI
+tS
+tY
+wi
+LF
+QE
+QK
+Se
 HI
 HI
 HI
@@ -57653,7 +57802,7 @@ Dm
 Dm
 Dm
 Dm
-Dm
+Zk
 Zq
 Zq
 Zq
@@ -57668,8 +57817,8 @@ kR
 Qm
 Qm
 Qm
-Qm
-Qm
+nh
+Rw
 Qm
 Qm
 Qm
@@ -57884,16 +58033,16 @@ aa
 aa
 aa
 aa
-aa
+ab
 OY
-Zk
-UW
-HI
-HI
-HI
-HI
-HI
-HI
+OY
+FR
+FR
+FR
+FR
+FR
+OY
+OY
 HI
 HI
 HI
@@ -57925,9 +58074,9 @@ Qm
 Qm
 Qm
 Qm
-Qm
-Qm
-Qm
+Rw
+Cf
+Rw
 Qm
 Qm
 Pb
@@ -58141,16 +58290,16 @@ aa
 aa
 aa
 aa
-aa
+ab
+Vc
+HI
+HI
+Vc
+HI
+HI
+HI
+Vc
 OY
-Se
-Lq
-tS
-Pv
-UU
-QK
-ri
-SL
 HI
 HI
 Rg
@@ -58183,7 +58332,7 @@ Qm
 Qm
 WZ
 Qm
-Qm
+Rw
 Qm
 Qm
 Qm
@@ -58399,14 +58548,14 @@ mD
 mD
 aa
 OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+HI
+HI
+GC
+HI
+HI
+HI
+HI
+HI
 OY
 XR
 XR
@@ -58685,12 +58834,12 @@ Mm
 Mm
 Zq
 Zq
-Mm
-Dm
-Mm
-Mm
-Mm
-Mm
+Zq
+Zq
+Zq
+Zq
+Zq
+Zq
 NR
 Qm
 Qm
@@ -58942,12 +59091,12 @@ Mm
 FE
 Zq
 Zq
-Mm
-Dm
-Mm
-Mm
-Mm
-Mm
+Zq
+Zq
+Zq
+Zq
+Zq
+Zq
 NR
 Qm
 Qm
@@ -59182,7 +59331,7 @@ GC
 HI
 HI
 HI
-HI
+UW
 OY
 aa
 aa
@@ -59953,7 +60102,7 @@ HI
 HI
 GC
 GC
-HI
+UW
 OY
 aa
 aa
@@ -60724,7 +60873,7 @@ GC
 HI
 HI
 HI
-HI
+UW
 Ep
 Ev
 Ev
@@ -60971,7 +61120,7 @@ aa
 OY
 Kw
 HI
-HI
+GC
 HI
 GC
 HI
@@ -61485,13 +61634,13 @@ aa
 OY
 Br
 HI
+Rg
 HI
 HI
+Rg
 HI
 HI
-HI
-HI
-HI
+Rg
 HI
 HI
 Rg
@@ -63082,12 +63231,12 @@ aa
 aa
 aa
 CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
+CR
+CR
+CR
+CR
+CR
+CR
 CR
 aa
 aa
@@ -63338,14 +63487,14 @@ zv
 zv
 aa
 aa
-CR
-Qm
-Qm
-kR
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -63595,14 +63744,14 @@ pT
 zv
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -63851,15 +64000,15 @@ pT
 pT
 zv
 aa
-CR
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64108,15 +64257,15 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64365,15 +64514,15 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64622,15 +64771,15 @@ pT
 pT
 zv
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-kR
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -64879,15 +65028,15 @@ pT
 pT
 zv
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -65136,15 +65285,15 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -65393,15 +65542,15 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -65650,16 +65799,16 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -65907,16 +66056,16 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -66164,16 +66313,16 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-kR
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -66421,16 +66570,16 @@ pT
 pT
 zv
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -66678,16 +66827,16 @@ pT
 pT
 zv
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -66935,16 +67084,16 @@ pT
 pT
 Rk
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -67192,16 +67341,16 @@ pT
 pT
 Rk
 aa
-CR
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -67450,15 +67599,15 @@ pT
 zv
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -67707,15 +67856,15 @@ pT
 zv
 aa
 aa
-CR
-Qm
-Qm
-Qm
-kR
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -67964,15 +68113,15 @@ Rk
 zv
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -68221,15 +68370,15 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -68478,15 +68627,15 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -68735,15 +68884,15 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-kR
-Qm
-Qm
-Qm
-CR
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -68992,14 +69141,14 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -69249,14 +69398,14 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -69506,14 +69655,14 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -69763,14 +69912,14 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-CR
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -70020,14 +70169,14 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -70277,14 +70426,14 @@ aa
 aa
 aa
 aa
-CR
-Qm
-Qm
-Qm
-kR
-Qm
-Qm
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -70534,14 +70683,14 @@ aa
 aa
 aa
 aa
-Mc
-Qm
-Qm
-Qm
-Qm
-Qm
-Qm
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -70791,14 +70940,14 @@ aa
 aa
 aa
 aa
-Mc
-Qm
-Qm
-Qm
-Qm
-Qm
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -71048,14 +71197,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-Qm
-Qm
-Qm
-Qm
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -71305,14 +71454,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-Qm
-Qm
-QM
-Qm
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -71562,14 +71711,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-Qm
-Qm
-QM
-Qm
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -71819,14 +71968,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-Qm
-QM
-Qm
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -72076,14 +72225,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-Qm
-QM
-Qm
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -72333,14 +72482,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-Qm
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -72590,14 +72739,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-Qm
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -72847,14 +72996,14 @@ aa
 aa
 aa
 aa
-Mc
-LF
-LF
-LF
-LF
-LF
-LF
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -73104,14 +73253,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -73361,14 +73510,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -73618,14 +73767,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -73875,14 +74024,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -74132,14 +74281,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -74389,14 +74538,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -74646,14 +74795,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -74903,14 +75052,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -75160,14 +75309,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -75417,14 +75566,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -75674,14 +75823,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -75931,14 +76080,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -76188,14 +76337,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -76445,14 +76594,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -76702,14 +76851,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -76959,14 +77108,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -77216,14 +77365,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -77473,14 +77622,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -77730,14 +77879,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -77987,14 +78136,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -78244,14 +78393,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -78501,14 +78650,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -78758,14 +78907,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -79015,14 +79164,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -79272,14 +79421,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -79529,14 +79678,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -79786,14 +79935,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -80043,14 +80192,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -80300,14 +80449,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -80557,14 +80706,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -80814,14 +80963,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -81071,14 +81220,14 @@ aa
 aa
 aa
 aa
-Mc
-QM
-QM
-QM
-QM
-QM
-QM
-Mc
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -81329,12 +81478,12 @@ Mc
 Mc
 Mc
 Mc
-QM
-QM
-QM
-QM
-QM
-Fo
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
 Mc
 Mc
 Mc
@@ -83372,7 +83521,7 @@ aa
 aa
 Mc
 UR
-YG
+Fn
 XF
 XF
 XF
@@ -83629,7 +83778,7 @@ aa
 aa
 Mc
 NC
-YG
+Fn
 OX
 BN
 BN
@@ -83885,8 +84034,8 @@ aa
 aa
 aa
 Mc
-YG
-YG
+Fn
+Fn
 XF
 Nj
 BN
@@ -84413,7 +84562,7 @@ UA
 Mr
 QM
 QM
-tb
+QM
 QM
 Yn
 QM
@@ -85171,7 +85320,7 @@ aa
 aa
 Mc
 Jq
-YG
+Fn
 XF
 QG
 Fd
@@ -85428,7 +85577,7 @@ aa
 aa
 Mc
 wS
-YG
+Fn
 XF
 XF
 XF

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -17614,6 +17614,13 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "MA" = (
@@ -18726,6 +18733,24 @@
 "PQ" = (
 /obj/structure/closet/secure_closet,
 /obj/item/coin/silver,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
+"PR" = (
+/obj/structure/table/wood/bar,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
 "PS" = (
@@ -48518,7 +48543,7 @@ Zl
 Zl
 Zl
 Nd
-Tq
+PR
 Sd
 MG
 YN

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -29,6 +29,27 @@
 /area/centcom/holding
 	name = "Holding Facility"
 
+/area/centcom/holding/cafe
+	name = "Ghost Cafe"
+
+/area/centcom/holding/cafewar
+	name = "Cafe Combat Zone"
+
+/area/centcom/holding/cafebotany
+	name = "Cafe Service Area"
+
+/area/centcom/holding/cafebuild
+	name = "Cafe Construction Zone"
+
+/area/centcom/holding/cafevox
+	name = "Cafe Vox Box"
+
+/area/centcom/holding/cafedorms
+	name = "Ghost Cafe Dorms"
+
+/area/centcom/holding/cafepark
+	name = "Ghost Cafe Outdoors"
+
 /area/centcom/vip
 	name = "VIP Zone"
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -673,7 +673,8 @@
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
 		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type,/area/hilbertshotel))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/hilbertshotel, /area/centcom/holding/cafe, /area/centcom/holding/cafewar, /area/centcom/holding/cafebotany,
+		/area/centcom/holding/cafebuild, /area/centcom/holding/cafevox, /area/centcom/holding/cafedorms, /area/centcom/holding/cafepark))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -677,7 +677,6 @@
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
-		ADD_TRAIT(new_spawn, TRAIT_PACIFISM, GHOSTROLE_TRAIT)
 		to_chat(new_spawn,"<span class='boldwarning'>Ghosting is free!</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
 		D.Grant(new_spawn)

--- a/modular_skyrat/code/game/objects/items/stackspawner/stackspawner_item.dm
+++ b/modular_skyrat/code/game/objects/items/stackspawner/stackspawner_item.dm
@@ -9,7 +9,7 @@
 
 /obj/item/stackspawner/attack_self(mob/user)
 	. = ..()
-	
+
 	var/static/list/material_list
 	if(!material_list)
 		material_list = list(
@@ -36,7 +36,6 @@
 			"Brass"						= image(icon = icon, icon_state = "brass"),
 			"Runed"						= image(icon = icon, icon_state = "runed"),
 			"Mythril"					= image(icon = icon, icon_state = "mythril"),
-			"Adamantine"				= image(icon = icon, icon_state = "adamantine"),
 			"Alien Alloy"				= image(icon = icon, icon_state = "alien"),
 			//"Alien Glass"				= image(icon = icon, icon_state = "aglass"),
 			"Coal"						= image(icon = icon, icon_state = "coal"),
@@ -108,12 +107,12 @@
 			itemstack = /obj/item/stack/sheet/runed_metal
 		if("Mythril")
 			itemstack = /obj/item/stack/sheet/mineral/mythril
-		if("Adamantine")	
+		if("Adamantine")
 			itemstack = /obj/item/stack/sheet/mineral/adamantine
 		if("Alien Alloy")
 			itemstack = /obj/item/stack/sheet/mineral/abductor
 		//if("Alien Glass")
-		//	itemstack = 
+		//	itemstack =
 		if("Coal")
 			itemstack = /obj/item/stack/sheet/mineral/coal
 		if("Wood")

--- a/modular_skyrat/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_skyrat/code/game/objects/structures/ghost_role_spawners.dm
@@ -278,7 +278,6 @@
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
-		ADD_TRAIT(new_spawn, TRAIT_PACIFISM, GHOSTROLE_TRAIT)
 		to_chat(new_spawn,"<span class='boldwarning'>Ghosting is free!</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
 		D.Grant(new_spawn)

--- a/modular_skyrat/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_skyrat/code/game/objects/structures/ghost_role_spawners.dm
@@ -274,7 +274,8 @@
 		var/area/A = get_area(src)
 		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type,/area/hilbertshotel))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/hilbertshotel, /area/centcom/holding/cafe, /area/centcom/holding/cafewar, /area/centcom/holding/cafebotany,
+		/area/centcom/holding/cafebuild, /area/centcom/holding/cafevox, /area/centcom/holding/cafedorms, /area/centcom/holding/cafepark))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The cafe now has individual areas it's split into, so now atmos won't fuck up as bad while retaining the thing where if you get out of the cafe you dust instantly. The snow area should be fine as well, though I can't make any promises because snow tiles suck. Removed hilbert's hotel because of redundancy. Removed the door into centcomm's thunder dome area.

Adamantine is also removed fro mthe stack spawner device due to people abusing it to make golems, escape the cafe, and making admins panic. 

**This is the last time I'm doing a fix for this thing. If I hear anymore complaints from staff that people are abusing or exploiting things, I'm removing the cafe changes outright. Act like fucking adults.**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Title.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added cafe areas
tweak: made stacker not able to spawn adamantine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
