### PR TITLE
Ports updates to railings from tg

### DIFF
--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -435,8 +435,8 @@
 /area/engine/atmos)
 "bm" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
-	icon_state = "mvalve_map-2";
-	dir = 4
+	dir = 4;
+	icon_state = "mvalve_map-2"
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -1502,8 +1502,8 @@
 /area/engine/storage)
 "gK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	icon_state = "connector_map-2";
-	dir = 8
+	dir = 8;
+	icon_state = "connector_map-2"
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
@@ -1512,10 +1512,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"hh" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/construction)
 "hi" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	icon_state = "inje_map-2";
-	dir = 4
+	dir = 4;
+	icon_state = "inje_map-2"
 	},
 /turf/open/floor/plating,
 /area/construction)
@@ -1553,10 +1559,16 @@
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"jm" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/construction)
 "jA" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 8
+	dir = 8;
+	icon_state = "warningline_white"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1567,8 +1579,8 @@
 /area/construction)
 "jV" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 6
+	dir = 6;
+	icon_state = "warningline_white"
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -1581,12 +1593,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"kt" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "lu" = (
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"lY" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/storage)
 "mZ" = (
 /turf/open/floor/plasteel{
 	dir = 4
@@ -1632,13 +1656,23 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"qf" = (
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "qo" = (
 /turf/open/openspace,
 /area/engine/storage)
 "qR" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 9
+	dir = 9;
+	icon_state = "warningline_white"
+	},
+/obj/structure/railing/corner{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -1659,14 +1693,24 @@
 /area/construction)
 "sE" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 4
+	dir = 4;
+	icon_state = "warningline_white"
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
 "td" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
+	dir = 8;
+	icon_state = "warningline_white"
+	},
+/turf/open/floor/plating,
+/area/engine/storage)
+"tQ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	icon_state = "warningline_white"
+	},
+/obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -1694,6 +1738,15 @@
 /obj/item/construction/rcd/combat/admin,
 /turf/open/floor/plasteel,
 /area/construction)
+"xb" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "xr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1704,8 +1757,8 @@
 /area/construction)
 "xB" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 1
+	dir = 1;
+	icon_state = "warningline_white"
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -1720,10 +1773,20 @@
 /area/construction)
 "zZ" = (
 /obj/structure/disposalpipe/trunk{
-	icon_state = "pipe-t";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-t"
 	},
 /obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/construction)
+"Az" = (
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
+"AB" = (
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/construction)
 "AG" = (
@@ -1757,11 +1820,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"Cy" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/storage)
+"CJ" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "CK" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"CO" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/construction)
 "Dm" = (
 /obj/machinery/light{
 	dir = 1
@@ -1782,18 +1864,24 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
 /area/engine/storage)
+"Ex" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "EF" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/construction)
 "EH" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 1
+	dir = 1;
+	icon_state = "warningline_white"
 	},
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 4
+	dir = 4;
+	icon_state = "warningline_white"
 	},
 /turf/open/floor/plating,
 /area/engine/storage)
@@ -1804,8 +1892,8 @@
 "FL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
-	icon_state = "pipe11-2";
-	dir = 4
+	dir = 4;
+	icon_state = "pipe11-2"
 	},
 /turf/open/floor/plating,
 /area/construction)
@@ -1896,8 +1984,8 @@
 /area/engine/storage)
 "Qo" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
-	icon_state = "pipe-down";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-down"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
@@ -1945,6 +2033,19 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/construction)
+"VP" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/storage)
+"WD" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction)
 "WN" = (
 /obj/machinery/light{
 	dir = 8
@@ -1960,14 +2061,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"Zg" = (
+/obj/structure/railing/corner,
+/turf/open/floor/plating,
+/area/hallway/secondary/service)
 "ZH" = (
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/plating,
 /area/construction)
 "ZQ" = (
 /obj/effect/turf_decal/stripes/white/line{
-	icon_state = "warningline_white";
-	dir = 5
+	dir = 5;
+	icon_state = "warningline_white"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3036,8 +3141,8 @@ Tf
 Tf
 Tf
 Tf
-Tf
-Tf
+jm
+CO
 dL
 cN
 af
@@ -3091,7 +3196,7 @@ Tf
 Tf
 Tf
 sm
-Tf
+AB
 dL
 cN
 af
@@ -3144,8 +3249,8 @@ Tf
 Tf
 Tf
 Tf
-Tf
-Tf
+WD
+hh
 ij
 cN
 af
@@ -5844,8 +5949,8 @@ XN
 XN
 XN
 XN
-XN
-XN
+Zg
+kt
 XN
 eL
 TY
@@ -5898,7 +6003,7 @@ LE
 IC
 jb
 XN
-XN
+Az
 iu
 XN
 eL
@@ -5952,8 +6057,8 @@ Zc
 XN
 XN
 XN
-XN
-XN
+qf
+xb
 XN
 eL
 TY
@@ -6006,7 +6111,7 @@ XN
 XN
 XN
 XN
-XN
+Az
 av
 XN
 eL
@@ -6060,8 +6165,8 @@ XN
 XN
 XN
 XN
-XN
-XN
+CJ
+Ex
 XN
 Kw
 TY
@@ -8762,8 +8867,8 @@ TH
 TH
 Pu
 TH
-TH
-Eb
+lY
+Cy
 qo
 qo
 qo
@@ -8817,7 +8922,7 @@ TH
 TH
 TH
 qo
-Eb
+VP
 qo
 qo
 qo
@@ -8870,7 +8975,7 @@ sE
 sE
 sE
 sE
-sE
+tQ
 qR
 qo
 qo

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1254,6 +1254,10 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 			var/obj/structure/window/W = O
 			if(W.ini_dir == dir_to_check || W.ini_dir == FULLTILE_WINDOW_DIR || dir_to_check == FULLTILE_WINDOW_DIR)
 				return FALSE
+		if(istype(O, /obj/structure/railing))
+			var/obj/structure/railing/rail = O
+			if(rail.ini_dir == dir_to_check || rail.ini_dir == FULLTILE_WINDOW_DIR || dir_to_check == FULLTILE_WINDOW_DIR)
+				return FALSE
 	return TRUE
 
 /proc/pass()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("scooter frame", /obj/item/scooter_frame, 10, time = 25, one_per_turf = 0), \
+	new/datum/stack_recipe("railing", /obj/structure/railing, 3, time = 18, window_checks = TRUE), \
 	))
 
 /obj/item/stack/rods

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -193,19 +193,6 @@
 	density = TRUE
 	deconstructible = FALSE
 
-/obj/structure/fluff/railing
-	name = "railing"
-	desc = "Basic railing meant to protect idiots like you from falling."
-	icon = 'icons/obj/fluff.dmi'
-	icon_state = "railing"
-	density = TRUE
-	anchored = TRUE
-	deconstructible = FALSE
-
-/obj/structure/fluff/railing/corner
-	icon_state = "railing_corner"
-	density = FALSE
-
 /obj/structure/fluff/beach_towel
 	name = "beach towel"
 	desc = "A towel decorated in various beach-themed designs."

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -1,0 +1,109 @@
+/obj/structure/railing
+	name = "railing"
+	desc = "Basic railing meant to protect idiots like you from falling."
+	icon = 'icons/obj/fluff.dmi'
+	icon_state = "railing"
+	density = TRUE
+	anchored = TRUE
+	climbable = TRUE
+	///Initial direction of the railing.
+	var/ini_dir
+
+/obj/structure/railing/corner //aesthetic corner sharp edges hurt oof ouch
+	icon_state = "railing_corner"
+	density = FALSE
+	climbable = FALSE
+
+/obj/structure/railing/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+
+/obj/structure/railing/Initialize()
+	. = ..()
+	ini_dir = dir
+
+/obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
+	..()
+	add_fingerprint(user)
+
+	if(I.tool_behaviour == TOOL_WELDER && user.a_intent == INTENT_HELP)
+		if(obj_integrity < max_integrity)
+			if(!I.tool_start_check(user, amount=0))
+				return
+
+			to_chat(user, "<span class='notice'>You begin repairing [src]...</span>")
+			if(I.use_tool(src, user, 40, volume=50))
+				obj_integrity = max_integrity
+				to_chat(user, "<span class='notice'>You repair [src].</span>")
+		else
+			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
+		return
+
+/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(!anchored)
+		to_chat(user, "<span class='warning'>You cut apart the railing.</span>")
+		I.play_tool_sound(src, 100)
+		deconstruct()
+		return TRUE
+
+/obj/structure/railing/deconstruct(disassembled)
+	. = ..()
+	if(!loc) //quick check if it's qdeleted already.
+		return
+	if(!(flags_1 & NODECONSTRUCT_1))
+		var/obj/item/stack/rods/rod = new /obj/item/stack/rods(drop_location(), 3)
+		transfer_fingerprints_to(rod)
+		qdel(src)
+///Implements behaviour that makes it possible to unanchor the railing.
+/obj/structure/railing/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(flags_1&NODECONSTRUCT_1)
+		return
+	to_chat(user, "<span class='notice'>You begin to [anchored ? "unfasten the railing from":"fasten the railing to"] the floor...</span>")
+	if(I.use_tool(src, user, volume = 75, extra_checks = CALLBACK(src, .proc/check_anchored, anchored)))
+		setAnchored(!anchored)
+		to_chat(user, "<span class='notice'>You [anchored ? "fasten the railing to":"unfasten the railing from"] the floor.</span>")
+	return TRUE
+
+/obj/structure/railing/CanPass(atom/movable/mover, turf/target)
+	. = ..()
+	if(get_dir(loc, target) & dir)
+		var/checking = FLYING | FLOATING
+		return . || mover.movement_type & checking
+	return TRUE
+
+/obj/structure/railing/corner/CanPass()
+	..()
+	return TRUE
+
+/obj/structure/railing/CheckExit(atom/movable/mover, turf/target)
+	..()
+	if(get_dir(loc, target) & dir)
+		var/checking = UNSTOPPABLE | FLYING | FLOATING
+		return !density || mover.movement_type & checking || mover.move_force >= MOVE_FORCE_EXTREMELY_STRONG
+	return TRUE
+
+/obj/structure/railing/corner/CheckExit()
+	return TRUE
+
+/obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
+	if(anchored)
+		to_chat(user, "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>")
+		return FALSE
+
+	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
+
+	if(!valid_window_location(loc, target_dir)) //Expanded to include rails, as well!
+		to_chat(user, "<span class='warning'>[src] cannot be rotated in that direction!</span>")
+		return FALSE
+	return TRUE
+
+/obj/structure/railing/proc/check_anchored(checked_anchored)
+	if(anchored == checked_anchored)
+		return TRUE
+
+/obj/structure/railing/proc/after_rotation(mob/user,rotation_type)
+	air_update_turf(1)
+	ini_dir = dir
+	add_fingerprint(user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1212,6 +1212,7 @@
 #include "code\game\objects\structures\noticeboard.dm"
 #include "code\game\objects\structures\petrified_statue.dm"
 #include "code\game\objects\structures\plasticflaps.dm"
+#include "code\game\objects\structures\railings.dm"
 #include "code\game\objects\structures\reflector.dm"
 #include "code\game\objects\structures\safe.dm"
 #include "code\game\objects\structures\showcase.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Railings are now an actual object instead of just fluff for maps. Can be constructed with rods and behaves similar to directional windows. Except that you can climb over them (drag your sprite onto them) and they don't block atmos.

Ported from the following PR's:
https://github.com/tgstation/tgstation/pull/49171/files
https://github.com/tgstation/tgstation/pull/50655/files
https://github.com/tgstation/tgstation/pull/52068/files
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More nifty stuff for any future multiz work. Also added an example of the railings + corners to the multiz test map
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MMMiracles, ArcaneMusic, MrMelbert, ported by coldud13
add: Railings can now be constructed with rods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
