### PR TITLE
Check the bloodsucker flag Dynamic!!

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -201,7 +201,7 @@
 	name = "Bloodsucker Infiltrator"
 	config_tag = "latejoin_bloodsucker"
 	antag_datum = ANTAG_DATUM_BLOODSUCKER
-	antag_flag = ROLE_TRAITOR
+	antag_flag = ROLE_BLOODSUCKER
 	restricted_roles = list("AI", "Cyborg")
 	protected_roles = list("Security Officer", "Warden", "Detective", "Brig Physician", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 	required_candidates = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Finally... people who have traitor enabled won't have to worry about randomly having bloodsucker bestowed upon them.
This also counts that dynamic won't force it on those that are jobbanned from bloodsucker.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dynamic will no longer think that bloodsuckers are fancy traitors
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Bloodsucker's won't be forced on those who have the preference turned off anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
