### PR TITLE
Makes Cling Hivemind free

### DIFF
--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -3,7 +3,7 @@
 	name = "Hivemind Communication"
 	desc = "We tune our senses to the airwaves to allow us to discreetly communicate and exchange DNA with other changelings."
 	helptext = "We will be able to talk with other changelings with :g. Exchanged DNA do not count towards absorb objectives." //MODE_TOKEN_CHANGELING needs to be manually updated here.
-	dna_cost = 1
+	dna_cost = 0	//Skyrats change. Clings not having Cloud storage for DNA entices murderbone. 
 	chemical_cost = -1
 	action_icon = 'icons/mob/actions/actions_xeno.dmi'
 	action_icon_state = "alien_whisper"


### PR DESCRIPTION
## About The Pull Request

Lowers DNA cost of Cling Hivemind, Hive Channel and Hive absorb to 0. 

## Why It's Good For The Game

Hive Channel is essentially cloud storage for genomes. It allows lings to store infinite genomes via DNA extraction sting. How to: Channel initial form. Go DNA sting people till at capacity. Change form. Channel all the forms. Reabsorb/Hive absorb your initial form. Free disguises, good for frame jobs and causing chaos. Hopefully should entice a less murderbony advance on "getting more genomes"

## Changelog
:cl:
balance: Shitlings can now get their hive absorb, hive channel and hivetalk ability for free again.
/:cl:


