### PR TITLE
ghost cafe fixes

### DIFF
--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -18298,7 +18298,9 @@
 /turf/closed/indestructible/rock/glacierrock,
 /area/centcom/holding/cafepark)
 "On" = (
-/obj/machinery/rnd/production/cafe_circuit_imprinter,
+/obj/machinery/rnd/production/cafe_circuit_imprinter{
+	console_link = 0
+	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafebotany)
 "Oo" = (
@@ -18439,7 +18441,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/rnd/production/techfab/department/engineering,
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafebotany)
 "OH" = (
@@ -18964,6 +18966,10 @@
 /obj/machinery/vending/custom,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
+"Qh" = (
+/obj/item/hilbertshotel/ghostdojo,
+/turf/open/floor/carpet/red,
+/area/centcom/holding/cafedorms)
 "Qi" = (
 /obj/item/paicard,
 /obj/structure/table/wood,
@@ -51872,7 +51878,7 @@ Kf
 WV
 WG
 Wa
-Of
+Qh
 Of
 Of
 Wa

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -21375,8 +21375,6 @@
 /obj/item/defibrillator/compact/loaded,
 /obj/structure/table/greyscale,
 /obj/item/gun/medbeam,
-/obj/item/gun/medbeam,
-/obj/item/gun/medbeam,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "WA" = (

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -2113,7 +2113,7 @@
 "fy" = (
 /obj/machinery/light,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "fz" = (
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
@@ -2944,7 +2944,7 @@
 	},
 /obj/machinery/prize_counter/upgraded,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3711,6 +3711,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"jA" = (
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "jB" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -4197,7 +4200,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "kw" = (
 /turf/open/floor/plasteel/yellowsiding,
 /area/centcom/supply)
@@ -4367,10 +4370,6 @@
 	icon_state = "alien19"
 	},
 /area/abductor_ship)
-"kR" = (
-/obj/effect/light_emitter,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
 "kS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4809,7 +4808,7 @@
 	name = "Dorm 1"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -4878,7 +4877,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "mb" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5440,8 +5439,10 @@
 /obj/item/melee/roastingstick,
 /obj/item/melee/roastingstick,
 /obj/item/melee/roastingstick,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "ni" = (
 /obj/machinery/newscaster/security_unit,
 /turf/closed/indestructible/riveted,
@@ -6505,7 +6506,13 @@
 /obj/item/ammo_box/n762,
 /obj/item/ammo_box/n762,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
+"oV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "oW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -6884,7 +6891,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "pz" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -6897,7 +6904,7 @@
 	dir = 8
 	},
 /turf/open/warzonetile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "pB" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien8";
@@ -6905,16 +6912,15 @@
 	},
 /area/bluespace_locker)
 "pC" = (
-/obj/machinery/chem_heater,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "pD" = (
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "pE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -7062,7 +7068,7 @@
 "pS" = (
 /obj/structure/fans/tiny/invisible,
 /turf/closed/indestructible/fakeglass,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "pT" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/podStorage)
@@ -7083,7 +7089,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "pW" = (
 /obj/effect/landmark/ai_multicam_room,
 /turf/open/ai_visible,
@@ -7463,7 +7469,7 @@
 	},
 /obj/structure/rack,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "qH" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -7472,7 +7478,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/benedict,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "qI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
@@ -7500,7 +7506,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "qM" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -7519,7 +7525,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/bearsteak,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "qO" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Bar Access"
@@ -7533,7 +7539,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "qQ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
@@ -7646,12 +7652,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "ri" = (
 /obj/item/storage/belt/utility/servant,
 /obj/item/storage/belt/utility/servant,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "rk" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -8149,7 +8155,7 @@
 	pixel_y = 24
 	},
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "rZ" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -8157,10 +8163,6 @@
 /obj/item/disk/surgery/debug,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
-"sa" = (
-/obj/item/hilbertshotel/ghostdojo,
-/turf/open/floor/carpet/red,
-/area/centcom/holding)
 "sb" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -8169,7 +8171,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/cornedbeef,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "sc" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership/control;
@@ -8194,7 +8196,7 @@
 "se" = (
 /obj/machinery/pool/drain,
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "sf" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -8244,7 +8246,10 @@
 "sk" = (
 /obj/machinery/computer/arcade/tetris,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
+"sl" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding/cafevox)
 "sm" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/mineral/titanium/white,
@@ -8262,7 +8267,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "sq" = (
 /obj/machinery/computer/shuttle/white_ship{
 	dir = 4
@@ -8658,7 +8663,7 @@
 "sY" = (
 /mob/living/simple_animal/parrot,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "sZ" = (
 /obj/structure/sign/map/left{
 	pixel_y = -32
@@ -8675,10 +8680,16 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/pacifytile,
 /area/centcom/evac)
+"tb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "tc" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "td" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -8715,8 +8726,10 @@
 "th" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/brown,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "ti" = (
 /obj/structure/table,
 /obj/structure/window{
@@ -8727,11 +8740,11 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "tj" = (
 /mob/living/simple_animal/chicken/rabbit,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "tk" = (
 /obj/structure/table,
 /obj/item/clothing/mask/luchador/tecnicos,
@@ -8747,6 +8760,13 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"tn" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafe)
 "to" = (
 /obj/machinery/computer/shuttle/ferry{
 	dir = 4
@@ -8805,14 +8825,16 @@
 /area/centcom/ferry)
 "tv" = (
 /mob/living/simple_animal/pet/penguin/emperor,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "tw" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -9076,7 +9098,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "tT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9147,14 +9169,14 @@
 	pixel_y = -8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "tZ" = (
 /obj/structure/chair/wood/normal,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ua" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/hypospraykit/toxin{
@@ -9195,10 +9217,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
-"ue" = (
-/obj/structure/flora/grass/brown,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
 "uf" = (
 /obj/machinery/light{
 	dir = 4
@@ -9221,7 +9239,7 @@
 	name = "Dorm 2"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ui" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -9845,7 +9863,7 @@
 "vq" = (
 /obj/machinery/pool/controller,
 /turf/open/floor/plasteel/yellowsiding,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "vs" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -9859,7 +9877,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "vt" = (
 /turf/closed/indestructible/wood,
 /area/centcom/holding)
@@ -9900,7 +9918,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "vy" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -9908,6 +9926,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"vz" = (
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -10276,10 +10298,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"wf" = (
-/obj/effect/light_emitter,
-/turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
 "wg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -10322,7 +10340,7 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "wj" = (
 /obj/machinery/light{
 	dir = 8
@@ -10885,12 +10903,12 @@
 	},
 /obj/item/reagent_containers/food/snacks/meat/steak,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "xD" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 8
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "xE" = (
 /obj/structure/table,
 /obj/item/clothing/mask/luchador,
@@ -10940,7 +10958,7 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "xM" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -10957,7 +10975,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "xP" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien2";
@@ -11072,6 +11090,14 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"yc" = (
+/obj/machinery/light,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
+"yd" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "yf" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -11080,7 +11106,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "yg" = (
 /obj/structure/chair,
 /turf/open/floor/mineral/titanium,
@@ -11101,7 +11127,7 @@
 	},
 /obj/structure/table,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "yi" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plating/beach/sand,
@@ -11386,11 +11412,18 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "yN" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
+"yO" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafebotany)
 "yP" = (
 /obj/machinery/light{
 	dir = 4
@@ -11416,7 +11449,7 @@
 	name = "Dorm 7"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "yT" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/centcom/evac)
@@ -11446,11 +11479,11 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "yX" = (
 /obj/item/target/syndicate,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "yY" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -11670,6 +11703,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership)
+"zt" = (
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "zu" = (
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
@@ -11683,7 +11719,7 @@
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "zx" = (
 /obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/stripes/line{
@@ -11889,7 +11925,10 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"zT" = (
+/turf/open/floor/plasteel/white,
+/area/centcom/holding/cafedorms)
 "zU" = (
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/plasteel/cafeteria,
@@ -11904,14 +11943,14 @@
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "zW" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "Ninja5";
 	name = "Dorm 5"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "zX" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -11919,7 +11958,7 @@
 	},
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "zY" = (
 /obj/item/bedsheet/wiz{
 	desc = "A glow in the dark blue bedsheet.";
@@ -11927,7 +11966,14 @@
 	},
 /obj/structure/bed,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"zZ" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/grass/brown,
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Aa" = (
 /turf/open/floor/mech_bay_recharge_floor,
 /area/syndicate_mothership)
@@ -12188,7 +12234,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "AD" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Leader's Room";
@@ -12467,7 +12513,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Bl" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
@@ -12495,12 +12541,12 @@
 "Br" = (
 /obj/machinery/recharger,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Bs" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Bt" = (
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
@@ -12774,7 +12820,7 @@
 "BP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "BQ" = (
 /obj/effect/landmark/abductor/scientist{
 	team_number = 3
@@ -12822,7 +12868,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "BX" = (
 /obj/structure/chair/sofa,
 /obj/machinery/light{
@@ -12886,7 +12932,7 @@
 "Cd" = (
 /mob/living/simple_animal/pet/redpanda,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ce" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -12894,8 +12940,10 @@
 /area/fabric_of_reality)
 "Cf" = (
 /obj/structure/bonfire/prelit,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Ch" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/mineral/titanium/blue,
@@ -12934,7 +12982,7 @@
 	dir = 4
 	},
 /turf/open/warzonetile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Cn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -13327,16 +13375,19 @@
 "CP" = (
 /obj/structure/pool/ladder,
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "CQ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"CR" = (
-/turf/closed/indestructible/rock/glacierrock,
-/area/centcom/holding)
+"CS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "CT" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
@@ -13352,12 +13403,12 @@
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "CW" = (
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -13473,7 +13524,7 @@
 "Dh" = (
 /obj/machinery/chem_heater,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Di" = (
 /turf/closed/indestructible/riveted,
 /area/ai_multicam_room)
@@ -13491,7 +13542,7 @@
 /area/centcom/holding)
 "Dm" = (
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Dn" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -13576,7 +13627,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Dx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/kirbyplants/random,
@@ -13595,11 +13646,13 @@
 	pixel_y = -24
 	},
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "DA" = (
 /obj/structure/flora/rock/icy,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "DB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plasteel/dark,
@@ -14068,7 +14121,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "EE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/neutral{
@@ -14270,19 +14323,23 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"EZ" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "Fa" = (
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
 /obj/item/instrument/guitar,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Fb" = (
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
 "Fc" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "Fd" = (
 /obj/structure/reagent_dispensers/beerkeg{
 	reagent_id = /datum/reagent/consumable/ethanol/beer/light
@@ -14306,10 +14363,10 @@
 /area/syndicate_mothership)
 "Fh" = (
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Fi" = (
 /turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Fj" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -14333,10 +14390,14 @@
 "Fl" = (
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Fn" = (
 /turf/open/floor/plating,
 /area/fabric_of_reality)
+"Fo" = (
+/obj/machinery/chem_dispenser/fullupgrade,
+/turf/open/indestructible,
+/area/centcom/holding/cafewar)
 "Fp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14411,7 +14472,7 @@
 "Fy" = (
 /mob/living/simple_animal/pet/fox,
 /turf/open/indestructible/cobble,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Fz" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -14443,11 +14504,15 @@
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 4
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "FE" = (
 /obj/effect/light_emitter,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
+"FF" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "FG" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -14544,7 +14609,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "FT" = (
 /obj/structure/destructible/cult/forge{
 	desc = "An engine used in powering the wizard's ship";
@@ -14569,10 +14634,10 @@
 	},
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "FX" = (
 /turf/open/floor/plasteel/stairs,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "FY" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -14752,7 +14817,7 @@
 /obj/structure/bedsheetbin/towel,
 /obj/structure/table,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Gu" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -14804,7 +14869,13 @@
 "GC" = (
 /obj/structure/barricade/security/murderdome,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
+"GD" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "GE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15103,7 +15174,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ha" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -15117,7 +15188,7 @@
 	},
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Hb" = (
 /obj/machinery/processor,
 /turf/open/floor/wood,
@@ -15173,14 +15244,14 @@
 "Hi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Hj" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/musician/piano,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Hk" = (
 /obj/structure/table/wood,
 /obj/item/camera/detective{
@@ -15191,7 +15262,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Hl" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -15209,7 +15280,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ho" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -15352,6 +15423,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"HA" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "HB" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -15425,7 +15501,7 @@
 /area/centcom/holding)
 "HI" = (
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "HJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/chef,
@@ -15523,7 +15599,7 @@
 "HQ" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "HR" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -15806,7 +15882,7 @@
 "In" = (
 /mob/living/simple_animal/parrot,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Io" = (
 /obj/item/storage/box/matches{
 	pixel_x = -3;
@@ -16052,7 +16128,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "IP" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -16255,7 +16331,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Jk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -16408,7 +16484,7 @@
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "JF" = (
 /obj/machinery/computer/camera_advanced/abductor{
 	team_number = 1
@@ -16603,7 +16679,7 @@
 /obj/item/cookiesynth,
 /obj/item/cookiesynth,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "JW" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien12";
@@ -16624,7 +16700,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "JZ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -16699,14 +16775,14 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Kf" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -16732,7 +16808,7 @@
 /obj/item/reagent_containers/rag/towel,
 /obj/item/reagent_containers/rag/towel,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Kj" = (
 /obj/machinery/door/airlock/external{
 	name = "Backup Emergency Escape Shuttle"
@@ -16797,16 +16873,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
-"Kp" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/turf/open/indestructible,
-/area/centcom/holding)
 "Kq" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "Kr" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -16921,7 +16993,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Kx" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating,
@@ -17071,7 +17143,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "KU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/blue,
@@ -17155,7 +17227,7 @@
 /obj/item/reagent_containers/food/snacks/meat/steak,
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Lg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17202,19 +17274,19 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Lm" = (
 /obj/machinery/shower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ln" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Lo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -17237,12 +17309,12 @@
 	pixel_y = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Lr" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ls" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -17259,7 +17331,7 @@
 /area/centcom/evac)
 "Lu" = (
 /turf/open/floor/plasteel/yellowsiding/corner,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Lv" = (
 /obj/structure/bed,
 /turf/open/floor/mineral/titanium/blue,
@@ -17282,6 +17354,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"Lz" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding/cafewar)
 "LA" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -17298,6 +17373,10 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"LD" = (
+/obj/structure/closet/crate/bin,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "LE" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -17310,7 +17389,7 @@
 /obj/item/melee/rapier,
 /obj/item/melee/rapier,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "LG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/mineral/titanium/blue,
@@ -17323,6 +17402,10 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"LI" = (
+/obj/structure/flora/tree/pine,
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "LJ" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -17543,7 +17626,7 @@
 /area/centcom/supplypod/loading/four)
 "Mm" = (
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Mn" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/purple,
@@ -17570,7 +17653,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Mv" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -17622,7 +17705,7 @@
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "MA" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien3";
@@ -17665,7 +17748,7 @@
 	name = "Animal Pen"
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "MH" = (
 /obj/structure/ladder/unbreakable/binary/unlinked,
 /turf/open/indestructible/airblock,
@@ -17679,17 +17762,19 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "MK" = (
 /obj/item/storage/belt/utility/servant,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "ML" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "MM" = (
 /obj/item/reagent_containers/spray/spraytan,
 /obj/effect/turf_decal/sand,
@@ -17736,8 +17821,9 @@
 /turf/open/floor/plating,
 /area/fabric_of_reality)
 "MV" = (
+/obj/structure/fans/tiny/invisible,
 /turf/open/water/lavaland_jungle,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "MW" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -17751,7 +17837,7 @@
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "MZ" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien23";
@@ -17775,13 +17861,13 @@
 /obj/item/reagent_containers/food/snacks/beefnoodle,
 /obj/item/reagent_containers/food/snacks/beefnoodle,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Nc" = (
 /obj/machinery/atm{
 	pixel_x = -30
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Nd" = (
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
@@ -17801,7 +17887,7 @@
 "Nf" = (
 /obj/machinery/autolathe/toy,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ng" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17813,7 +17899,7 @@
 "Nh" = (
 /obj/structure/window/plasma/reinforced,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ni" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -17839,10 +17925,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
-"Nl" = (
-/obj/machinery/chem_master,
-/turf/open/indestructible,
-/area/centcom/holding)
 "Nm" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -17877,7 +17959,7 @@
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Nq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/window/reinforced/spawner{
@@ -17897,11 +17979,11 @@
 "Ns" = (
 /obj/machinery/vending/donksofttoyvendor,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Nt" = (
 /obj/structure/bedsheetbin/color,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Nu" = (
 /turf/open/floor/wood,
 /area/syndicate_mothership)
@@ -17921,14 +18003,14 @@
 "Nw" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Nx" = (
 /obj/machinery/processor,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ny" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/nuclear{
@@ -17941,7 +18023,7 @@
 	pixel_y = -3
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Nz" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -17980,7 +18062,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "NF" = (
 /obj/structure/ladder/unbreakable/binary,
 /turf/open/indestructible/airblock,
@@ -18025,7 +18107,7 @@
 "NL" = (
 /obj/item/target/clown,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "NM" = (
 /turf/closed/indestructible/abductor{
 	opacity = 0
@@ -18034,7 +18116,7 @@
 "NN" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "NO" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/hypospray/combat{
@@ -18055,16 +18137,18 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "NR" = (
 /obj/structure/fans/tiny/invisible,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "NS" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/toy/poolnoodle/blue,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "NT" = (
 /obj/structure/window/paperframe{
 	CanAtmosPass = 0
@@ -18106,7 +18190,7 @@
 "NY" = (
 /obj/structure/pool/Lboard,
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "NZ" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/bag/money/c5000,
@@ -18114,16 +18198,15 @@
 /obj/item/storage/bag/money/c5000,
 /obj/item/key/janitor,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Oa" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/syndicate_mothership)
 "Ob" = (
 /obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Oc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -18139,17 +18222,17 @@
 "Od" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Oe" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/syndicate_mothership)
 "Of" = (
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Og" = (
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Oh" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/shotgun/automatic/combat{
@@ -18165,7 +18248,7 @@
 	pixel_y = 5
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Oi" = (
 /obj/item/tank/internals/nitrogen/belt/full,
 /obj/item/clothing/mask/breath/vox,
@@ -18210,14 +18293,14 @@
 "Ol" = (
 /obj/structure/table/wood/fancy,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Om" = (
 /turf/closed/indestructible/rock/glacierrock,
-/area/space)
+/area/centcom/holding/cafepark)
 "On" = (
 /obj/machinery/rnd/production/cafe_circuit_imprinter,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Oo" = (
 /obj/machinery/light{
 	dir = 8
@@ -18240,7 +18323,17 @@
 	},
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"Oq" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
+"Or" = (
+/obj/structure/mineral_door/paperframe,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "Os" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -18249,16 +18342,19 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ot" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ou" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Cold Storage"
 	},
 /area/syndicate_mothership)
+"Ov" = (
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "Ow" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/purple,
@@ -18268,7 +18364,7 @@
 	name = "Cryo"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Oy" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/tequila,
@@ -18287,7 +18383,7 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "OB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Barracks";
@@ -18300,10 +18396,10 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "OD" = (
 /turf/open/floor/plasteel/yellowsiding,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "OE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -18345,12 +18441,12 @@
 	},
 /obj/machinery/rnd/production/techfab/department/engineering,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "OH" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/toy/poolnoodle/red,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "OI" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18374,7 +18470,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "ON" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
@@ -18387,7 +18483,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "OP" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -18431,7 +18527,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "OX" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Bar Storage"
@@ -18453,7 +18549,7 @@
 /obj/structure/flora/tree/pine,
 /obj/structure/flora/grass/brown,
 /turf/open/floor/grass/snow,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Pc" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -18473,7 +18569,7 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/item/book/manual/hydroponics_pod_people,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Pd" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -18504,7 +18600,7 @@
 "Ph" = (
 /obj/structure/closet/crate/bin,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Pi" = (
 /obj/structure/chair{
 	dir = 1
@@ -18575,7 +18671,7 @@
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ps" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/structure/extinguisher_cabinet{
@@ -18585,8 +18681,10 @@
 /area/centcom/evac)
 "Pt" = (
 /obj/structure/chair/wood,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Pu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel/dark,
@@ -18598,7 +18696,7 @@
 	pixel_x = 32
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Pw" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -18666,7 +18764,7 @@
 "PG" = (
 /mob/living/simple_animal/pet/redpanda,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "PH" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
@@ -18687,7 +18785,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18703,13 +18801,13 @@
 "PL" = (
 /obj/machinery/autolathe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PM" = (
 /obj/machinery/vending/clothing{
 	extended_inventory = 1
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "PO" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -18723,7 +18821,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PP" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -18734,7 +18832,7 @@
 /obj/structure/closet/secure_closet,
 /obj/item/coin/silver,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "PR" = (
 /obj/structure/table/wood/bar,
 /obj/item/storage/toolbox/mechanical,
@@ -18752,7 +18850,7 @@
 /obj/item/storage/box/stockparts/deluxe,
 /obj/item/storage/box/stockparts/deluxe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PS" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /obj/effect/turf_decal/tile/bar,
@@ -18768,7 +18866,7 @@
 	pixel_y = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "PU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18803,7 +18901,7 @@
 "PX" = (
 /obj/machinery/computer/arcade/battle,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "PY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -18816,11 +18914,11 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "PZ" = (
 /mob/living/simple_animal/sloth,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Qa" = (
 /obj/machinery/sleeper/centcom{
 	dir = 4
@@ -18841,6 +18939,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"Qd" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/holding/cafebuild)
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
@@ -18888,7 +18989,7 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Ql" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18897,8 +18998,10 @@
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Qm" = (
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Qn" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/mineral/titanium/white,
@@ -18909,7 +19012,7 @@
 "Qp" = (
 /obj/structure/bedsheetbin,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Qq" = (
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
@@ -18924,8 +19027,10 @@
 /area/centcom/holding)
 "Qs" = (
 /mob/living/simple_animal/deer,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Qt" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/pizzaslice/mushroom,
@@ -18940,7 +19045,7 @@
 	name = "Dorms"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Qv" = (
 /obj/structure/chair{
 	dir = 1
@@ -18952,7 +19057,7 @@
 /area/centcom/evac)
 "Qw" = (
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Qx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -18984,11 +19089,11 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QB" = (
 /obj/machinery/computer/telecrystals/uplinker,
 /obj/effect/turf_decal/stripes/line{
@@ -19001,7 +19106,7 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QD" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -19033,7 +19138,7 @@
 	pixel_x = 9
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "QF" = (
 /obj/machinery/button/door{
 	id = "Ninja3";
@@ -19043,12 +19148,15 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QG" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
 /area/fabric_of_reality)
+"QH" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding/cafebotany)
 "QI" = (
 /obj/structure/closet{
 	name = "coat closet"
@@ -19080,17 +19188,17 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QK" = (
 /obj/structure/rack,
 /obj/item/melee/transforming/cleaving_saw,
 /obj/item/melee/transforming/cleaving_saw,
 /obj/item/crucible,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "QL" = (
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "QM" = (
 /turf/open/floor/plating/beach/sand,
 /area/fabric_of_reality)
@@ -19099,7 +19207,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "QO" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -19134,7 +19242,7 @@
 	icon_state = "wood";
 	smooth = 1
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QU" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -19156,7 +19264,7 @@
 	locked = 0
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "QX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -19214,7 +19322,7 @@
 "Re" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Rf" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -19230,19 +19338,19 @@
 	dir = 4
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Rh" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ri" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Rj" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/tile/green{
@@ -19256,7 +19364,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Rk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
@@ -19274,7 +19382,7 @@
 	dir = 3
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Rn" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien7";
@@ -19316,7 +19424,7 @@
 	light_color = "#cee5d2"
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Rr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19341,15 +19449,17 @@
 "Ru" = (
 /obj/structure/fireplace,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Rv" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Rw" = (
 /obj/structure/chair/stool,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Rx" = (
 /obj/structure/displaycase/trophy,
 /turf/open/indestructible/hotelwood,
@@ -19359,7 +19469,7 @@
 	pixel_y = 22
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Rz" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating,
@@ -19385,7 +19495,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/beefnoodle,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "RD" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -19442,7 +19552,7 @@
 "RL" = (
 /obj/machinery/vending/cola,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RM" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -19464,7 +19574,7 @@
 	},
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "RO" = (
 /obj/machinery/shower{
 	dir = 1
@@ -19474,14 +19584,14 @@
 	},
 /obj/structure/curtain,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RP" = (
 /obj/machinery/door/airlock/wood{
 	id_tag = "Ninja4";
 	name = "Dorm 4"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RQ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -19489,7 +19599,7 @@
 	pixel_y = 3
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "RR" = (
 /obj/structure/chair/comfy/brown{
 	color = "#c45c57";
@@ -19514,7 +19624,7 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/item/toy/poolnoodle/yellow,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "RU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19554,11 +19664,11 @@
 	color = "#596479"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "RY" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "RZ" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -19603,7 +19713,7 @@
 	},
 /obj/structure/rack,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Sf" = (
 /obj/structure/chair{
 	dir = 4;
@@ -19642,7 +19752,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Sk" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/vending/snack/random,
@@ -19651,15 +19761,15 @@
 "Sl" = (
 /obj/structure/bed,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Sm" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Sn" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "So" = (
 /obj/structure/chair/sofa/right,
 /obj/machinery/light{
@@ -19681,7 +19791,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Sr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -19733,7 +19843,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Sx" = (
 /obj/machinery/button/door{
 	id = "CCD2";
@@ -19755,6 +19865,10 @@
 	},
 /turf/open/floor/wood,
 /area/fabric_of_reality)
+"SA" = (
+/obj/machinery/light,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "SB" = (
 /obj/structure/curtain,
 /obj/structure/window/reinforced/tinted{
@@ -19764,7 +19878,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "SC" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -19795,7 +19909,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/bearsteak,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "SG" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -19803,7 +19917,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "SH" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -19849,7 +19963,7 @@
 "SL" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "SM" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -19860,7 +19974,7 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "SO" = (
 /obj/structure/destructible/cult/tome,
 /turf/open/indestructible/hotelwood,
@@ -19883,7 +19997,7 @@
 	name = "Dorm 7"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "SS" = (
 /obj/structure/table,
 /obj/structure/window{
@@ -19891,14 +20005,14 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "ST" = (
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "SU" = (
 /obj/structure/fans/tiny/invisible,
 /turf/closed/indestructible/rock/snow,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "SV" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -19920,7 +20034,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "SX" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
@@ -19940,7 +20054,7 @@
 	name = "Dorm 3"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ta" = (
 /obj/machinery/door/airlock{
 	id_tag = "CCD3"
@@ -19963,7 +20077,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Td" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
@@ -19976,7 +20090,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Tg" = (
 /obj/effect/mob_spawn/human/ghostcafe{
 	dir = 8
@@ -19992,7 +20106,7 @@
 "Ti" = (
 /mob/living/simple_animal/pet/redpanda,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Tj" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -20025,7 +20139,7 @@
 	pixel_y = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "To" = (
 /turf/open/indestructible/airblock,
 /area/fabric_of_reality)
@@ -20037,11 +20151,11 @@
 /obj/item/stack/sheet/plastic/fifty,
 /obj/item/multitool,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Tr" = (
 /obj/structure/closet/chefcloset,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ts" = (
 /obj/machinery/button/door{
 	id = "CCD1";
@@ -20062,7 +20176,7 @@
 	icon_state = "twindow"
 	},
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Tu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -20070,11 +20184,11 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Tv" = (
 /obj/structure/flora/ausbushes,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Tw" = (
 /obj/effect/mob_spawn/robot/ghostcafe,
 /turf/open/indestructible/hotelwood,
@@ -20093,11 +20207,13 @@
 	},
 /obj/structure/table,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ty" = (
 /mob/living/simple_animal/pet/penguin/baby,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "Tz" = (
 /obj/effect/light_emitter,
 /turf/open/floor/plating/asteroid/snow/airless,
@@ -20111,11 +20227,11 @@
 "TB" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "TC" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/freezer,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "TD" = (
 /obj/structure/mirror{
 	pixel_x = -28
@@ -20155,13 +20271,16 @@
 	},
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/white,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "TH" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien16";
 	opacity = 0
 	},
 /area/bluespace_locker)
+"TI" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/holding/cafewar)
 "TJ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -20172,7 +20291,7 @@
 /area/centcom/holding)
 "TK" = (
 /turf/closed/indestructible/rock,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "TL" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -20240,6 +20359,10 @@
 /obj/item/toy/plush/carpplushie,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"TV" = (
+/obj/machinery/vending/snack/random,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "TW" = (
 /turf/open/floor/carpet/royalblack,
 /area/centcom/evac)
@@ -20272,7 +20395,7 @@
 	pixel_y = -2
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "TY" = (
 /obj/machinery/light{
 	dir = 1
@@ -20283,7 +20406,7 @@
 /obj/item/janiupgrade,
 /obj/vehicle/ridden/janicart,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "TZ" = (
 /obj/item/storage/backpack/duffelbag,
 /turf/open/floor/plating/beach/sand,
@@ -20317,6 +20440,10 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/open/floor/plating/beach/water,
 /area/fabric_of_reality)
+"Uf" = (
+/obj/structure/flora/grass/brown,
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "Ug" = (
 /obj/machinery/door/poddoor/shuttledock{
 	checkdir = 1;
@@ -20332,6 +20459,10 @@
 	},
 /turf/open/floor/material,
 /area/centcom/holding)
+"Ui" = (
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "Uj" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Restroom";
@@ -20357,7 +20488,7 @@
 /obj/item/vending_refill/snack,
 /obj/item/vending_refill/snack,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Ul" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -20385,7 +20516,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Un" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -20395,10 +20526,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Uo" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafebotany)
 "Up" = (
 /mob/living/simple_animal/pet/cat,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Uq" = (
 /obj/structure/table/wood,
 /obj/item/soap,
@@ -20409,10 +20546,10 @@
 /obj/item/storage/bag/trash,
 /obj/item/storage/bag/trash,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ur" = (
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Us" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -20458,7 +20595,7 @@
 /obj/structure/table,
 /obj/machinery/dish_drive,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "UA" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel,
@@ -20489,11 +20626,11 @@
 /obj/item/coin/silver,
 /obj/item/coin/silver,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UF" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/mineral/titanium/blue,
@@ -20522,7 +20659,7 @@
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UK" = (
 /obj/machinery/door/airlock{
 	id_tag = "CCD1"
@@ -20557,7 +20694,7 @@
 	},
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -20597,24 +20734,24 @@
 "US" = (
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "UT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UU" = (
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "UV" = (
 /obj/machinery/computer/arcade,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UW" = (
 /obj/machinery/light,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "UX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -20626,11 +20763,11 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "UZ" = (
 /obj/item/target,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Va" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20648,17 +20785,17 @@
 	dir = 8
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Vd" = (
 /mob/living/simple_animal/kiwi,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Ve" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Vf" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
@@ -20722,7 +20859,7 @@
 "Vn" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Vo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/toxin,
@@ -20753,7 +20890,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Vq" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/mineral/titanium/blue,
@@ -20785,12 +20922,12 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Vv" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Vw" = (
 /obj/structure/table,
 /obj/item/kitchen/fork,
@@ -20823,7 +20960,7 @@
 	use_power = 0
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "VA" = (
 /obj/effect/landmark/holding_facility,
 /mob/living/simple_animal/bot/medbot{
@@ -20852,7 +20989,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "VE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/fire,
@@ -20890,11 +21027,18 @@
 /area/centcom/holding)
 "VG" = (
 /turf/closed/indestructible/rock/snow,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "VH" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"VI" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafevox)
 "VJ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -20905,7 +21049,7 @@
 "VK" = (
 /mob/living/simple_animal/pet/dog/cheems,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "VL" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumGhostDojo";
@@ -20914,7 +21058,11 @@
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"VM" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "VN" = (
 /obj/structure/rack,
 /obj/item/shield/riot/tele{
@@ -20973,7 +21121,7 @@
 /obj/item/clothing/suit/space/hardsuit/syndi,
 /obj/item/clothing/suit/space/hardsuit/syndi,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "VO" = (
 /turf/closed/indestructible/fakedoor,
 /area/centcom/evac)
@@ -20992,6 +21140,26 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"VS" = (
+/obj/structure/closet,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/tile/wood{
+	amount = 24
+	},
+/obj/item/stack/tile/carpet/black/fifty,
+/obj/item/stack/tile/carpet/blackred/fifty,
+/obj/item/stack/tile/carpet/blue/fifty,
+/obj/item/stack/tile/carpet/cyan/fifty,
+/obj/item/stack/tile/carpet/fifty,
+/obj/item/stack/tile/carpet/green/fifty,
+/obj/item/stack/tile/carpet/monochrome/fifty,
+/obj/item/stack/tile/carpet/orange/fifty,
+/obj/item/stack/tile/carpet/purple/fifty,
+/obj/item/stack/tile/carpet/red/fifty,
+/obj/item/stack/tile/carpet/royalblack/fifty,
+/obj/item/stack/tile/carpet/royalblue/fifty,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "VT" = (
 /obj/structure/table/wood,
 /obj/item/syndicatedetonator{
@@ -21009,7 +21177,7 @@
 /obj/item/storage/box/lethalslugs,
 /obj/structure/closet,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "VV" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/red,
@@ -21034,7 +21202,14 @@
 "VZ" = (
 /mob/living/simple_animal/pet/dog/corgi,
 /turf/open/floor/carpet/royalblue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"Wa" = (
+/turf/closed/indestructible{
+	icon = 'icons/turf/walls/wood_wall.dmi';
+	icon_state = "wood";
+	smooth = 1
+	},
+/area/centcom/holding/cafedorms)
 "Wb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -21079,14 +21254,14 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/carpet/royalblack,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Wh" = (
 /obj/machinery/jukebox/disco{
 	req_access = null;
 	req_one_access = null
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Wi" = (
 /turf/open/warzonetile,
 /area/centcom/holding)
@@ -21100,7 +21275,7 @@
 "Wl" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Wm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -21112,7 +21287,13 @@
 "Wn" = (
 /obj/machinery/vending/tool,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
+"Wo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "Wp" = (
 /turf/open/floor/carpet/royalblue,
 /area/centcom/evac)
@@ -21136,7 +21317,7 @@
 	name = "Dorm 6"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Wt" = (
 /obj/structure/table/reinforced,
 /obj/item/healthanalyzer/advanced{
@@ -21168,7 +21349,7 @@
 	id = "crematoriumGhostDojo"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Wx" = (
 /obj/machinery/light{
 	dir = 8
@@ -21181,7 +21362,7 @@
 "Wy" = (
 /mob/living/simple_animal/pet/fox,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Wz" = (
 /obj/item/defibrillator/compact/loaded,
 /obj/item/defibrillator/compact/loaded,
@@ -21218,19 +21399,22 @@
 	pixel_y = 28
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "WE" = (
 /obj/machinery/vending/kink{
 	extended_inventory = 1
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "WF" = (
 /obj/machinery/door/airlock/sandstone{
 	name = "Lavatory"
 	},
 /turf/open/floor/plating,
 /area/fabric_of_reality)
+"WG" = (
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "WH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -21241,7 +21425,7 @@
 /obj/item/storage/box/beakers/variety,
 /obj/item/storage/box/beakers/variety,
 /turf/open/indestructible,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "WJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
@@ -21273,7 +21457,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "WN" = (
 /obj/machinery/button/door{
 	id = "Ninja6";
@@ -21283,12 +21467,17 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"WO" = (
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "WP" = (
 /obj/structure/flora/grass/brown,
-/obj/effect/light_emitter,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "WQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -21335,7 +21524,7 @@
 	name = "red bedsheet"
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "WW" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -21349,11 +21538,16 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "WZ" = (
 /obj/structure/flora/tree/pine,
-/turf/open/floor/grass/snow,
-/area/centcom/holding)
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
+"Xa" = (
+/turf/open/floor/grass,
+/area/centcom/holding/cafepark)
 "Xb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box{
@@ -21376,11 +21570,11 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Xe" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Xf" = (
 /obj/structure/table/wood/bar,
 /obj/structure/mirror{
@@ -21396,7 +21590,7 @@
 /obj/item/construction/rld,
 /obj/item/construction/rld,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Xg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -21440,11 +21634,11 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Xo" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Xp" = (
 /obj/structure/rack,
 /obj/item/chameleon{
@@ -21498,7 +21692,7 @@
 	pixel_x = 6
 	},
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Xq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21513,7 +21707,7 @@
 "Xs" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Xt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -21543,13 +21737,13 @@
 "Xw" = (
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Xx" = (
 /obj/machinery/turnstile{
 	dir = 4
 	},
 /turf/open/pacifytile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Xy" = (
 /obj/machinery/door/airlock/external{
 	name = "Ferry Airlock"
@@ -21574,7 +21768,7 @@
 	pixel_y = 24
 	},
 /turf/open/pool,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "XB" = (
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/white,
@@ -21600,7 +21794,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "XE" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Kitchen";
@@ -21637,16 +21831,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
+"XK" = (
+/turf/open/floor/plating,
+/area/centcom/holding/cafevox)
 "XL" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XM" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
+"XN" = (
+/obj/structure/chair/stool,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "XO" = (
 /obj/machinery/light{
 	dir = 4
@@ -21678,7 +21879,7 @@
 "XR" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "XS" = (
 /obj/structure/closet/secure_closet/hydroponics{
 	locked = 0
@@ -21698,12 +21899,12 @@
 /obj/item/seeds/pumpkin/blumpkin,
 /obj/item/seeds/pumpkin/blumpkin,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XT" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/sashimi,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XU" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -21713,12 +21914,15 @@
 "XV" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
+"XW" = (
+/turf/open/water/lavaland_jungle,
+/area/centcom/holding/cafepark)
 "XX" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/sake,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "XY" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "nukeop_ready";
@@ -21739,7 +21943,7 @@
 	specialfunctions = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Yb" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -21766,7 +21970,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chawanmushi,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Yg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -21778,7 +21982,7 @@
 	pixel_x = -27
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Yi" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/dark,
@@ -21829,7 +22033,7 @@
 "Ym" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Yn" = (
 /obj/item/reagent_containers/spray/spraytan,
 /turf/open/floor/plating/beach/sand,
@@ -21839,7 +22043,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Yp" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -21854,7 +22058,7 @@
 "Yr" = (
 /mob/living/simple_animal/opossum,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Ys" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red,
@@ -21875,7 +22079,7 @@
 	locked = 0
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "Yv" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -21907,7 +22111,7 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "YA" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -21943,7 +22147,7 @@
 "YE" = (
 /obj/item/target/alien,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "YF" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -21958,7 +22162,7 @@
 /obj/item/storage/firstaid/tactical/nukeop,
 /obj/item/storage/firstaid/tactical/nukeop,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "YH" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien13";
@@ -21976,7 +22180,7 @@
 /obj/item/book/granter/action/drink_fling,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/cafeteria,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "YK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
@@ -21984,24 +22188,24 @@
 "YL" = (
 /obj/machinery/vending/clothing,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "YM" = (
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "YN" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "YO" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "YP" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -22022,7 +22226,7 @@
 /obj/item/stack/tile/carpet/royalblue/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafevox)
 "YQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -22034,7 +22238,7 @@
 	dir = 8
 	},
 /turf/open/pacifytile,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "YS" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supply";
@@ -22071,7 +22275,7 @@
 "YX" = (
 /mob/living/simple_animal/pet/dog/pug,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "YY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -22089,7 +22293,7 @@
 	id_tag = "lmrestroom"
 	},
 /turf/open/floor/wood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "Zb" = (
 /obj/machinery/sleeper/centcom{
 	dir = 4
@@ -22128,7 +22332,7 @@
 	icon_state = "plant-10"
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Zi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -22142,10 +22346,10 @@
 /obj/item/flashlight/lamp/bananalamp,
 /obj/structure/table/wood,
 /turf/open/floor/plating/smooth/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Zl" = (
 /turf/open/floor/plating,
-/area/centcom/holding)
+/area/centcom/holding/cafebuild)
 "Zm" = (
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
@@ -22155,7 +22359,7 @@
 /obj/item/storage/box/firingpins,
 /obj/structure/closet,
 /turf/open/indestructible/clock_spawn_room,
-/area/centcom/holding)
+/area/centcom/holding/cafewar)
 "Zn" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -22169,7 +22373,7 @@
 /area/centcom/evac)
 "Zq" = (
 /turf/open/indestructible/cobble,
-/area/centcom/holding)
+/area/centcom/holding/cafepark)
 "Zr" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -22211,7 +22415,7 @@
 	stationary_mode = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafe)
 "Zy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -22254,7 +22458,7 @@
 	pixel_x = 28
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ZF" = (
 /obj/effect/turf_decal/trimline/red/end{
 	dir = 1
@@ -22325,15 +22529,19 @@
 /obj/item/stack/tile/carpet/royalblack/fifty,
 /obj/item/stack/tile/carpet/royalblue/fifty,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "ZM" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ZN" = (
 /obj/machinery/vending/snack,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
+"ZO" = (
+/obj/machinery/chem_master,
+/turf/open/indestructible,
+/area/centcom/holding/cafewar)
 "ZP" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -22348,7 +22556,7 @@
 "ZR" = (
 /obj/structure/bed/dogbed,
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafedorms)
 "ZS" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/red,
@@ -22356,7 +22564,7 @@
 "ZT" = (
 /mob/living/simple_animal/cow,
 /turf/open/floor/grass,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 "ZU" = (
 /turf/open/floor/material,
 /area/centcom/holding)
@@ -22404,7 +22612,7 @@
 	pixel_x = -4
 	},
 /turf/open/indestructible/hotelwood,
-/area/centcom/holding)
+/area/centcom/holding/cafebotany)
 
 (1,1,1) = {"
 aa
@@ -46467,71 +46675,71 @@ hh
 hh
 aa
 aa
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
 aa
 aa
 aa
@@ -46724,7 +46932,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -46743,7 +46951,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 SW
 PO
 PO
@@ -46752,12 +46960,12 @@ PO
 PO
 PO
 PO
-Nd
+Wa
 Tt
 Tt
 TG
 Op
-Nd
+Wa
 Wh
 QL
 Fi
@@ -46765,30 +46973,30 @@ QL
 Fi
 QL
 Fi
-NT
+Oq
 sk
-CV
-Sd
-Nd
+XN
+zt
+Wa
 OW
 Ln
-Nd
+Wa
 Lm
 Lm
 Lm
-Nd
+Wa
 PQ
-Sd
+WG
 ZR
-Nd
+Wa
 RL
-Yo
+GD
 Uq
-Nd
+Wa
 VL
 Ww
 NN
-Nd
+Wa
 aa
 aa
 aa
@@ -46955,33 +47163,33 @@ aa
 aa
 aa
 aa
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
 Zl
 Zl
 Zl
@@ -47000,7 +47208,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Pc
 PY
 PY
@@ -47009,43 +47217,43 @@ PY
 PY
 PY
 PY
-Nd
-ZW
-ZW
-ZW
-ZW
+Wa
+zT
+zT
+zT
+zT
 Za
-Sd
+zt
 Fi
 QL
 Fi
 QL
 Fi
 QL
-NT
+Oq
 RQ
-Sd
-HH
-Nd
+zt
+yc
+Wa
 UN
 ST
-Nd
+Wa
 zS
 Qw
 TC
-Nd
+Wa
 MJ
-Sd
-Sd
-Nd
-AE
-Sd
-Ph
-Nd
-ZL
-Sd
-HH
-Nd
+WG
+WG
+Wa
+WO
+WG
+vz
+Wa
+VS
+WG
+SA
+Wa
 aa
 aa
 aa
@@ -47212,7 +47420,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -47257,7 +47465,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 ZZ
 PY
 PY
@@ -47266,43 +47474,43 @@ PY
 PY
 PY
 RN
-Nd
+Wa
 SB
-ZW
-ZW
-ZW
-Nd
-Sd
+zT
+zT
+zT
+Wa
+zt
 QL
 Fi
 QL
 Fi
 QL
 Fi
-NT
+Oq
 UV
-CV
-Sd
-Nd
+XN
+zt
+Wa
 Ot
 ST
-Nd
+Wa
 Tf
 Qw
 Tf
-Nd
+Wa
 ma
-Sd
-Sd
-Nd
+WG
+WG
+Wa
 ZN
-Sd
-Sd
-Nd
-ZL
-Sd
-Lr
-Nd
+WG
+WG
+Wa
+VS
+WG
+HA
+Wa
 aa
 aa
 aa
@@ -47469,7 +47677,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -47514,7 +47722,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 PI
 PY
 Ha
@@ -47523,43 +47731,43 @@ PY
 PY
 PY
 Rj
-Nd
+Wa
 SB
 NE
 Fl
 Nw
-Nd
-Sd
+Wa
+zt
 Fi
 QL
 Fi
 QL
 Fi
 QL
-Nd
+tn
 hH
-Sd
-Sd
-Nd
-Nd
-Wl
-Nd
-Nd
-Wl
-Nd
-Nd
-Nd
+zt
+zt
+Wa
+Wa
+yd
+Wa
+Wa
+yd
+Wa
+Wa
+Wa
 yS
-Nd
-Nd
+Wa
+Wa
 WD
-Sd
-HH
-Nd
-Nd
+WG
+SA
+Wa
+Wa
 Ox
-Nd
-Nd
+Wa
+Wa
 aa
 aa
 aa
@@ -47726,7 +47934,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -47771,7 +47979,7 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Tx
 PY
 yh
@@ -47780,23 +47988,23 @@ Um
 XS
 PY
 vs
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Gs
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wo
 QL
 Fi
 QL
 Fi
 QL
 Fi
-NT
+Oq
 PX
-CV
-Sd
+XN
+zt
 NT
 Sd
 Sd
@@ -47804,7 +48012,7 @@ Sd
 Sd
 Sd
 Sd
-Nd
+Wa
 Of
 Of
 Of
@@ -47816,7 +48024,7 @@ Yr
 Of
 Of
 WE
-Nd
+Wa
 aa
 aa
 aa
@@ -47983,7 +48191,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48028,32 +48236,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Nd
-Nd
-FR
+yO
+yO
+yO
+QH
 XL
-FR
-Nd
+QH
+yO
 py
-Nd
-Nd
+yO
+tn
 Yh
-Sd
-Yo
-Sd
-Wl
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-NT
+zt
+CS
+zt
+VM
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+Oq
 Zh
-Sd
-Sd
+zt
+zt
 Dl
 Sd
 Sd
@@ -48073,7 +48281,7 @@ Of
 Of
 Of
 Sj
-Nd
+Wa
 aa
 aa
 aa
@@ -48240,7 +48448,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48285,32 +48493,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Lr
-Sd
+jA
 Yo
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Nd
-Nd
-Nd
-Nd
-Gs
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-NT
+jA
+jA
+jA
+jA
+jA
+jA
+jA
+yO
+yO
+yO
+tn
+Wo
+zt
+zt
+zt
+zt
+zt
+zt
+Oq
 Ym
-CV
-Sd
+XN
+zt
 NT
 Sd
 MR
@@ -48318,7 +48526,7 @@ Sd
 Sd
 MR
 Sd
-Nd
+Wa
 Of
 Of
 Of
@@ -48330,7 +48538,7 @@ Of
 Cd
 Of
 PM
-Nd
+Wa
 aa
 aa
 aa
@@ -48497,7 +48705,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48542,32 +48750,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 PR
-Sd
+jA
 MG
 YN
-Nd
+yO
 US
 Fh
 Fh
 zV
-Nd
-Nd
+yO
+yO
 Hj
 Fa
 KT
-Sd
-Sd
+zt
+zt
 zw
 Yz
 UY
-Sd
-HH
-Nd
-Sd
-Sd
-Sd
+zt
+yc
+tn
+zt
+zt
+zt
 Nd
 Nd
 Nd
@@ -48575,19 +48783,19 @@ FR
 FR
 Nd
 Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
 Rq
 Of
 ZM
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
 aa
 aa
 aa
@@ -48754,7 +48962,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -48799,32 +49007,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Ry
-Sd
+jA
 Rh
 Mm
-Nd
+yO
 Nx
 Fh
 Fh
 Yu
-Nd
-AE
+yO
+Ui
 CV
-Sd
+jA
 KT
-Sd
-Sd
+zt
+zt
 Nh
 tw
 UY
-Sd
-Sd
+zt
+zt
 Re
-Sd
-Sd
-HH
+zt
+zt
+yc
 TE
 Sd
 YV
@@ -48832,19 +49040,19 @@ RS
 RS
 RS
 VF
-Nd
+Wa
 UD
 tZ
-SY
-Nd
+EZ
+Wa
 Of
 Of
 Of
-Nd
-SY
+Wa
+EZ
 Os
 UD
-Nd
+Wa
 aa
 aa
 aa
@@ -49011,7 +49219,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49056,32 +49264,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 On
-Sd
+jA
 yW
 ZT
-Nd
+yO
 Pr
 Fh
 Fh
 QW
-Nd
+yO
 QJ
-Sd
-Sd
+jA
+jA
 KT
-Sd
-Sd
+zt
+zt
 Nh
 tw
 UY
-Sd
-Sd
-Nd
-Gs
+zt
+zt
+tn
+Wo
 Zx
-Sd
+zt
 OL
 Wi
 Po
@@ -49089,19 +49297,19 @@ ZU
 ZU
 ZU
 fR
-Nd
-Sd
-Sd
-Sd
+Wa
+WG
+WG
+WG
 lS
 Of
 Of
 Of
 RP
-Sd
-Sd
-Sd
-Nd
+WG
+WG
+WG
+Wa
 aa
 aa
 aa
@@ -49268,7 +49476,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49313,32 +49521,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Nd
+yO
+yO
 XL
-Nd
-Nd
-Nd
+yO
+yO
+yO
 JE
 Fh
 Fh
 Vv
-Nd
-Sd
-Sd
-Sd
+yO
+jA
+jA
+jA
 FW
-Sd
-Sd
+zt
+zt
 zw
 tw
 UY
-Sd
-Sd
+zt
+zt
 Re
-Sd
+zt
 pD
-Sd
+zt
 SJ
 So
 Po
@@ -49346,19 +49554,19 @@ ZU
 Nv
 ZU
 fR
-Nd
+Wa
 Xn
-Sd
+WG
 Ya
-Nd
+Wa
 Of
 Of
 Of
-Nd
+Wa
 XD
-Sd
+WG
 Xn
-Nd
+Wa
 aa
 aa
 aa
@@ -49525,7 +49733,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49570,32 +49778,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 NZ
-Sd
+jA
 Yo
 PL
-Nd
+yO
 SG
 Fh
 Fh
 Fh
 Wl
-Sd
-MR
-Sd
+jA
+Uo
+jA
 FX
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-HH
-Nd
+zt
+zt
+zt
+zt
+zt
+zt
+yc
+tn
 WM
-Sd
-Sd
+zt
+zt
 SJ
 YU
 Po
@@ -49603,19 +49811,19 @@ ZU
 Nv
 ZU
 fR
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
 Of
 Of
 Up
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
 aa
 aa
 aa
@@ -49782,7 +49990,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -49827,32 +50035,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 OG
-Sd
-Sd
+jA
+jA
 Tq
-Nd
+yO
 zX
 Fh
 Fh
 JV
-Nd
-Dl
-Nd
-Nd
-Nd
-Gs
-Sd
+yO
+Or
+yO
+yO
+tn
+Wo
+zt
 XM
 Tu
-Sd
-Sd
+zt
+zt
 XM
-NT
-Sd
-Sd
-Sd
+Oq
+zt
+zt
+zt
 SJ
 YU
 Po
@@ -49860,19 +50068,19 @@ ZU
 ZU
 ZU
 fR
-Nd
+Wa
 UD
 tZ
-SY
-Nd
+EZ
+Wa
 Of
 Of
 Of
-Nd
-SY
+Wa
+EZ
 Os
 UD
-Nd
+Wa
 aa
 aa
 aa
@@ -50039,7 +50247,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50084,32 +50292,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Xf
-Sd
-Sd
+jA
+jA
 Nf
-Nd
+yO
 QA
 Fh
 Fh
 Uz
 ED
-Sd
+jA
 Yo
 Yf
 UE
-Sd
-Sd
+zt
+zt
 Tn
 Xd
-Sd
-Sd
+zt
+zt
 NP
-NT
-Sd
-Sd
-Sd
+Oq
+zt
+zt
+zt
 SJ
 BX
 TM
@@ -50117,19 +50325,19 @@ TM
 TM
 TM
 TM
-Nd
-Sd
-Sd
-Sd
+Wa
+WG
+WG
+WG
 uh
 Of
 Of
 Of
 zW
-Sd
-Sd
-Sd
-Nd
+WG
+WG
+WG
+Wa
 aa
 aa
 aa
@@ -50296,7 +50504,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50341,32 +50549,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 YL
-Sd
-Sd
+jA
+jA
 Uk
-Nd
+yO
 Xo
 Fh
 Fh
 Fh
 py
-Sd
-Sd
-SY
+jA
+jA
+FF
 UE
-Sd
-Sd
+zt
+zt
 GY
 Tu
-Sd
-Sd
+zt
+zt
 GY
-NT
-Sd
-Sd
-Sd
+Oq
+zt
+zt
+zt
 SJ
 YU
 PA
@@ -50374,19 +50582,19 @@ ZU
 ZU
 ZU
 FY
-Nd
+Wa
 Xn
-Sd
+WG
 Tc
-Nd
+Wa
 Of
 Of
 Of
-Nd
+Wa
 AC
-Sd
+WG
 Xn
-Nd
+Wa
 aa
 aa
 aa
@@ -50553,7 +50761,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50598,32 +50806,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Xe
-Sd
-Sd
+jA
+jA
 ZL
-Nd
+yO
 TB
 Fh
 Fh
 Fh
 BV
-Sd
-Sd
+jA
+jA
 XT
 UE
-Sd
-Sd
-Sd
-Ph
-Sd
+zt
+zt
+zt
+LD
+zt
 Qk
 Vu
-Nd
-Gs
-Sd
-Sd
+tn
+Wo
+zt
+zt
 SJ
 YU
 PA
@@ -50631,19 +50839,19 @@ ZU
 re
 ZU
 FY
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
 Rq
 Of
 ZM
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
 aa
 aa
 aa
@@ -50810,7 +51018,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -50855,32 +51063,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 TY
-Sd
-Sd
+jA
+jA
 Wn
-Nd
+yO
 Vz
 Fh
 Fh
 YJ
 QT
-Sd
-Sd
-SY
+jA
+jA
+FF
 UE
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
+zt
+zt
 XM
-NT
-Sd
-Sd
-Sd
+Oq
+zt
+zt
+zt
 SJ
 Ye
 PA
@@ -50888,19 +51096,19 @@ ZU
 re
 ZU
 FY
-Nd
+Wa
 Xs
 Ol
 YO
-Nd
+Wa
 Of
 Of
 Of
-Nd
+Wa
 RX
 Xw
 qP
-Nd
+Wa
 aa
 aa
 aa
@@ -51067,7 +51275,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51112,32 +51320,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Bs
 Ri
-Sd
-Sd
+jA
+jA
 XL
 Fh
 Fh
 Fh
 Fh
 XL
-Sd
-Sd
+jA
+jA
 XX
 Pv
-Sd
-Sd
-Sd
+zt
+zt
+zt
 Tu
-Sd
-Sd
+zt
+zt
 NP
-NT
-Sd
-Sd
-Sd
+Oq
+zt
+zt
+zt
 OL
 Wi
 PA
@@ -51145,19 +51353,19 @@ ZU
 ZU
 ZU
 FY
-Nd
-Gs
-Sd
-Sd
+Wa
+tb
+WG
+WG
 SZ
 Of
 Of
 Of
 Ws
-Sd
-Sd
-HH
-Nd
+WG
+WG
+SA
+Wa
 aa
 aa
 aa
@@ -51324,7 +51532,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51369,32 +51577,32 @@ Zl
 Zl
 Zl
 Zl
-Nd
+yO
 Hk
-Sd
-MR
+jA
+Uo
 Mz
-Nd
+yO
 SN
 pV
 pV
 Tr
-Nd
+yO
 WY
 Ph
-Nd
-Nd
+yO
+tn
 Rm
 Tn
 UT
 Hm
-Sd
-Sd
+zt
+zt
 GY
-NT
-Sd
-Sd
-HH
+Oq
+zt
+zt
+yc
 TE
 Sd
 Mx
@@ -51402,19 +51610,19 @@ Uh
 Uh
 Uh
 tW
-Nd
+Wa
 Ru
 Of
 QF
-Nd
+Wa
 Of
 Of
 Of
-Nd
+Wa
 WN
 Ur
 Ki
-Nd
+Wa
 aa
 aa
 aa
@@ -51581,7 +51789,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51626,28 +51834,28 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Gs
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+yO
+tn
+tn
+Wo
+zt
+zt
+zt
+zt
+zt
+zt
 Nd
 Nd
 Te
@@ -51659,19 +51867,19 @@ TT
 TT
 FR
 Nd
-Nd
+Wa
 Kf
 WV
-Sd
-Nd
-sa
+WG
+Wa
 Of
 Of
-Nd
-Sd
+Of
+Wa
+WG
 zY
 Rv
-Nd
+Wa
 aa
 aa
 aa
@@ -51838,7 +52046,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -51883,28 +52091,28 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Gs
+tn
+Wo
 Gt
 Gt
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-yQ
-yQ
-Sd
+zt
+zt
+zt
+zt
+zt
+zt
+TV
+TV
+zt
 Nc
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Nd
 Qj
 Sd
@@ -51916,19 +52124,19 @@ ZW
 ZW
 px
 Lk
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
 QC
-Nd
-Nd
+Wa
+Wa
 SR
-Nd
-Nd
+Wa
+Wa
 QC
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
 aa
 aa
 aa
@@ -52095,7 +52303,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -52141,7 +52349,7 @@ Zl
 Zl
 Zl
 Mu
-Sd
+zt
 Lu
 IO
 IO
@@ -52149,10 +52357,10 @@ IO
 IO
 IO
 FC
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
 Ve
 Ve
 Ve
@@ -52160,8 +52368,8 @@ Ve
 Ve
 Ve
 Ve
-Sd
-Sd
+zt
+zt
 Nd
 Gs
 Sd
@@ -52173,19 +52381,19 @@ ZW
 ZW
 ZW
 OT
-Nd
+Wa
 Ln
 ST
 ST
-Nd
+Wa
 Qp
-Sd
+WG
 Nt
-Nd
+Wa
 ST
 ST
 Ln
-Nd
+Wa
 aa
 YB
 aa
@@ -52352,7 +52560,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -52397,8 +52605,8 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Gs
+tn
+Wo
 OD
 rY
 Og
@@ -52406,10 +52614,10 @@ CP
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
 Nb
 VD
 xC
@@ -52417,8 +52625,8 @@ qN
 sb
 Wg
 vx
-Sd
-Sd
+zt
+zt
 Nd
 Tw
 Tg
@@ -52430,19 +52638,19 @@ ZW
 ZW
 FV
 Wz
-Nd
+Wa
 xO
 QN
 ZE
-Nd
+Wa
 Qp
 Qz
 Nt
-Nd
+Wa
 ZE
 QN
 RO
-Nd
+Wa
 aa
 aa
 aa
@@ -52609,7 +52817,7 @@ aa
 aa
 aa
 aa
-OY
+Qd
 Zl
 Zl
 Zl
@@ -52654,8 +52862,8 @@ Zl
 Zl
 Zl
 Zl
-Nd
-Sd
+tn
+zt
 OD
 Og
 Og
@@ -52663,10 +52871,10 @@ Og
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
 SF
 RC
 yf
@@ -52674,8 +52882,8 @@ Lf
 kv
 qH
 yM
-Sd
-HH
+zt
+yc
 Nd
 Nd
 Nd
@@ -52687,19 +52895,19 @@ XG
 FR
 Nd
 Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
+Wa
 aa
 aa
 aa
@@ -52866,53 +53074,53 @@ aa
 aa
 aa
 aa
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-Nd
-Sd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+Qd
+tn
+zt
 OD
 XA
 Og
@@ -52920,10 +53128,10 @@ Og
 Og
 Dz
 CW
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
 Ll
 Ll
 Ll
@@ -52931,8 +53139,8 @@ Ll
 Ll
 Ll
 Ll
-Sd
-Sd
+zt
+zt
 Rx
 Bn
 TJ
@@ -52947,22 +53155,22 @@ Fx
 AE
 pY
 Qg
-Nd
-Zl
-Zl
+VI
+XK
+XK
 MY
-Zl
-Zl
+XK
+XK
 MY
-Zl
-Zl
-Nd
-CR
-CR
-CR
-CR
-CR
-CR
+XK
+XK
+VI
+Om
+Om
+Om
+Om
+Om
+Om
 Om
 aa
 aa
@@ -53168,8 +53376,8 @@ aa
 aa
 aa
 aa
-Nd
-Sd
+tn
+zt
 OD
 Og
 Og
@@ -53177,6 +53385,19 @@ Og
 Og
 Og
 CW
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Sd
 Sd
 Sd
@@ -53191,36 +53412,23 @@ Sd
 Sd
 Sd
 Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Nd
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+VI
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+VI
 Qm
 WZ
 Qm
 Qm
 WZ
 Qm
-CR
+Om
 Om
 aa
 aa
@@ -53425,8 +53633,8 @@ aa
 aa
 aa
 aa
-Nd
-Sd
+tn
+zt
 vq
 Og
 Og
@@ -53434,19 +53642,19 @@ se
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Rx
 Bn
 Bn
@@ -53461,24 +53669,24 @@ Sd
 Sd
 Sd
 Sd
-FR
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
+sl
+XK
+XK
+XK
+XK
+XK
+XK
+XK
 Fc
-Nd
+VI
 Qm
-ue
-Qm
-Qm
+WP
 Qm
 Qm
 Qm
-CR
+Qm
+Ov
+Om
 Om
 aa
 aa
@@ -53682,8 +53890,8 @@ aa
 aa
 aa
 aa
-Nd
-Gs
+tn
+Wo
 OD
 Og
 Og
@@ -53691,6 +53899,19 @@ Og
 Og
 Og
 CW
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Sd
 Sd
 Sd
@@ -53705,38 +53926,25 @@ Sd
 Sd
 Sd
 Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-FR
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+sl
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+VI
 Qm
 Qm
-ue
+WP
 Qm
 WZ
 Qm
-Qm
-Qm
-CR
+Ov
+Ov
+Om
 Om
 aa
 aa
@@ -53939,7 +54147,7 @@ aa
 aa
 aa
 aa
-Nd
+tn
 NS
 OD
 XA
@@ -53948,19 +54156,19 @@ Og
 Og
 Dz
 CW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Sd
 Sd
 SO
@@ -53976,25 +54184,25 @@ Sd
 Sd
 Sd
 OO
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+VI
 Qm
 WZ
-ue
-ue
+WP
+WP
 Qm
 Qm
-WZ
-Qm
-Qm
-CR
+LI
+Ov
+Ov
+Om
 Om
 aa
 aa
@@ -54196,7 +54404,7 @@ aa
 aa
 aa
 aa
-Nd
+tn
 OH
 OD
 Og
@@ -54205,6 +54413,19 @@ Og
 Og
 Og
 CW
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Sd
 Sd
 Sd
@@ -54219,40 +54440,27 @@ Sd
 Sd
 Sd
 Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-FR
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+sl
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+VI
 Qm
 Qm
 Qm
-ue
-ue
+WP
+WP
 Qm
-Qm
-ue
-Qm
-Qm
-CR
+Ov
+Uf
+Ov
+Ov
+Om
 Om
 aa
 aa
@@ -54453,7 +54661,7 @@ aa
 aa
 aa
 aa
-Nd
+tn
 RT
 OD
 Og
@@ -54462,19 +54670,19 @@ NY
 Og
 Og
 CW
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
-Sd
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 Rx
 Bn
 Bn
@@ -54489,28 +54697,28 @@ Sd
 Sd
 Sd
 Sd
-FR
+sl
 YP
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
+XK
+XK
+XK
+XK
+XK
+XK
 Fc
-Nd
+VI
 Qm
 WZ
 Qm
 Qm
 WZ
 Qm
-Qm
+Ov
 Pb
 Pb
-Qm
-Qm
-CR
+Ov
+Ov
+Om
 Om
 aa
 aa
@@ -54710,7 +54918,7 @@ aa
 aa
 aa
 aa
-Nd
+tn
 Gt
 xD
 Sq
@@ -54719,19 +54927,19 @@ UJ
 Sq
 Sq
 Np
-Sd
-Sd
-Sd
-MR
-Sd
-MR
-Sd
-MR
-Sd
-MR
-Sd
-Sd
-Sd
+zt
+zt
+zt
+oV
+zt
+oV
+zt
+oV
+zt
+oV
+zt
+zt
+zt
 Sd
 Sd
 Sd
@@ -54746,16 +54954,16 @@ Sd
 Sd
 Sd
 Sd
-Nd
+VI
 BP
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Nd
+XK
+XK
+XK
+XK
+XK
+XK
+XK
+VI
 Qm
 Qm
 WZ
@@ -54768,7 +54976,7 @@ Qm
 Qm
 WZ
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -54967,25 +55175,25 @@ aa
 aa
 aa
 aa
-Nd
-Gs
+tn
+Wo
 NS
 OH
 Sl
 Sl
 Sl
 Sl
-Sd
+zt
 OC
 Vp
 Bk
-FR
+Lz
 YR
-FR
+Lz
 Xx
-FR
+Lz
 YR
-FR
+Lz
 OC
 Vp
 Bk
@@ -55003,16 +55211,16 @@ QI
 tQ
 Sd
 HH
-Nd
+VI
 BP
-Zl
+XK
 Kq
-Zl
-Zl
+XK
+XK
 Kq
-Zl
-Zl
-Nd
+XK
+XK
+VI
 Qm
 Qm
 Qm
@@ -55020,12 +55228,12 @@ Qm
 Qm
 Qm
 Qm
-ue
+WP
 Qm
 WZ
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -55224,32 +55432,32 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-OY
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+tn
+TI
 pS
 pS
 pS
-FR
+Lz
 pA
-FR
+Lz
 Cm
-FR
+Lz
 pA
-FR
+Lz
 pS
 pS
 pS
-FR
-FR
-OY
-OY
+Lz
+Lz
+TI
+TI
 Nd
 Nd
 Nd
@@ -55260,29 +55468,29 @@ Nd
 Nd
 VB
 VB
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Qm
-Qm
-kR
+VI
+VI
+VI
+VI
+VI
+VI
+VI
+VI
+VI
+VI
 Qm
 Qm
 Qm
 Qm
-ue
-ue
+Qm
+Qm
+Qm
+WP
+WP
 Qm
 Qm
 WZ
-CR
+Om
 aa
 aa
 aa
@@ -55489,7 +55697,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 OA
 Dw
 qG
@@ -55499,22 +55707,22 @@ Vc
 HI
 Vc
 HI
-OY
+TI
 pC
 Dh
-Nl
-Kp
-Nl
-Kp
-OY
+UU
+UU
+ZO
+Fo
+TI
 TK
-wf
-Mm
-Mm
+Dm
+Xa
+Xa
 sp
 Vn
-Mm
-Mm
+Xa
+Xa
 Zq
 Zq
 Dm
@@ -55535,11 +55743,11 @@ Qm
 Qm
 WZ
 Qm
-ue
-ue
+WP
+WP
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -55746,7 +55954,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 PT
 MK
 HI
@@ -55763,14 +55971,14 @@ WI
 UU
 WI
 fy
-OY
+TI
 TK
-Mm
+Xa
 Dm
 Dm
 Vn
 sp
-Mm
+Xa
 Dm
 Zq
 Zq
@@ -55782,12 +55990,6 @@ Dm
 rg
 Hi
 VG
-kR
-Qm
-Qm
-Qm
-Qm
-WZ
 Qm
 Qm
 Qm
@@ -55795,8 +55997,14 @@ Qm
 Qm
 WZ
 Qm
+Qm
+Qm
+Qm
+Qm
 WZ
-CR
+Qm
+WZ
+Om
 aa
 aa
 aa
@@ -56003,7 +56211,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 Ny
 MK
 Br
@@ -56020,14 +56228,14 @@ WI
 UU
 WI
 fy
-OY
+TI
 TK
 Dm
-Mm
+Xa
 Dm
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 YM
 Zq
 Zq
@@ -56046,14 +56254,14 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
 Qm
-ue
 Qm
-CR
+WP
+Qm
+Om
 aa
 aa
 aa
@@ -56260,7 +56468,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 xL
 MK
 HI
@@ -56270,14 +56478,14 @@ HI
 HI
 HI
 HI
-OY
+TI
 pC
 Dh
-Nl
-Kp
-Nl
-Kp
-OY
+UU
+UU
+ZO
+Fo
+TI
 TK
 Dm
 Vd
@@ -56308,9 +56516,9 @@ Qs
 Qm
 Qm
 WZ
-Pb
-ue
-CR
+zZ
+WP
+Om
 aa
 aa
 aa
@@ -56517,7 +56725,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 Zm
 HI
 HI
@@ -56527,31 +56735,31 @@ HI
 HI
 HI
 HI
-OY
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+TI
+TI
+TI
+TI
+TI
+TI
+TI
+TI
 TK
 Dm
 Dm
 Dm
 Dm
-Mm
+Xa
 Dm
 Dm
 Zq
 Zq
 Dm
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
@@ -56566,8 +56774,8 @@ Qm
 Qm
 Qm
 Qm
-ue
-CR
+WP
+Om
 aa
 aa
 aa
@@ -56774,7 +56982,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 Jj
 HI
 HI
@@ -56791,10 +56999,10 @@ HI
 Vc
 HI
 UZ
-OY
+TI
 TK
-Mm
-Mm
+Xa
+Xa
 Dm
 Dm
 Dm
@@ -56802,13 +57010,13 @@ Dm
 Dm
 Zq
 Zq
-Mm
+Xa
 Dm
-Mm
+Xa
 Dm
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
@@ -56823,8 +57031,8 @@ Qm
 Qm
 Qm
 WZ
-ue
-CR
+WP
+Om
 aa
 aa
 aa
@@ -57031,7 +57239,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 oU
 MK
 HI
@@ -57048,20 +57256,20 @@ HI
 HI
 HI
 UZ
-OY
+TI
 TK
-Mm
+Xa
 Dm
 Dm
 Dm
-FE
+Xa
 YM
 Dm
 Zq
 Zq
 YM
-Mm
-wf
+Xa
+Dm
 Dm
 Dm
 Dm
@@ -57079,9 +57287,9 @@ Qm
 Qm
 Qm
 Qm
-Pb
+zZ
 th
-CR
+Om
 aa
 aa
 aa
@@ -57288,7 +57496,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 VU
 MK
 HI
@@ -57305,40 +57513,40 @@ HI
 HI
 HI
 YE
-OY
+TI
 TK
-Mm
+Xa
 Dm
 Dm
-Mm
+Xa
 Dm
 Dm
 Dm
 Zq
 Zq
-Mm
+Xa
 Dm
 Dm
 Dm
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
-kR
+Qm
+Qm
 Qm
 Qm
 Qm
 WZ
 Qm
-Pb
-ue
-CR
+zZ
+WP
+Om
 aa
 aa
 aa
@@ -57545,7 +57753,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 TX
 ri
 HI
@@ -57562,9 +57770,9 @@ HI
 HI
 HI
 YE
-OY
+TI
 TK
-Mm
+Xa
 Vd
 Dm
 Dm
@@ -57574,12 +57782,12 @@ Dm
 Zq
 Zq
 Zq
-Mm
+Xa
 Dm
 Dm
 Dm
-Mm
-FE
+Xa
+Xa
 VG
 Qm
 Qm
@@ -57591,11 +57799,11 @@ Qm
 Qm
 Qm
 Qm
-ue
-ue
-ue
-ue
-CR
+WP
+WP
+WP
+WP
+Om
 aa
 aa
 aa
@@ -57802,7 +58010,7 @@ aa
 aa
 aa
 aa
-OY
+TI
 Oh
 tS
 tY
@@ -57819,10 +58027,10 @@ HI
 HI
 HI
 yX
-OY
+TI
 TK
 RY
-Mm
+Xa
 Dm
 Dm
 Dm
@@ -57831,14 +58039,14 @@ Zk
 Zq
 Zq
 Zq
-Mm
-Mm
+Xa
+Xa
 Wy
 Dm
 Dm
 Dm
 SU
-kR
+Qm
 Qm
 Qm
 Qm
@@ -57848,11 +58056,11 @@ Qm
 Qm
 Qm
 WP
-ue
+WP
 Qm
-Pb
-ue
-CR
+zZ
+WP
+Om
 aa
 aa
 aa
@@ -58058,16 +58266,16 @@ aa
 aa
 aa
 aa
-ab
-OY
-OY
-FR
-FR
-FR
-FR
-FR
-OY
-OY
+TI
+TI
+TI
+Lz
+Lz
+Lz
+Lz
+Lz
+TI
+TI
 HI
 HI
 HI
@@ -58076,11 +58284,11 @@ HI
 HI
 HI
 yX
-OY
+TI
 TK
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
 Dm
@@ -58088,9 +58296,9 @@ Dm
 Dm
 Zq
 Zq
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
 Dm
@@ -58104,25 +58312,25 @@ Cf
 Rw
 Qm
 Qm
-Pb
-ue
+zZ
+WP
 Qm
 Qm
 Qm
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 aa
 aa
 aa
@@ -58315,7 +58523,7 @@ aa
 aa
 aa
 aa
-ab
+TI
 Vc
 HI
 HI
@@ -58324,7 +58532,7 @@ HI
 HI
 HI
 Vc
-OY
+TI
 HI
 HI
 Rg
@@ -58333,23 +58541,23 @@ HI
 Rg
 HI
 NL
-OY
+TI
 TK
-Mm
+Xa
 yN
 PZ
 Dm
-FE
+Xa
 Dm
-Mm
-Mm
+Xa
+Xa
 Fy
 Zq
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
-Mm
+Xa
 Dm
 SU
 Qm
@@ -58362,26 +58570,26 @@ Qm
 Qm
 Qm
 Qm
-Pb
+zZ
 Qm
-ue
+WP
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
-CR
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
+Om
+Om
 aa
 aa
 aa
@@ -58572,7 +58780,7 @@ oe
 mD
 mD
 aa
-OY
+TI
 HI
 HI
 GC
@@ -58581,33 +58789,33 @@ HI
 HI
 HI
 HI
-OY
+TI
 XR
 XR
-OY
-OY
-OY
-OY
-OY
-OY
-OY
+TI
+TI
+TI
+TI
+TI
+TI
+TI
 TK
 Dm
 Dm
 Dm
 Dm
 Dm
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 Zq
 Zq
 FE
-Mm
-Mm
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
+Xa
+Xa
 SU
 Qm
 Qm
@@ -58620,25 +58828,25 @@ Qm
 Qm
 Qm
 Qm
-ue
-ue
+WP
+WP
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -58829,7 +59037,7 @@ BZ
 Cq
 mD
 aa
-OY
+TI
 Br
 HI
 HI
@@ -58849,14 +59057,14 @@ aa
 aa
 aa
 TK
-Mm
+Xa
 Sm
-Mm
+Xa
 yN
 PZ
 Dm
-Mm
-Mm
+Xa
+Xa
 Zq
 Zq
 Zq
@@ -58883,19 +59091,19 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -59086,7 +59294,7 @@ pg
 Cr
 mD
 aa
-OY
+TI
 HI
 HI
 HI
@@ -59106,14 +59314,14 @@ aa
 aa
 aa
 TK
-Mm
+Xa
 In
 Dm
-Mm
-Mm
-Mm
-Mm
-FE
+Xa
+Xa
+Xa
+Xa
+Xa
 Zq
 Zq
 Zq
@@ -59130,7 +59338,7 @@ Qm
 Qm
 Qm
 Qm
-kR
+Qm
 Qm
 Ty
 Qm
@@ -59140,19 +59348,19 @@ Qm
 Qm
 Pt
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -59343,7 +59551,7 @@ pg
 Cs
 qR
 aa
-OY
+TI
 Kw
 HI
 HI
@@ -59366,19 +59574,19 @@ TK
 Dm
 Dm
 Dm
-Mm
+Xa
 RY
 sY
 Dm
-Mm
-Zq
-Zq
-wf
-Mm
-Mm
+Xa
+Xa
+Xa
+Dm
+Xa
+Xa
 Dm
 Dm
-Mm
+Xa
 SU
 Qm
 Qm
@@ -59392,24 +59600,24 @@ tv
 tv
 Ty
 Qm
-kR
+Qm
 Qm
 Qm
 Pt
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -59600,7 +59808,7 @@ pg
 Ct
 nT
 aa
-OY
+TI
 HI
 HI
 HI
@@ -59624,20 +59832,20 @@ Dm
 Sm
 Dm
 Dm
-Mm
+Xa
 Tv
-Mm
-Mm
-Zq
-Zq
-Mm
-Mm
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
 Dm
-FE
+Xa
 Dm
-Mm
+Xa
 SU
-kR
+Qm
 Qm
 Qm
 Qm
@@ -59655,18 +59863,18 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -59857,7 +60065,7 @@ zA
 Cu
 nU
 aa
-OY
+TI
 HI
 HI
 HI
@@ -59877,22 +60085,22 @@ aa
 aa
 aa
 TK
-Mm
+Xa
 Dm
 Dm
 In
 Dm
-Mm
-Mm
+Xa
+Xa
 RY
-Zq
-Zq
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
@@ -59913,17 +60121,17 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -60114,7 +60322,7 @@ sw
 Cv
 mD
 aa
-OY
+TI
 HI
 GC
 GC
@@ -60135,25 +60343,25 @@ aa
 aa
 TK
 FE
-Mm
-Mm
+Xa
+Xa
 Sn
-Mm
+Xa
 RY
-Mm
-Mm
-Zq
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
+Xa
+Xa
+Xa
 Dm
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
-kR
+Qm
 Qm
 Qm
 Qm
@@ -60171,16 +60379,16 @@ Qm
 Qm
 Qm
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -60371,7 +60579,7 @@ Ca
 Cw
 mD
 aa
-OY
+TI
 HI
 HI
 HI
@@ -60399,14 +60607,14 @@ Iv
 Iv
 Iv
 Iv
-Zq
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
-Mm
+Xa
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
@@ -60430,14 +60638,14 @@ Qm
 Qm
 MV
 MV
-MV
-MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -60628,7 +60836,7 @@ Cb
 Cx
 mD
 aa
-OY
+TI
 HI
 HI
 HI
@@ -60656,14 +60864,14 @@ IR
 Jd
 Jn
 Iv
-Zq
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
@@ -60672,7 +60880,6 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
@@ -60680,21 +60887,22 @@ Qm
 Qm
 Qm
 Qm
-WZ
-kR
 Qm
 WZ
 Qm
 Qm
+WZ
+Qm
+Qm
 Qm
 MV
 MV
-MV
-MV
-MV
-MV
-MV
-CR
+XW
+XW
+XW
+XW
+XW
+Om
 aa
 aa
 aa
@@ -60885,7 +61093,7 @@ Ca
 Cy
 mD
 aa
-OY
+TI
 HI
 HI
 HI
@@ -60913,13 +61121,13 @@ Iv
 IR
 IR
 Iv
-Zq
-Mm
+Xa
+Xa
 Ti
 Dm
 Dm
-Mm
-Mm
+Xa
+Xa
 Dm
 VG
 Qm
@@ -60933,7 +61141,7 @@ WZ
 Qm
 Qm
 Qm
-kR
+Qm
 Qm
 Qm
 Qm
@@ -60949,9 +61157,9 @@ Qm
 MV
 MV
 MV
-CR
-CR
-CR
+Om
+Om
+Om
 aa
 aa
 aa
@@ -61142,7 +61350,7 @@ sw
 Cz
 mD
 aa
-OY
+TI
 Kw
 HI
 GC
@@ -61170,14 +61378,14 @@ IS
 JG
 JG
 Iv
-Zq
-Mm
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
+Xa
+Xa
 Dm
 Dm
-Mm
+Xa
 VG
 Qm
 Qm
@@ -61206,7 +61414,7 @@ Qm
 ML
 ML
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -61399,7 +61607,7 @@ zA
 CA
 mD
 aa
-OY
+TI
 HI
 HI
 HI
@@ -61427,13 +61635,13 @@ IS
 JG
 JG
 Iv
-Cj
+Iv
 Iv
 Dm
 Dm
 PG
 Dm
-Mm
+Xa
 Dm
 VG
 Qm
@@ -61456,14 +61664,14 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
 Qm
 Qm
 Qm
-CR
+Qm
+Om
 aa
 aa
 aa
@@ -61656,7 +61864,7 @@ rz
 nU
 mD
 aa
-OY
+TI
 Br
 HI
 Rg
@@ -61686,21 +61894,21 @@ JG
 JG
 JG
 Iv
-Mm
+Xa
 Dm
 Dm
 Dm
-Mm
+Xa
 Dm
 VG
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
-kR
+Qm
+Qm
 Qm
 Qm
 Qm
@@ -61720,7 +61928,7 @@ Qm
 Qm
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -61913,9 +62121,9 @@ zD
 CB
 mD
 aa
-OY
-OY
-OY
+TI
+TI
+TI
 Ep
 Ep
 Ep
@@ -61943,14 +62151,14 @@ JO
 JG
 JG
 Iv
-Mm
-Mm
+Xa
+Xa
 Dm
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 VG
-kR
+Qm
 Qm
 Qm
 Qm
@@ -61966,7 +62174,6 @@ Qm
 Qm
 Qm
 Qm
-kR
 Qm
 Qm
 Qm
@@ -61977,7 +62184,8 @@ Qm
 Qm
 Qm
 Qm
-CR
+Qm
+Om
 aa
 aa
 aa
@@ -62200,12 +62408,12 @@ Iv
 RH
 RH
 Iv
-Mm
-Mm
-Mm
+Xa
+Xa
+Xa
 Dm
 Dm
-FE
+Xa
 VG
 Qm
 Qm
@@ -62234,7 +62442,7 @@ Qm
 WZ
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -62459,23 +62667,18 @@ JG
 Iv
 Iv
 Iv
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
 Qm
 Qm
 Qm
 Qm
 Qm
 Qm
-kR
 Qm
-Qm
-Qm
-Qm
-WZ
 Qm
 Qm
 Qm
@@ -62483,6 +62686,11 @@ Qm
 WZ
 Qm
 Qm
+Qm
+Qm
+WZ
+Qm
+Qm
 WZ
 Qm
 Qm
@@ -62491,7 +62699,7 @@ Qm
 Qm
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -62720,7 +62928,7 @@ aa
 aa
 aa
 aa
-CR
+Om
 Qm
 Qm
 Qm
@@ -62748,7 +62956,7 @@ Qm
 Qm
 Qm
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -62977,8 +63185,8 @@ aa
 aa
 aa
 aa
-CR
-CR
+Om
+Om
 Qm
 Qm
 Qm
@@ -62991,21 +63199,21 @@ Qm
 Qm
 Qm
 Qm
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 Qm
 Qm
 Qm
 Qm
 WZ
 Qm
-CR
+Om
 aa
 aa
 aa
@@ -63235,34 +63443,34 @@ aa
 aa
 aa
 aa
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 aa
 aa
 aa
 aa
 aa
 aa
-CR
-CR
-CR
-CR
-CR
-CR
-CR
-CR
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -7658,6 +7658,14 @@
 /obj/item/storage/belt/utility/servant,
 /turf/open/indestructible/clock_spawn_room,
 /area/centcom/holding/cafewar)
+"rj" = (
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
+/turf/open/indestructible/cobble,
+/area/centcom/holding/cafepark)
 "rk" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -13382,6 +13390,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"CR" = (
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
+/turf/open/floor/grass/snow,
+/area/centcom/holding/cafepark)
 "CS" = (
 /obj/machinery/light{
 	dir = 8
@@ -13400,6 +13416,14 @@
 /obj/item/storage/box/silver_ids,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"CU" = (
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
+/turf/open/floor/grass,
+/area/centcom/holding/cafepark)
 "CV" = (
 /obj/structure/chair/stool,
 /turf/open/indestructible/hotelwood,
@@ -14505,6 +14529,16 @@
 	dir = 4
 	},
 /area/centcom/holding/cafe)
+"FD" = (
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
+/turf/open/floor/grass/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=220"
+	},
+/area/centcom/holding/cafepark)
 "FE" = (
 /obj/effect/light_emitter,
 /turf/open/floor/grass,
@@ -17639,6 +17673,14 @@
 /obj/machinery/clonepod/fullupgrade,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"Mq" = (
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
+/turf/open/water/lavaland_jungle,
+/area/centcom/holding/cafepark)
 "Mr" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plating/beach/sand,
@@ -18205,6 +18247,11 @@
 /area/syndicate_mothership)
 "Ob" = (
 /obj/structure/flora/ausbushes/brflowers,
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
 /turf/open/floor/grass,
 /area/centcom/holding/cafepark)
 "Oc" = (
@@ -22347,8 +22394,11 @@
 /turf/open/floor/wood,
 /area/centcom/evac)
 "Zk" = (
-/obj/item/flashlight/lamp/bananalamp,
-/obj/structure/table/wood,
+/obj/effect/light_emitter{
+	name = "outdoor light";
+	set_cap = 3;
+	set_luminosity = 6
+	},
 /turf/open/floor/plating/smooth/grass,
 /area/centcom/holding/cafepark)
 "Zl" = (
@@ -53426,7 +53476,7 @@ XK
 XK
 XK
 VI
-Qm
+FD
 WZ
 Qm
 Qm
@@ -54205,7 +54255,7 @@ Qm
 Qm
 LI
 Ov
-Ov
+CR
 Om
 Om
 aa
@@ -55227,7 +55277,7 @@ XK
 VI
 Qm
 Qm
-Qm
+FD
 Qm
 Qm
 Qm
@@ -55720,14 +55770,14 @@ ZO
 Fo
 TI
 TK
-Dm
+Zk
 Xa
 Xa
 sp
 Vn
 Xa
 Xa
-Zq
+rj
 Zq
 Dm
 Dm
@@ -55737,7 +55787,7 @@ HQ
 XV
 Ob
 VG
-Qm
+FD
 Qm
 Qm
 Qm
@@ -56264,7 +56314,7 @@ Qm
 Qm
 Qm
 WP
-Qm
+FD
 Om
 aa
 aa
@@ -57268,7 +57318,7 @@ Dm
 Dm
 Xa
 YM
-Dm
+Zk
 Zq
 Zq
 YM
@@ -57285,7 +57335,7 @@ Qm
 WZ
 Qm
 Qm
-Qm
+FD
 Qm
 Qm
 Qm
@@ -58039,7 +58089,7 @@ Dm
 Dm
 Dm
 Dm
-Zk
+Dm
 Zq
 Zq
 Zq
@@ -58307,7 +58357,7 @@ Dm
 Dm
 Dm
 SU
-Qm
+FD
 Qm
 Qm
 Qm
@@ -58554,7 +58604,7 @@ Dm
 Xa
 Dm
 Xa
-Xa
+CU
 Fy
 Zq
 Xa
@@ -58582,7 +58632,7 @@ Qm
 MV
 XW
 XW
-XW
+Mq
 XW
 XW
 XW
@@ -58849,7 +58899,7 @@ XW
 XW
 XW
 XW
-XW
+Mq
 Om
 aa
 aa
@@ -59061,7 +59111,7 @@ aa
 aa
 aa
 TK
-Xa
+CU
 Sm
 Xa
 yN
@@ -59347,7 +59397,7 @@ Qm
 Ty
 Qm
 Qm
-Qm
+FD
 Qm
 Qm
 Pt
@@ -59614,7 +59664,7 @@ XW
 XW
 XW
 XW
-XW
+Mq
 XW
 XW
 XW
@@ -60106,12 +60156,12 @@ Dm
 Dm
 Xa
 VG
+FD
 Qm
 Qm
 Qm
 Qm
-Qm
-Qm
+FD
 WZ
 Qm
 Qm
@@ -60346,18 +60396,18 @@ aa
 aa
 aa
 TK
-FE
+Xa
 Xa
 Xa
 Sn
 Xa
 RY
+CU
 Xa
 Xa
 Xa
 Xa
-Xa
-Xa
+CU
 Dm
 Dm
 Dm
@@ -60884,7 +60934,7 @@ Qm
 Qm
 Qm
 Qm
-Qm
+FD
 Qm
 Qm
 Qm
@@ -60897,7 +60947,7 @@ Qm
 Qm
 WZ
 Qm
-Qm
+FD
 Qm
 MV
 MV
@@ -61382,7 +61432,7 @@ IS
 JG
 JG
 Iv
-Xa
+CU
 Xa
 Xa
 Xa
@@ -62417,7 +62467,7 @@ Xa
 Xa
 Dm
 Dm
-Xa
+CU
 VG
 Qm
 Qm
@@ -62933,6 +62983,7 @@ aa
 aa
 aa
 Om
+FD
 Qm
 Qm
 Qm
@@ -62950,8 +63001,7 @@ Qm
 Qm
 Qm
 Qm
-Qm
-Qm
+FD
 Qm
 Qm
 Qm
@@ -63195,28 +63245,28 @@ Qm
 Qm
 Qm
 WZ
-Qm
-Qm
-Qm
-WZ
-Qm
-Qm
-Qm
-Qm
-Om
-Om
-Om
-Om
-Om
-Om
-Om
-Om
-Qm
-Qm
+FD
 Qm
 Qm
 WZ
 Qm
+Qm
+Qm
+FD
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Om
+Qm
+Qm
+Qm
+Qm
+WZ
+FD
 Om
 aa
 aa

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -18441,7 +18441,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/machinery/rnd/production/techfab/department/engineering,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafebotany)
 "OH" = (

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -29,6 +29,27 @@
 /area/centcom/holding
 	name = "Holding Facility"
 
+/area/centcom/holding/cafe
+	name = "Ghost Cafe"
+
+/area/centcom/holding/cafewar
+	name = "Cafe Combat Zone"
+
+/area/centcom/holding/cafebotany
+	name = "Cafe Service Area"
+
+/area/centcom/holding/cafebuild
+	name = "Cafe Construction Zone"
+
+/area/centcom/holding/cafevox
+	name = "Cafe Vox Box"
+
+/area/centcom/holding/cafedorms
+	name = "Ghost Cafe Dorms"
+
+/area/centcom/holding/cafepark
+	name = "Ghost Cafe Outdoors"
+
 /area/centcom/vip
 	name = "VIP Zone"
 	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -673,7 +673,8 @@
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
 		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type,/area/hilbertshotel))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/hilbertshotel, /area/centcom/holding/cafe, /area/centcom/holding/cafewar, /area/centcom/holding/cafebotany,
+		/area/centcom/holding/cafebuild, /area/centcom/holding/cafevox, /area/centcom/holding/cafedorms, /area/centcom/holding/cafepark))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.

--- a/modular_skyrat/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_skyrat/code/game/objects/structures/ghost_role_spawners.dm
@@ -274,7 +274,8 @@
 		var/area/A = get_area(src)
 		new_spawn.AddElement(/datum/element/ghost_role_eligibility, free_ghosting = TRUE)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
-		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type,/area/hilbertshotel))
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type, /area/hilbertshotel, /area/centcom/holding/cafe, /area/centcom/holding/cafewar, /area/centcom/holding/cafebotany,
+		/area/centcom/holding/cafebuild, /area/centcom/holding/cafevox, /area/centcom/holding/cafedorms, /area/centcom/holding/cafepark))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The cafe now has individual areas it's split into, so now atmos won't fuck up as bad while retaining the thing where if you get out of the cafe you dust instantly. The snow area should be fine as well, though I can't make any promises because snow tiles suck. Removed the door into centcomm's thunder dome area.

Adamantine is also removed fro mthe stack spawner device due to people abusing it to make golems, escape the cafe, and making admins panic.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added cafe areas
tweak: made stacker not able to spawn adamantine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
