### PR TITLE
AI/Cyborgs no longer need to directly click the door sprite to interact with it.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -129,8 +129,8 @@
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
 		if(airlock)
 			airlock.AICtrlClick(src)
-		A.AICtrlClick(src)
-	A.AICtrlClick(src) // End of skyrat edit
+	else
+		A.AICtrlClick(src) // End of skyrat edit
 
 /mob/living/silicon/ai/AltClickOn(var/atom/A)
 	if(!A.AIAltClick(src))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -121,8 +121,8 @@
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
 		if(airlock)
 			airlock.AIShiftClick(src)
-		A.AIShiftClick(src)
-	A.AIShiftClick(src) // End of skyrat edit
+	else
+		A.AIShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/ai/CtrlClickOn(var/atom/A)
 	if(isturf(A)) // Skyrat edit

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -113,8 +113,8 @@
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
 		if(airlock)
 			airlock.AICtrlShiftClick(src)
-		A.AICtrlShiftClick(src)
-	A.AICtrlShiftClick(src) // End of skyrat edit
+	else
+		A.AICtrlShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
 	if(isturf(A)) // Skyrat edit

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -109,26 +109,29 @@
 */
 
 /mob/living/silicon/ai/CtrlShiftClickOn(var/atom/A)
-	A.AICtrlShiftClick(src)
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
-	if(airlock)
-		airlock.AICtrlShiftClick(src)
-	return // End of skyrat edit
+	if(isturf(A)) // Skyrat edit
+		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
+		if(airlock)
+			airlock.AICtrlShiftClick(src)
+		A.AICtrlShiftClick(src)
+	A.AICtrlShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
-	A.AIShiftClick(src)
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
-	if(airlock)
-		airlock.AIShiftClick(src)
-	return // End of skyrat edit 
+		if(isturf(A)) // Skyrat edit
+		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
+		if(airlock)
+			airlock.AIShiftClick(src)
+		A.AIShiftClick(src)
+	A.AIShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/ai/CtrlClickOn(var/atom/A)
-	A.AICtrlClick(src)
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A    // Skyrat edit 
-	if(airlock)                              
-		airlock.AICtrlClick(src)
-	return // End of skyrat edit
-	
+	if(isturf(A)) // Skyrat edit
+		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
+		if(airlock)
+			airlock.AICtrlClick(src)
+		A.AICtrlClick(src)
+	A.AICtrlClick(src) // End of skyrat edit
+
 /mob/living/silicon/ai/AltClickOn(var/atom/A)
 	if(!A.AIAltClick(src))
 		altclick_listed_turf(A)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -110,11 +110,26 @@
 
 /mob/living/silicon/ai/CtrlShiftClickOn(var/atom/A)
 	A.AICtrlShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AICtrlShiftClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
 	A.AIShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AIShiftClick(src)
+	return // End of skyrat edit 
+
 /mob/living/silicon/ai/CtrlClickOn(var/atom/A)
 	A.AICtrlClick(src)
-/mob/living/silicon/ai/AltClickOn(var/atom/A)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A    // Skyrat edit 
+	if(airlock)                              
+		airlock.AICtrlClick(src)
+	return // End of skyrat edit
+	
+	/mob/living/silicon/ai/AltClickOn(var/atom/A)
 	if(!A.AIAltClick(src))
 		altclick_listed_turf(A)
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -129,7 +129,7 @@
 		airlock.AICtrlClick(src)
 	return // End of skyrat edit
 	
-	/mob/living/silicon/ai/AltClickOn(var/atom/A)
+/mob/living/silicon/ai/AltClickOn(var/atom/A)
 	if(!A.AIAltClick(src))
 		altclick_listed_turf(A)
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -117,7 +117,7 @@
 	A.AICtrlShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/ai/ShiftClickOn(var/atom/A)
-		if(isturf(A)) // Skyrat edit
+	if(isturf(A)) // Skyrat edit
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A 
 		if(airlock)
 			airlock.AIShiftClick(src)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -108,8 +108,8 @@
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
 		if(airlock)
 			airlock.BorgCtrlShiftClick(src)
-		A.BorgCtrlShiftClick(src)
-	A.BorgCtrlShiftClick(src) // End of skyrat edit
+	else
+		A.BorgCtrlShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
 	if(isturf(A)) // Skyrat edit

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -116,8 +116,8 @@
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
 		if(airlock)
 			airlock.BorgShiftClick(src)
-		A.BorgShiftClick(src)
-	A.BorgShiftClick(src) // End of skyrat edit
+	else
+		A.BorgShiftClick(src) // End of skyrat edit
 	
 /mob/living/silicon/robot/CtrlClickOn(atom/A)
 	if(isturf(A)) // Skyrat edit

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -124,8 +124,8 @@
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
 		if(airlock)
 			airlock.BorgCtrlClick(src)
-		A.BorgCtrlClick(src)
-	A.BorgCtrlClick(src) // End of skyrat edit
+	else
+		A.BorgCtrlClick(src) // End of skyrat edit
 
 /mob/living/silicon/robot/AltClickOn(atom/A)
 	if(!A.BorgAltClick(src))

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -105,10 +105,26 @@
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
 	A.BorgCtrlShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AICtrlShiftClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
 	A.BorgShiftClick(src)
+	A.AIShiftClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AIShiftClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/robot/CtrlClickOn(atom/A)
 	A.BorgCtrlClick(src)
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+	if(airlock)
+		airlock.AICtrlClick(src)
+	return // End of skyrat edit
+
 /mob/living/silicon/robot/AltClickOn(atom/A)
 	if(!A.BorgAltClick(src))
 		altclick_listed_turf(A)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -111,19 +111,20 @@
 	return // End of skyrat edit
 
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
-	A.BorgShiftClick(src)
-	A.AIShiftClick(src)
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
-	if(airlock)
-		airlock.AIShiftClick(src)
-	return // End of skyrat edit
-
+	if(isturf(A)) // Skyrat edit
+		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+		if(airlock)
+			airlock.BorgShiftClick(src)
+		A.BorgShiftClick(src)
+	A.BorgShiftClick(src) // End of skyrat edit
+	
 /mob/living/silicon/robot/CtrlClickOn(atom/A)
-	A.BorgCtrlClick(src)
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
-	if(airlock)
-		airlock.AICtrlClick(src)
-	return // End of skyrat edit
+	if(isturf(A)) // Skyrat edit
+		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+		if(airlock)
+			airlock.BorgCtrlClick(src)
+		A.BorgCtrlClick(src)
+	A.BorgCtrlClick(src) // End of skyrat edit
 
 /mob/living/silicon/robot/AltClickOn(atom/A)
 	if(!A.BorgAltClick(src))

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -104,11 +104,12 @@
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
-	A.BorgCtrlShiftClick(src)
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
-	if(airlock)
-		airlock.AICtrlShiftClick(src)
-	return // End of skyrat edit
+	if(isturf(A)) // Skyrat edit
+		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in A // Skyrat edit
+		if(airlock)
+			airlock.BorgCtrlShiftClick(src)
+		A.BorgCtrlShiftClick(src)
+	A.BorgCtrlShiftClick(src) // End of skyrat edit
 
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
 	if(isturf(A)) // Skyrat edit


### PR DESCRIPTION


## About The Pull Request
AI/Cyborgs no longer have to directly press the sprite of the door to use their shortcut bolt/close/emergency acces
Thanks  to Bob Joga for helping with the code.
## Why It's Good For The Game
QoL for any AI/Cyborg player , there is no longer a need to shift the mouse a few pixels to close a door
## Changelog
:cl:
add:AI/Cyborgs no longer are required to click the door sprite to close/bolt/emergency acces them.
/:cl:

