### PR TITLE
few small changes to ghost cafe and a change to CC

### DIFF
--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -9900,11 +9900,12 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/toy/plush/mammal/odrew{
-	step_x = 6;
-	step_y = 7
+	pixel_x = 8;
+	pixel_y = 5
 	},
 /obj/item/toy/plush/mammal/redtail{
-	desc = "An adorable stuffed toy resembling a red panda."
+	pixel_x = -6;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
@@ -10692,11 +10693,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/toy/plush/mammal/reece{
-	step_x = 4;
-	step_y = 5
+	pixel_x = 4
 	},
 /obj/item/toy/plush/mammal/taff{
-	step_x = -6
+	pixel_x = -6
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
@@ -11177,10 +11177,7 @@
 /obj/structure/table/reinforced,
 /obj/item/toy/katana,
 /obj/item/toy/plush/carpplushie,
-/obj/item/toy/plush/mammal/trace{
-	step_x = -4;
-	step_y = 4
-	},
+/obj/item/toy/plush/mammal/trace,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "yf" = (
@@ -11803,11 +11800,11 @@
 "zw" = (
 /obj/item/paicard,
 /obj/structure/table/reinforced,
-/obj/item/toy/plush/mammal/edgar{
-	step_x = 9;
-	step_y = 4
+/obj/item/toy/plush/mammal/edgar,
+/obj/item/toy/plush/mammal/fox{
+	pixel_x = 8;
+	pixel_y = -5
 	},
-/obj/item/toy/plush/mammal/fox,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "zx" = (
@@ -12560,11 +12557,11 @@
 /obj/item/megaphone,
 /obj/machinery/light,
 /obj/item/toy/plush/catgirl/trilby{
-	step_x = 3;
-	step_y = 3
+	pixel_x = -8
 	},
 /obj/item/toy/plush/catgirl/kobe{
-	step_x = -2
+	pixel_x = 4;
+	pixel_y = -6
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
@@ -12588,12 +12585,11 @@
 /obj/item/binoculars,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/toy/plush/lizardplushie/bottles{
-	step_x = 4;
-	step_y = 4
+	pixel_x = 4
 	},
 /obj/item/toy/plush/lizardplushie/emily{
-	step_x = -5;
-	step_y = 3
+	pixel_x = -7;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
@@ -12634,13 +12630,10 @@
 	},
 /obj/item/reagent_containers/food/snacks/popcorn,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/item/toy/plush/lizardplushie/katra{
-	step_x = 5;
-	step_y = 5
-	},
+/obj/item/toy/plush/lizardplushie/katra,
 /obj/item/toy/plush/lizardplushie/lyssa{
-	step_x = -2;
-	step_y = -2
+	pixel_x = 9;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
@@ -12678,12 +12671,11 @@
 /obj/item/binoculars,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/toy/plush/lizardplushie/xil{
-	step_x = -3;
-	step_y = 4
+	pixel_x = -6
 	},
 /obj/item/toy/plush/mammal/bobjoga{
-	step_x = 5;
-	step_y = -3
+	pixel_x = 6;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
@@ -13040,11 +13032,11 @@
 	pixel_x = -5
 	},
 /obj/item/toy/plush/mammal/cinder{
-	step_x = -7;
-	step_y = 3
+	pixel_x = -7
 	},
 /obj/item/toy/plush/mammal/dubious{
-	step_x = 5
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
@@ -13139,14 +13131,14 @@
 	name = "cookie of encouragement";
 	pixel_y = 3
 	},
-/obj/item/toy/plush/mammal/kato{
-	step_x = -10;
-	step_y = 3
+/obj/item/toy/plush/mammal/kato,
+/obj/item/toy/plush/mammal/michael{
+	pixel_x = 8;
+	pixel_y = -5
 	},
-/obj/item/toy/plush/mammal/michael,
 /obj/item/toy/plush/mammal/monika{
-	step_x = 9;
-	step_y = 5
+	pixel_x = -9;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
@@ -14599,8 +14591,8 @@
 "Fk" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/plush/sergal/jadek{
-	step_x = -3;
-	step_y = -5
+	pixel_x = -3;
+	pixel_y = -4
 	},
 /turf/open/floor/carpet/royalblue,
 /area/centcom/evac)
@@ -14611,8 +14603,8 @@
 "Fm" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/plush/sergal/ray{
-	step_x = -4;
-	step_y = -6
+	pixel_x = -4;
+	pixel_y = -4
 	},
 /turf/open/floor/carpet/royalblue,
 /area/centcom/evac)
@@ -18906,6 +18898,9 @@
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafe)

--- a/_maps/map_files/generic/CentCom_Skyrat.dmm
+++ b/_maps/map_files/generic/CentCom_Skyrat.dmm
@@ -4370,6 +4370,10 @@
 	icon_state = "alien19"
 	},
 /area/abductor_ship)
+"kR" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "kS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6927,6 +6931,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"pF" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "pG" = (
 /obj/vehicle/ridden/scooter/skateboard{
 	dir = 4
@@ -7653,6 +7664,10 @@
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plating/smooth/grass,
 /area/centcom/holding/cafepark)
+"rh" = (
+/obj/structure/mineral_door/paperframe,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "ri" = (
 /obj/item/storage/belt/utility/servant,
 /obj/item/storage/belt/utility/servant,
@@ -8171,6 +8186,10 @@
 /obj/item/disk/surgery/debug,
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"sa" = (
+/mob/living/simple_animal/opossum,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafedorms)
 "sb" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -8838,11 +8857,12 @@
 	},
 /area/centcom/holding/cafepark)
 "tw" = (
-/obj/machinery/computer/slot_machine,
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/window/plasma/reinforced/spawner/east,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
+/obj/machinery/turnstile{
+	dir = 8
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/warzonetile,
+/area/centcom/holding/cafewar)
 "tx" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -9225,6 +9245,13 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
+"ue" = (
+/obj/structure/mineral_door/paperframe{
+	name = "Dodgeball Court"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/pacifytile,
+/area/centcom/holding)
 "uf" = (
 /obj/machinery/light{
 	dir = 4
@@ -9551,6 +9578,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
+"uI" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding)
 "uJ" = (
 /obj/effect/baseturf_helper/asteroid/snow,
 /turf/closed/indestructible/riveted,
@@ -9858,20 +9892,30 @@
 /turf/open/floor/wood,
 /area/centcom/evac)
 "vp" = (
-/obj/machinery/light,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/popcorn{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/snacks/popcorn,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/mammal/odrew{
+	step_x = 6;
+	step_y = 7
+	},
+/obj/item/toy/plush/mammal/redtail{
+	desc = "An adorable stuffed toy resembling a red panda."
+	},
+/turf/open/floor/plasteel,
 /area/centcom/evac)
 "vq" = (
 /obj/machinery/pool/controller,
 /turf/open/floor/plasteel/yellowsiding,
 /area/centcom/holding/cafe)
+"vr" = (
+/obj/structure/fans/tiny/invisible,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/holding)
 "vs" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -10306,6 +10350,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"wf" = (
+/obj/machinery/door/airlock{
+	id_tag = "CCD2"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/pacifytile,
+/area/centcom/holding)
 "wg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -10633,6 +10684,22 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"wR" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/toy/plush/mammal/reece{
+	step_x = 4;
+	step_y = 5
+	},
+/obj/item/toy/plush/mammal/taff{
+	step_x = -6
+	},
+/turf/open/floor/plasteel,
+/area/centcom/evac)
 "wS" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -11106,6 +11173,16 @@
 /obj/machinery/door/airlock/wood,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafedorms)
+"ye" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/katana,
+/obj/item/toy/plush/carpplushie,
+/obj/item/toy/plush/mammal/trace{
+	step_x = -4;
+	step_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "yf" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -11724,10 +11801,15 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/supplypod)
 "zw" = (
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/light,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
+/obj/item/paicard,
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/mammal/edgar{
+	step_x = 9;
+	step_y = 4
+	},
+/obj/item/toy/plush/mammal/fox,
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "zx" = (
 /obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/stripes/line{
@@ -12472,6 +12554,20 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"Bb" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table/reinforced,
+/obj/item/megaphone,
+/obj/machinery/light,
+/obj/item/toy/plush/catgirl/trilby{
+	step_x = 3;
+	step_y = 3
+	},
+/obj/item/toy/plush/catgirl/kobe{
+	step_x = -2
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "Bc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -12479,14 +12575,27 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "Bd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
+/obj/item/binoculars{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/binoculars,
+/obj/item/binoculars{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/binoculars,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/item/toy/plush/lizardplushie/bottles{
+	step_x = 4;
+	step_y = 4
+	},
+/obj/item/toy/plush/lizardplushie/emily{
+	step_x = -5;
+	step_y = 3
+	},
+/turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "Be" = (
 /obj/machinery/computer/camera_advanced/abductor{
@@ -12516,6 +12625,25 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"Bj" = (
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/popcorn{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/popcorn,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/item/toy/plush/lizardplushie/katra{
+	step_x = 5;
+	step_y = 5
+	},
+/obj/item/toy/plush/lizardplushie/lyssa{
+	step_x = -2;
+	step_y = -2
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "Bk" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -12536,6 +12664,29 @@
 /obj/structure/bookcase/random,
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding)
+"Bo" = (
+/obj/structure/table/reinforced,
+/obj/item/binoculars{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/binoculars,
+/obj/item/binoculars{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/binoculars,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/item/toy/plush/lizardplushie/xil{
+	step_x = -3;
+	step_y = 4
+	},
+/obj/item/toy/plush/mammal/bobjoga{
+	step_x = 5;
+	step_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "Bp" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -12877,6 +13028,26 @@
 	smooth = 1
 	},
 /area/centcom/holding/cafebotany)
+"BW" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/item/reagent_containers/food/snacks/hotdog{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/snacks/hotdog,
+/obj/item/reagent_containers/food/snacks/hotdog{
+	pixel_x = -5
+	},
+/obj/item/toy/plush/mammal/cinder{
+	step_x = -7;
+	step_y = 3
+	},
+/obj/item/toy/plush/mammal/dubious{
+	step_x = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "BX" = (
 /obj/structure/chair/sofa,
 /obj/machinery/light{
@@ -12952,6 +13123,33 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=220"
 	},
 /area/centcom/holding/cafepark)
+"Cg" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/snacks/cookie{
+	desc = "Feeling disheartened by the events of the shift? Take solace in a sugary treat, you did your best!";
+	name = "cookie of encouragement";
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/snacks/cookie{
+	desc = "Feeling disheartened by the events of the shift? Take solace in a sugary treat, you did your best!";
+	name = "cookie of encouragement"
+	},
+/obj/item/reagent_containers/food/snacks/cookie{
+	desc = "Feeling disheartened by the events of the shift? Take solace in a sugary treat, you did your best!";
+	name = "cookie of encouragement";
+	pixel_y = 3
+	},
+/obj/item/toy/plush/mammal/kato{
+	step_x = -10;
+	step_y = 3
+	},
+/obj/item/toy/plush/mammal/michael,
+/obj/item/toy/plush/mammal/monika{
+	step_x = 9;
+	step_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom/evac)
 "Ch" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/mineral/titanium/blue,
@@ -14399,22 +14597,25 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "Fk" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table/reinforced,
-/obj/machinery/light,
-/obj/item/reagent_containers/food/snacks/hotdog{
-	pixel_x = 5
+/obj/item/toy/plush/sergal/jadek{
+	step_x = -3;
+	step_y = -5
 	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/obj/item/reagent_containers/food/snacks/hotdog{
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/royalblue,
 /area/centcom/evac)
 "Fl" = (
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding/cafedorms)
+"Fm" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/sergal/ray{
+	step_x = -4;
+	step_y = -6
+	},
+/turf/open/floor/carpet/royalblue,
+/area/centcom/evac)
 "Fn" = (
 /turf/open/floor/plating,
 /area/fabric_of_reality)
@@ -15305,16 +15506,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"Hm" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "Ho" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -15895,24 +16086,6 @@
 "Il" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeobserve)
-"Im" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/cookie{
-	desc = "Feeling disheartened by the events of the shift? Take solace in a sugary treat, you did your best!";
-	name = "cookie of encouragement";
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/snacks/cookie{
-	desc = "Feeling disheartened by the events of the shift? Take solace in a sugary treat, you did your best!";
-	name = "cookie of encouragement"
-	},
-/obj/item/reagent_containers/food/snacks/cookie{
-	desc = "Feeling disheartened by the events of the shift? Take solace in a sugary treat, you did your best!";
-	name = "cookie of encouragement";
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "In" = (
 /mob/living/simple_animal/parrot,
 /turf/open/floor/plating/smooth/grass,
@@ -17938,10 +18111,6 @@
 	name = "Thunderdome Admin"
 	},
 /area/tdome/tdomeobserve)
-"Nh" = (
-/obj/structure/window/plasma/reinforced,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "Ni" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -18509,12 +18678,6 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
 /area/centcom/evac)
-"OL" = (
-/obj/structure/mineral_door/paperframe{
-	name = "Dodgeball Court"
-	},
-/turf/open/pacifytile,
-/area/centcom/holding)
 "OM" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /mob/living/simple_animal/butterfly,
@@ -19573,11 +19736,6 @@
 /obj/item/megaphone,
 /turf/open/floor/wood,
 /area/fabric_of_reality)
-"RG" = (
-/obj/item/paicard,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "RH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -20000,12 +20158,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"SJ" = (
-/obj/structure/window/paperframe{
-	CanAtmosPass = 0
-	},
-/turf/closed/indestructible/fakeglass,
-/area/centcom/holding)
 "SK" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -20088,15 +20240,6 @@
 	},
 /turf/open/indestructible/hotelwood,
 /area/centcom/holding/cafebotany)
-"SX" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "SY" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
@@ -20400,18 +20543,6 @@
 	},
 /turf/open/floor/wood,
 /area/fabric_of_reality)
-"TT" = (
-/obj/machinery/door/airlock{
-	id_tag = "CCD2"
-	},
-/turf/open/pacifytile,
-/area/centcom/holding)
-"TU" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/katana,
-/obj/item/toy/plush/carpplushie,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "TV" = (
 /obj/machinery/vending/snack/random,
 /turf/open/indestructible/hotelwood,
@@ -20811,12 +20942,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"UY" = (
-/obj/structure/chair/stool,
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/window/plasma/reinforced/spawner/east,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "UZ" = (
 /obj/item/target,
 /turf/open/indestructible/clock_spawn_room,
@@ -20865,21 +20990,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/centcom/evac)
-"Vi" = (
-/obj/structure/table/reinforced,
-/obj/item/binoculars{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/binoculars,
-/obj/item/binoculars{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/binoculars,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "Vj" = (
 /obj/structure/toilet{
@@ -21099,10 +21209,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/one)
-"VK" = (
-/mob/living/simple_animal/pet/dog/cheems,
-/turf/open/floor/carpet/royalblue,
-/area/centcom/holding/cafedorms)
 "VL" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumGhostDojo";
@@ -21252,10 +21358,6 @@
 /obj/effect/turf_decal/trimline/white/filled/corner,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"VZ" = (
-/mob/living/simple_animal/pet/dog/corgi,
-/turf/open/floor/carpet/royalblue,
-/area/centcom/holding/cafedorms)
 "Wa" = (
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
@@ -22106,10 +22208,6 @@
 /obj/machinery/vending/wallmed,
 /turf/closed/indestructible/riveted,
 /area/centcom/evac)
-"Yr" = (
-/mob/living/simple_animal/opossum,
-/turf/open/floor/carpet/red,
-/area/centcom/holding/cafedorms)
 "Ys" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red,
@@ -22156,13 +22254,6 @@
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/mineral/titanium,
 /area/centcom/evac)
-"Yz" = (
-/obj/machinery/computer/slot_machine,
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/window/plasma/reinforced/spawner/east,
-/turf/open/indestructible/hotelwood,
-/area/centcom/holding/cafe)
 "YA" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -22323,10 +22414,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/beach/sand,
 /area/fabric_of_reality)
-"YX" = (
-/mob/living/simple_animal/pet/dog/pug,
-/turf/open/floor/carpet/red,
-/area/centcom/holding/cafedorms)
 "YY" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -22354,13 +22441,6 @@
 "Zc" = (
 /turf/open/indestructible/binary,
 /area/space)
-"Zd" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table/reinforced,
-/obj/item/megaphone,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "Ze" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/door/airlock/sandstone{
@@ -47020,9 +47100,9 @@ Tt
 TG
 Op
 Wa
+zt
+zt
 Wh
-QL
-Fi
 QL
 Fi
 QL
@@ -47278,8 +47358,8 @@ zT
 zT
 Za
 zt
-Fi
-QL
+zt
+zt
 Fi
 QL
 Fi
@@ -47301,7 +47381,7 @@ WG
 WG
 Wa
 WO
-WG
+sa
 vz
 Wa
 VS
@@ -47535,8 +47615,8 @@ zT
 zT
 Wa
 zt
-QL
-Fi
+zt
+zt
 QL
 Fi
 QL
@@ -47792,8 +47872,8 @@ Fl
 Nw
 Wa
 zt
-Fi
-QL
+zt
+zt
 Fi
 QL
 Fi
@@ -48049,12 +48129,12 @@ Wa
 Wa
 Wa
 Wo
-QL
-Fi
-QL
-Fi
-QL
-Fi
+zt
+zt
+zt
+zt
+zt
+zt
 Oq
 PX
 XN
@@ -48071,10 +48151,10 @@ Of
 Of
 Of
 Of
-Ur
-VK
-Ur
-Yr
+Of
+Of
+Of
+Of
 Of
 Of
 WE
@@ -48327,10 +48407,10 @@ Qu
 Of
 Of
 Of
-YX
-Ur
-Ur
-Ur
+Of
+Of
+Of
+Of
 Of
 Of
 Of
@@ -48585,9 +48665,9 @@ Of
 Of
 Of
 Of
-Ur
-Ur
-VZ
+Of
+Of
+Of
 Of
 Cd
 Of
@@ -48820,10 +48900,10 @@ Hj
 Fa
 KT
 zt
+Tu
+Qk
+Tu
 zt
-zw
-Yz
-UY
 zt
 yc
 tn
@@ -48833,8 +48913,8 @@ zt
 Nd
 Nd
 Nd
-FR
-FR
+vr
+vr
 Nd
 Nd
 Wa
@@ -49077,10 +49157,10 @@ CV
 jA
 KT
 zt
+Rm
+Tn
+UT
 zt
-Nh
-tw
-UY
 zt
 zt
 Re
@@ -49335,16 +49415,16 @@ jA
 KT
 zt
 zt
-Nh
-tw
-UY
+zt
+zt
+zt
 zt
 zt
 tn
 Wo
 Zx
 zt
-OL
+ue
 Wi
 Po
 ZU
@@ -49592,16 +49672,16 @@ jA
 FW
 zt
 zt
-zw
-tw
-UY
+zt
+zt
+zt
 zt
 zt
 Re
 zt
 pD
 zt
-SJ
+uI
 So
 Po
 ZU
@@ -49858,7 +49938,7 @@ tn
 WM
 zt
 zt
-SJ
+uI
 YU
 Po
 ZU
@@ -49872,7 +49952,7 @@ Wa
 Wa
 Of
 Of
-Up
+Of
 Wa
 Wa
 Wa
@@ -50115,7 +50195,7 @@ Oq
 zt
 zt
 zt
-SJ
+uI
 YU
 Po
 ZU
@@ -50372,7 +50452,7 @@ Oq
 zt
 zt
 zt
-SJ
+uI
 BX
 TM
 TM
@@ -50629,7 +50709,7 @@ Oq
 zt
 zt
 zt
-SJ
+uI
 YU
 PA
 ZU
@@ -50886,7 +50966,7 @@ tn
 Wo
 zt
 zt
-SJ
+uI
 YU
 PA
 ZU
@@ -51143,7 +51223,7 @@ Oq
 zt
 zt
 zt
-SJ
+uI
 Ye
 PA
 ZU
@@ -51392,7 +51472,7 @@ Pv
 zt
 zt
 zt
-Tu
+zt
 zt
 zt
 NP
@@ -51400,7 +51480,7 @@ Oq
 zt
 zt
 zt
-OL
+ue
 Wi
 PA
 ZU
@@ -51649,7 +51729,7 @@ tn
 Rm
 Tn
 UT
-Hm
+zt
 zt
 zt
 GY
@@ -51670,7 +51750,7 @@ Of
 QF
 Wa
 Of
-Of
+Up
 Of
 Wa
 WN
@@ -51903,23 +51983,23 @@ yO
 yO
 tn
 tn
-Wo
-zt
-zt
-zt
-zt
-zt
-zt
+Oq
+Oq
+Oq
+rh
+Oq
+Oq
+Oq
 Nd
 Nd
 Te
 Nd
 Nd
 Nd
-FR
-TT
-TT
-FR
+vr
+wf
+wf
+vr
 Nd
 Wa
 Kf
@@ -52155,18 +52235,18 @@ zt
 zt
 zt
 zt
-TV
-TV
+kR
+kR
 zt
 Nc
+pF
 zt
 zt
 zt
 zt
 zt
 zt
-zt
-zt
+TV
 Nd
 Qj
 Sd
@@ -52415,15 +52495,15 @@ zt
 zt
 zt
 zt
-Ve
-Ve
-Ve
-Ve
-Ve
-Ve
-Ve
 zt
 zt
+zt
+zt
+zt
+zt
+zt
+zt
+TV
 Nd
 Gs
 Sd
@@ -52672,13 +52752,13 @@ zt
 zt
 zt
 zt
-Nb
-VD
-xC
-qN
-sb
-Wg
-vx
+zt
+zt
+zt
+zt
+zt
+zt
+zt
 zt
 zt
 Nd
@@ -52928,14 +53008,14 @@ CW
 zt
 zt
 zt
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
+Ve
 zt
-SF
-RC
-yf
-Lf
-kv
-qH
-yM
 zt
 yc
 Nd
@@ -53185,14 +53265,14 @@ CW
 zt
 zt
 zt
+Nb
+VD
+xC
+qN
+sb
+Wg
+vx
 zt
-Ll
-Ll
-Ll
-Ll
-Ll
-Ll
-Ll
 zt
 zt
 Rx
@@ -53442,13 +53522,13 @@ CW
 zt
 zt
 zt
-zt
-zt
-zt
-zt
-zt
-zt
-zt
+SF
+RC
+yf
+Lf
+kv
+qH
+yM
 zt
 zt
 zt
@@ -53699,13 +53779,13 @@ CW
 zt
 zt
 zt
-zt
-zt
-zt
-zt
-zt
-zt
-zt
+Ll
+Ll
+Ll
+Ll
+Ll
+Ll
+Ll
 zt
 zt
 zt
@@ -55498,18 +55578,18 @@ TI
 pS
 pS
 pS
-Lz
-pA
-Lz
+pS
+tw
+pS
 Cm
-Lz
+pS
 pA
-Lz
 pS
 pS
 pS
-Lz
-Lz
+pS
+pS
+pS
 TI
 TI
 Nd
@@ -71940,7 +72020,7 @@ BO
 SI
 ZF
 Wr
-Zd
+Bb
 qx
 qx
 Zt
@@ -71953,7 +72033,7 @@ Lo
 ZD
 Pu
 wh
-TQ
+Fk
 TQ
 qx
 Nz
@@ -72210,7 +72290,7 @@ Lo
 ZD
 Pu
 wh
-TQ
+Fm
 TQ
 qx
 Mj
@@ -72711,7 +72791,7 @@ BO
 WK
 ZD
 ZD
-Vi
+Bd
 qx
 wZ
 Zj
@@ -72968,7 +73048,7 @@ BO
 SI
 ZF
 Wr
-vp
+Bj
 qx
 Dy
 Zj
@@ -73225,7 +73305,7 @@ BO
 WK
 ZD
 ZD
-Vi
+Bo
 qx
 wZ
 Zj
@@ -73996,7 +74076,7 @@ BO
 SI
 ZF
 Wr
-Fk
+BW
 qx
 qx
 Zt
@@ -75535,7 +75615,7 @@ No
 vh
 wn
 qx
-TU
+ye
 ZD
 ZD
 NK
@@ -75795,7 +75875,7 @@ ta
 ZD
 ZD
 ZD
-Im
+Cg
 qx
 ZD
 ZD
@@ -77066,13 +77146,13 @@ BO
 pz
 vh
 sU
-Bd
+vp
 RU
 Rr
 PH
 Dd
 Ua
-SX
+wR
 ly
 vh
 sU
@@ -77848,7 +77928,7 @@ lm
 lm
 ll
 qx
-RG
+zw
 ND
 QO
 ug


### PR DESCRIPTION
## About The Pull Request

Ghost cafe changes: 
- moves the slot machines that were *right in front of the doors with goddamn walls to walk into* to beneath the pool
- protects the rest of the cafe from any gas problems via invisible tiny fans (you may trust them but I don't, especially since I've seen three rounds in a row now where someone lit up plasma in the cafe and it heated it up)
- moves the giant table a teensy bit to the right and up a bit
- downsizes the disco floor a bit because nobody needs that much room
- removes some of the pets because you don't need every fucking pet there
- adds a paper wall divide between the giant table area and the small tables area

CC changes:
plushies.


# All the plushies.


specifically the staff ones because nobody ever uses the prize machine and so they never see the staff plushies, now they can be seen every round in cc yay.

## Why It's Good For The Game

the about the pull request should cover this

## Changelog
:cl:
tweak: ghost cafe tweaks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
