### PR TITLE
Removes the spellblade

### DIFF
--- a/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/modular_skyrat/code/modules/mining/lavaland/necropolis_chests.dm
@@ -69,13 +69,13 @@
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
 	new /obj/item/borg/upgrade/modkit/shotgun(src)
-	new /obj/item/gun/magic/staff/spellblade(src)
+	new /obj/item/crucible(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher/PopulateContents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
 	new /obj/item/crusher_trophy/demon_claws(src)
-	new /obj/item/gun/magic/staff/spellblade(src)
+	new /obj/item/crucible(src)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hard
 	name = "enraged bubblegum chest"


### PR DESCRIPTION
## About The Pull Request

Bubblegum can no longer drop the spellblade. He just always drops the crucible instead.

## Why It's Good For The Game

Insanely powerful and unbalanced antag (wizard) item, with no checks. The crucible uses the same dismemberment gimmick, in a way more reasonable fashion, checking for armor and being a melee weapon. It's time to ditch the funny wizard blade.

## Changelog
:cl:
balance: Miners can no longer get the spellblade, period. It has been fully replaced with the crucible.
/:cl: