### PR TITLE
Blob Nerf

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -92,7 +92,7 @@
 //#define BLOB_SPREAD_COST 4
 #define BLOB_SPREAD_COST 3 //SKYRAT EDIT - BLOB
 //#define BLOB_ATTACK_REFUND 3 //blob refunds this much if it attacks and doesn't spread also SKYRAT CHANGE FROM 2
-#define BLOB_ATTACK_REFUND 0 //blob refunds this much if it attacks and doesn't spread also SKYRAT EDIT - BLOB
+#define BLOB_ATTACK_REFUND 1 // Skyrat Edit: Blob attacks cost 2 points. Attacks work by using spread cost, then if it doesn't spread, it gives the blob the attack refund. -3 + 1 = -2. Attacks cost 2 points.
 //#define BLOB_REFLECTOR_COST 15
 #define BLOB_REFLECTOR_COST 5 //SKYRAT EDIT - BLOB
 

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -54,7 +54,7 @@
 /obj/screen/blob/Blobbernaut
 	icon_state = "ui_blobbernaut"
 	name = "Produce Blobbernaut (40)"
-	desc = "Produces a strong, smart blobbernaut from a factory blob for 40 resources.<br>The factory blob used will become fragile and unable to produce spores."
+	desc = "Produces a strong, smart player-controlled blobbernaut from a factory blob for 40 resources.<br>The factory blob used will become fragile and unable to produce spores."	//Skyrat Edit: Now states the blobbernaut is player-controlled.
 
 /obj/screen/blob/Blobbernaut/Click()
 	if(isovermind(usr))
@@ -63,8 +63,8 @@
 
 /obj/screen/blob/ResourceBlob
 	icon_state = "ui_resource"
-	name = "Produce Resource Blob (40)"
-	desc = "Produces a resource blob for 40 resources.<br>Resource blobs will give you resources every few seconds."
+	name = "Produce Resource Blob (25)"	//Skyrat Edit: Cost down to 30 from 40.
+	desc = "Produces a resource blob for 25 resources.<br>Resource blobs will give you resources every few seconds. The closer to a node, the more resources."	//Skyrat Edit: Instructs the player that they should be built next to nodes.
 
 /obj/screen/blob/ResourceBlob/Click()
 	if(isovermind(usr))
@@ -73,8 +73,8 @@
 
 /obj/screen/blob/NodeBlob
 	icon_state = "ui_node"
-	name = "Produce Node Blob (50)"
-	desc = "Produces a node blob for 50 resources.<br>Node blobs will expand and activate nearby resource and factory blobs."
+	name = "Produce Node Blob (40)"	//Skyrat Edit: Cost down to 40 from 50.
+	desc = "Produces a node blob for 40 resources.<br>Node blobs will expand and activate nearby resource and factory blobs."
 
 /obj/screen/blob/NodeBlob/Click()
 	if(isovermind(usr))
@@ -83,8 +83,8 @@
 
 /obj/screen/blob/FactoryBlob
 	icon_state = "ui_factory"
-	name = "Produce Factory Blob (60)"
-	desc = "Produces a factory blob for 60 resources.<br>Factory blobs will produce spores every few seconds."
+	name = "Produce Factory Blob (50)"	//Skyrat Edit: Cost down to 50 from 60.
+	desc = "Produces a factory blob for 50 resources.<br>Factory blobs will produce spores every few seconds."
 
 /obj/screen/blob/FactoryBlob/Click()
 	if(isovermind(usr))

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -92,8 +92,7 @@
 	movement_type = FLYING
 	del_on_death = 1
 	deathmessage = "explodes into a cloud of gas!"
-	//var/death_cloud_size = 1 //size of cloud produced from a dying spore
-	var/death_cloud_size = 2 //size of cloud produced from a dying spore SKYRAT EDIT - BLOB
+	var/death_cloud_size = 1 //size of cloud produced from a dying spore
 	var/mob/living/carbon/human/oldguy
 	var/is_zombie = 0
 	gold_core_spawnable = HOSTILE_SPAWN
@@ -128,7 +127,6 @@
 	melee_damage_lower += 8
 	melee_damage_upper += 11
 	movement_type = GROUND
-	//death_cloud_size = 0
 	death_cloud_size = 1 //SKYRAT EDIT - BLOB
 	icon = H.icon
 	icon_state = "zombie"

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -82,8 +82,8 @@
 	verb_ask = "psychically probes"
 	verb_exclaim = "psychically yells"
 	verb_yell = "psychically screams"
-	melee_damage_lower = 2
-	melee_damage_upper = 4
+	melee_damage_lower = 5	//2 to 5.
+	melee_damage_upper = 10	//4 to 10.
 	obj_damage = 20
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	attack_verb_continuous = "hits"

--- a/code/modules/antagonists/blob/blob/blobs/core.dm
+++ b/code/modules/antagonists/blob/blob/blobs/core.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blank_blob"
 	desc = "A huge, pulsating yellow mass."
-	max_integrity = 800 //Skyrat change.
+	max_integrity = 600	// Skyrat Edit: 400 to 600.
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 5, "bomb" = 70, "bio" = 0, "rad" = 0, "fire" = 75, "acid" = 90) // Last stand
 	explosion_block = 6
 	point_return = -1

--- a/code/modules/antagonists/blob/blob/blobs/factory.dm
+++ b/code/modules/antagonists/blob/blob/blobs/factory.dm
@@ -3,14 +3,13 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_factory"
 	desc = "A thick spire of tendrils."
-	max_integrity = 400 //Skyrat change.
+	max_integrity = 300	// Skyrat Edit: 200 to 300.
 	health_regen = 1
 	point_return = 25
 	armor = list("melee" = 10, "bullet" = 20, "laser" = 15, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 	var/list/spores = list()
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/naut = null
-	//var/max_spores = 3
-	var/max_spores = 5 //SKYRAT EDIT - BLOB
+	var/max_spores = 3
 	var/spore_delay = 0
 	var/spore_cooldown = 80 //8 seconds between spores and after spore death
 

--- a/code/modules/antagonists/blob/blob/blobs/node.dm
+++ b/code/modules/antagonists/blob/blob/blobs/node.dm
@@ -36,6 +36,6 @@
 		Pulse_Area(overmind, 10, 3, 2)
 	// SKYRAT EDIT START - BLOB
 	for(var/obj/structure/blob/normal/B in range(1, src))
-		if(prob(5))
+		if(prob(0.1))
 			B.change_to(/obj/structure/blob/shield/core, overmind)
-	// SKYRAT EDIT END - BLOB
+	// SKYRAT EDIT END - Probability to make blob around a node from 0% to 0.1%. It was once 5%, and this was rolled so frequently it resulted in constant upgrades.

--- a/code/modules/antagonists/blob/blob/blobs/node.dm
+++ b/code/modules/antagonists/blob/blob/blobs/node.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blank_blob"
 	desc = "A large, pulsating yellow mass."
-	max_integrity = 400 //Skyrat Change
+	max_integrity = 150	// Skyrat Edit: 200 to 150.
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 65, "acid" = 90)
 	health_regen = 3
 	point_return = 25

--- a/code/modules/antagonists/blob/blob/blobs/resource.dm
+++ b/code/modules/antagonists/blob/blob/blobs/resource.dm
@@ -26,7 +26,7 @@
 		return
 	flick("blob_resource_glow", src)
 	if(overmind)
-		overmind.add_points(1)
+		overmind.add_points(1.5)	//Skyrat Edit: 1 to 1.5
 		resource_delay = world.time + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
 	else
 		resource_delay = world.time + 40

--- a/code/modules/antagonists/blob/blob/blobs/resource.dm
+++ b/code/modules/antagonists/blob/blob/blobs/resource.dm
@@ -26,7 +26,7 @@
 		return
 	flick("blob_resource_glow", src)
 	if(overmind)
-		overmind.add_points(1.5)	// Skyrat Edit: 1 to 1.5
+		overmind.add_points(1)
 		resource_delay = world.time + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
 	else
 		resource_delay = world.time + 40

--- a/code/modules/antagonists/blob/blob/blobs/resource.dm
+++ b/code/modules/antagonists/blob/blob/blobs/resource.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_resource"
 	desc = "A thin spire of slightly swaying tendrils."
-	max_integrity = 120 //Skyrat Change.
+	max_integrity = 80	// Skyrat Edit: 60 to 80.
 	point_return = 15
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 0, "energy" = 0, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 	var/resource_delay = 0
@@ -26,8 +26,7 @@
 		return
 	flick("blob_resource_glow", src)
 	if(overmind)
-		//overmind.add_points(1)
-		overmind.add_points(2) //SKYRAT EDIT - BLOB
+		overmind.add_points(1.5)	// Skyrat Edit: 1 to 1.5
 		resource_delay = world.time + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
 	else
 		resource_delay = world.time + 40

--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -137,14 +137,14 @@
 	set name = "Create Resource Blob (25)" //SKYRAT EDIT - BLOB
 	set desc = "Create a resource tower which will generate resources for you."
 	//createSpecial(40, /obj/structure/blob/resource, 4, 1)
-	createSpecial(25, /obj/structure/blob/resource, 3, 1) //SKYRAT EDIT - BLOB
+	createSpecial(25, /obj/structure/blob/resource, 4, 1) //SKYRAT EDIT - BLOB
 
 /mob/camera/blob/verb/create_node()
 	set category = "Blob"
 	set name = "Create Node Blob (40)" //SKYRAT EDIT - BLOB
 	set desc = "Create a node, which will power nearby factory and resource blobs."
 	//createSpecial(50, /obj/structure/blob/node, 5, 0)
-	createSpecial(40, /obj/structure/blob/node, 4, 0) //SKYRAT EDIT - BLOB
+	createSpecial(40, /obj/structure/blob/node, 5, 0) //SKYRAT EDIT - BLOB
 
 /mob/camera/blob/verb/create_factory()
 	set category = "Blob"

--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -113,7 +113,7 @@
 
 /mob/camera/blob/verb/create_shield_power()
 	set category = "Blob"
-	set name = "Create/Upgrade Shield Blob (5)" //SKYRAT EDIT - BLOB
+	set name = "Create/Upgrade Shield Blob (10)"	// Skyrat Edit: 15 to 10
 	set desc = "Create a shield blob, which will block fire and is hard to kill. Using this on an existing shield blob turns it into a reflective blob, capable of reflecting most projectiles but making it much weaker than usual to brute attacks."
 	create_shield()
 
@@ -130,14 +130,14 @@
 		S.change_to(/obj/structure/blob/shield/reflective, src)
 	else
 		//createSpecial(15, /obj/structure/blob/shield, 0, 0, T)
-		createSpecial(5, /obj/structure/blob/shield, 0, 0, T) //SKYRAT EDIT - BLOB
+		createSpecial(10, /obj/structure/blob/shield, 0, 0, T)	// Skyrat Edit: 15 to 10.
 
 /mob/camera/blob/verb/create_resource()
 	set category = "Blob"
-	set name = "Create Resource Blob (30)" //SKYRAT EDIT - BLOB
+	set name = "Create Resource Blob (25)" //SKYRAT EDIT - BLOB
 	set desc = "Create a resource tower which will generate resources for you."
 	//createSpecial(40, /obj/structure/blob/resource, 4, 1)
-	createSpecial(30, /obj/structure/blob/resource, 3, 1) //SKYRAT EDIT - BLOB
+	createSpecial(25, /obj/structure/blob/resource, 3, 1) //SKYRAT EDIT - BLOB
 
 /mob/camera/blob/verb/create_node()
 	set category = "Blob"
@@ -156,7 +156,7 @@
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"
 	set name = "Create Blobbernaut (40)"
-	set desc = "Create a powerful blobbernaut which is mildly smart and will attack enemies."
+	set desc = "Create a powerful player-controlled blobbernaut you can communicate and coordinate with to fend off attackers."	// Skyrat Edit: Made this say it makes a player controlled mob.
 	var/turf/T = get_turf(src)
 	var/obj/structure/blob/factory/B = locate(/obj/structure/blob/factory) in T
 	if(!B)

--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -10,7 +10,7 @@
 	layer = BELOW_MOB_LAYER
 	CanAtmosPass = ATMOS_PASS_PROC
 	var/point_return = 0 //How many points the blob gets back when it removes a blob of that type. If less than 0, blob cannot be removed.
-	max_integrity = 60 //Skyrat change.
+	max_integrity = 40	// Skyrat Edit: 30 to 40.
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 70)
 	var/health_regen = 2 //how much health this blob regens when pulsed
 	var/pulse_timestamp = 0 //we got pulsed when?


### PR DESCRIPTION
## About The Pull Request
**Nerfs:**
• Blob Core health 800 => 600 (originally 400).
• Blob Factory health 400 => 300 (originally 200); max spores 5 => 3.
• Blob Node health 400 => 150 (originally 200).
• Blob Resource health 120 => 80 (original 60).
• Normal Blob tile health 60 => 40 (originally 30).
• Blob resource generation reverted from 2x => 1x.
• Attack cost is now 2 resources (this is a buff because it was actually 3 resources with Jake’s nerf, which was a bug).
• Shield Blob upgrade cost 5 => 10 (originally 15).
• Blob spore cloud size reverted from 2 => 1.
• Blob node distance from other nodes reverted from 4 => 5.
• Blob resource distance from other resource blobs reverted from 3 => 4.
• Reverts blob points generation from 2 => 1.
• Reverts node blob free upgrades to surrounding blobs to strong blobs from 5% => 0.1% as it was just spitting out upgrades constantly.

**Buffs:**
• Spore lower damage 2 => 5; spore upper damage 4 => 10.
• Resource Blob upgrade cost 30 => 25 (originally 40).
**Quality of Life:**
• Blobbernaut tooltip tells the player that blobbernauts are player-controlled.
• Factory tooltip now displays the correct price for factory blobs.
• Resource tooltip now displays the correct price for resource blobs.

## Why It's Good For The Game
This is a partial revert of #3228 and nerf to the changes of #1355. The best parts of #3228 were kept whilst #1355's health buffs that make the blob so frustrating to fight have been reeled back. Think of it as a revert of #3228 that brings back some of it, so it's a minor buff to what we had beforehand and a moderate nerf to what we have now. It was a good change, and definitely better change than outright doubling blob health, but wounds for some reason being given for 20 force attacks (the fuck?) and 

Having doubled health made the blobs incredibly annoying to fight. Emitters, which used to carve the blob up, became kinda laughable.

## What do I do if I'm a player?
If you're a player looking at this PR and there's a blob, do one of these things:
• Get roller beds and medical equipment, drag people out and keep them alive.
• Break into security checkpoints in departments and unwrench the weapon rechargers, drag them towards the blob so those with lasers can keep firing.
• Scientists should mass-print experimental welders and throw them for the masses to collect.
• Engineers and anyone with EVA access should set emitters up facing the blob core in space, away from the blob and they should protect said emitters.
• If engineering is incompetent or scarce, break in and steal emitters from the supermatter engine **but not the damn singularity engine** and set them up to carve up the blob. Deconstructing the reinforced wall into secure engineering will help with this.
• Miner? Get a PKA and vent the area completely. Use points to supply the crew with more PKAs. The insane damage and infinite ammo is invaluable.
• Drag water and fire extinguishers to the blob. If they decide to change the strain into one vulnerable to water (blazing oil), **punish**.

## Changelog
:cl: Floof Ball#0798 Kathrin Morrison
balance: Blobs are now weaker, with 1.5x resource generation, blob spores are stronger, resource nodes are cheaper and the health of blobs has been lowered across the board to make them less frustrating to fight.
fix: Blob tooltips were displaying incorrect prices for blob tiles and missing some critical information.
/:cl: