### PR TITLE
(FUCK) Bloodbrothers are gone :crab:

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -48,7 +48,7 @@
 //           BLOOD BROTHERS             //
 //                                      //
 //////////////////////////////////////////
-
+/*
 /datum/dynamic_ruleset/roundstart/traitorbro
 	name = "Blood Brothers"
 	config_tag = "traitorbro"
@@ -91,6 +91,7 @@
 		team.update_name()
 	mode.brother_teams += pre_brother_teams
 	return TRUE
+*/
 
 //////////////////////////////////////////////
 //                                          //


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bloodbrothers is a horrible gamemode made to torture people. All it does is make people adminhelp for an antag trade for traitor. Or cryo. One of the two.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bloodbrothers only spawns like two to three pairs of people (4-6 antags) which have no gear, essentially no way to combat sec without ((powergaming)) and is unironically one of the most hated and despised gamemodes of all time on RP servers because it becomes literally impossible to do anything. Its not worth its threat cost, and should ideally be something thats also bundled with traitors in the round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Commented out bloodbrothers. I hate those guys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
