### PR TITLE
Emagged/Hacked cyborgs can no longer be detonated / locked down

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -543,9 +543,7 @@
 
 /mob/living/silicon/robot/proc/self_destruct()
 	if(emagged)
-		if(mmi)
-			qdel(mmi)
-		explosion(src.loc,1,2,4,flame_range = 2)
+		return to_chat(usr, "<span class='notice'>Unable to execute selfdestruct sequence</span>") //skyrat addition
 	else
 		explosion(src.loc,-1,0,2)
 	gib()
@@ -579,6 +577,8 @@
 
 /mob/living/silicon/robot/proc/SetLockdown(state = 1)
 	// They stay locked down if their wire is cut.
+	if(emagged)
+		return to_chat(usr, "<span class='notice'>Unable to engage lockdown protocol</span>") // Skyrat addition 
 	if(wires.is_cut(WIRE_LOCKDOWN))
 		state = 1
 	if(state)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -578,7 +578,8 @@
 /mob/living/silicon/robot/proc/SetLockdown(state = 1)
 	// They stay locked down if their wire is cut.
 	if(emagged)
-		return to_chat(usr, "<span class='notice'>Unable to engage lockdown protocol</span>") // Skyrat addition 
+		state = 0
+		to_chat(usr, "<span class='notice'>Unable to engage lockdown protocol</span>") // Skyrat addition 
 	if(wires.is_cut(WIRE_LOCKDOWN))
 		state = 1
 	if(state)


### PR DESCRIPTION

## About The Pull Request

Emagged/Hacked cyborgs can no longer be remotely detonated/locked
## Why It's Good For The Game
Being able to perma-kill any malfunctioning / emagged cyborg spontaneously and without warning is both extremly annoying and extremly unfair for the cyborgs . You can't remotely detonate a traitor , so you shouldn't be able to remotely detonate a hacked cyborg either. 
## Changelog
:cl:
balance: Hacked/Emagged cyborgs can no longer be detonated / locked down
/:cl:
