### PR TITLE
Some small changes to make the particle defender more in line with other shotguns.

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -153,7 +153,7 @@
 
 /obj/item/ammo_casing/energy/laser/pump
 	projectile_type = /obj/item/projectile/beam/pump
-	e_cost = 350
+	e_cost = 120
 	select_name = "kill"
 	pellets = 6
 	variance = 15
@@ -163,7 +163,7 @@
 	projectile_type = /obj/item/projectile/energy/disabler/pump
 	select_name = "disable"
 	fire_sound = 'sound/weapons/LaserSlugv3.ogg'
-	e_cost = 150
+	e_cost = 80
 	pellets = 6
 	variance = 20
 
@@ -182,12 +182,12 @@
 	icon_state = "disablerslug"
 
 /obj/item/projectile/beam/pump
-	damage = 9
+	damage = 12
 	range = 6
 
 /obj/item/projectile/energy/disabler/pump
 	name = "disabling blast"
 	icon_state = "disablerslug"
 	color = null
-	stamina = 13
+	stamina = 15
 	range = 6

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -153,7 +153,7 @@
 
 /obj/item/ammo_casing/energy/laser/pump
 	projectile_type = /obj/item/projectile/beam/pump
-	e_cost = 120
+	e_cost = 200
 	select_name = "kill"
 	pellets = 6
 	variance = 15
@@ -163,7 +163,7 @@
 	projectile_type = /obj/item/projectile/energy/disabler/pump
 	select_name = "disable"
 	fire_sound = 'sound/weapons/LaserSlugv3.ogg'
-	e_cost = 80
+	e_cost = 120
 	pellets = 6
 	variance = 20
 
@@ -182,7 +182,7 @@
 	icon_state = "disablerslug"
 
 /obj/item/projectile/beam/pump
-	damage = 12
+	damage = 10
 	range = 6
 
 /obj/item/projectile/energy/disabler/pump


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This increases the number of shots the particle defender can fire before needing to recharge as well as slightly increasing the damage to be more in line with rubbershot and buckshot for both modes. 
edit: Disable mode allows for 10 shots with 90 stamina damage if all beams hit. Originally 8 shots with 78.
edit: Kill mode allows for 6 shots with 60 burn damage if all beams hit. Originally 3 shots with 54.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This makes the warden's particle defender more on par with other shotguns, increasing margin for error and making for a far scarier weapon to be up against.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: adjusts number of shots and damage the particle defender has.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
