### PR TITLE
Mirrors #3126 correctly with modular changes (Paramedic heirloom is now a health analyzer)

### DIFF
--- a/modular_skyrat/code/datums/traits/negative.dm
+++ b/modular_skyrat/code/datums/traits/negative.dm
@@ -13,7 +13,7 @@
 		if("Medical Doctor")
 			heirloom_type = /obj/item/healthanalyzer
 		if("Paramedic")
-			heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
+			heirloom_type = /obj/item/healthanalyzer
 		if("Station Engineer")
 			heirloom_type = /obj/item/wirecutters/brass
 		if("Atmospheric Technician")


### PR DESCRIPTION
## About The Pull Request
Something something weight class, it's mirroring #3126 but it makes sense because why a lighter?

## Why It's Good For The Game
It's intended behaviour. Also, why a lighter? Paramedics having a family health analyzer is much more sensible. It's the same as what the MDs get for their heirlooms.

## Changelog
:cl:
fix: Paramedics spawn with a small heirloom like they should've being doing.
/:cl: