### PR TITLE
Removes reroll limit on contractor kit.

### DIFF
--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -80,7 +80,6 @@
 	name = "Contract Reroll"
 	desc = "Request a reroll of your current contract list. Will generate a new target, payment, and dropoff for the contracts you currently have available."
 	item_icon = "fa-dice"
-	limited = 2
 	cost = 0
 
 /datum/contractor_item/contract_reroll/handle_purchase(var/datum/contractor_hub/hub)

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -76,11 +76,11 @@
 	var/limited = -1 // Any number above 0 for how many times it can be bought in a round for a single traitor. -1 is unlimited.
 	var/cost // Cost of the item in contract rep.
 
-/datum/contractor_item/contract_reroll
+/datum/contractor_item/contract_reroll	//Skyrat Change begin
 	name = "Contract Reroll"
 	desc = "Request a reroll of your current contract list. Will generate a new target, payment, and dropoff for the contracts you currently have available."
 	item_icon = "fa-dice"
-	cost = 0
+	cost = 0	//Skyrat Change end
 
 /datum/contractor_item/contract_reroll/handle_purchase(var/datum/contractor_hub/hub)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Removes the limit on contract rerolls for the contractor kit. No more full rolls on people that are: SSD/AFK, ERPing in dorms, god knows where the contractor tracker cannot locate them properly. 

## Why It's Good For The Game

Now you can reroll indefinitly. Good for when all your targets are unavailable/not findable and you spend your previous two rerolls to get similar results because of RNG.

## Changelog
:cl:
tweak: Changes contractor kits reroll limit. Its gone.
/:cl:


