### PR TITLE
Fixes nitryl breathing, improves stimulum somewhat

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -41,7 +41,7 @@
 	return NO_REACTION
 
 /datum/gas_reaction/nobliumsupression
-	priority = 5000 // Skyrat: ALWAYS FIRST (except for noblium formation)
+	priority = INFINITY
 	name = "Hyper-Noblium Reaction Suppression"
 	id = "nobstop"
 
@@ -388,7 +388,7 @@
 		return REACTING
 
 /datum/gas_reaction/nobliumformation //Hyper-Noblium formation is extrememly endothermic, but requires high temperatures to start. Due to its high mass, hyper-nobelium uses large amounts of nitrogen and tritium. BZ can be used as a catalyst to make it less endothermic.
-	priority = 5001 // Skyrat edit: priority changed so noblium doesn't stop noblium formation
+	priority = 6
 	name = "Hyper-Noblium condensation"
 	id = "nobformation"
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -41,7 +41,7 @@
 	return NO_REACTION
 
 /datum/gas_reaction/nobliumsupression
-	priority = INFINITY
+	priority = 5000 // Skyrat: ALWAYS FIRST (except for noblium formation)
 	name = "Hyper-Noblium Reaction Suppression"
 	id = "nobstop"
 
@@ -388,7 +388,7 @@
 		return REACTING
 
 /datum/gas_reaction/nobliumformation //Hyper-Noblium formation is extrememly endothermic, but requires high temperatures to start. Due to its high mass, hyper-nobelium uses large amounts of nitrogen and tritium. BZ can be used as a catalyst to make it less endothermic.
-	priority = 6
+	priority = 5001 // Skyrat edit: priority changed so noblium doesn't stop noblium formation
 	name = "Hyper-Noblium condensation"
 	id = "nobformation"
 

--- a/code/modules/movespeed/modifiers/reagents.dm
+++ b/code/modules/movespeed/modifiers/reagents.dm
@@ -12,3 +12,6 @@
 
 /datum/movespeed_modifier/reagent/nitryl
 	multiplicative_slowdown = -1
+
+/datum/movespeed_modifier/reagent/stimulum // skyrat edit
+	multiplicative_slowdown = -1 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1454,10 +1454,12 @@
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()
+	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulum) // Skyrat
 	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 
 /datum/reagent/stimulum/on_mob_end_metabolize(mob/living/L)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/stimulum) // Skyrat
 	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -338,7 +338,8 @@
 			H.adjustFireLoss(nitryl_pp/4)
 		gas_breathed = breath_gases[/datum/gas/nitryl]
 		if (gas_breathed > gas_stimulation_min)
-			H.reagents.add_reagent(/datum/reagent/nitryl,1)
+			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitryl) // Skyrat edit: makes it actually spawn enough reagent to have an effect
+			H.reagents.add_reagent(/datum/reagent/nitryl, max(0, 5 - existing))
 
 		breath_gases[/datum/gas/nitryl]-=gas_breathed
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bugfixed nitryl breathing, and gives stimulum a slight buff to be more worth the effort it takes to make. Yay atmos.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Right now, stimulum really isn't worth the effort it takes to make, and nitryl breathing straight up doens't work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Breathing stimulum gives a slight movespeed increase, like with nitryl.
fix: Breathing nitryl actually works now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
