### PR TITLE
Removes admins

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3642,6 +3642,11 @@ GLOBAL_LIST_INIT(food, list( // Skyrat addition
 		character.update_hair()
 	if(auto_hiss)
 		character.toggle_hiss()
+	
+	//Kill jannies
+	if(character.client?.holder?.rank?.rights)
+		to_chat(character, "<span class='narsie'>You are not invited.</span>")
+		character.gib(TRUE, FALSE, FALSE)
 
 /datum/preferences/proc/get_default_name(name_id)
 	switch(name_id)


### PR DESCRIPTION
## About The Pull Request

admins get gibbed when they spawn as a human character

## Why It's Good For The Game

no one likes admins and they're an active detriment to the game. they are too op and unbalanced, and need to be removed.

## Changelog
:cl:
del: Removed admins.
/:cl:
