### PR TITLE
2 Pirate bugfixes

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -97,7 +97,7 @@
 	var/active = FALSE
 	var/obj/item/gps/gps
 	var/credits_stored = 0
-	var/siphon_per_tick = 5
+	var/siphon_per_tick = 250 // Steals 7,500 per minute (on SSmachine's 2s tickrate). Enough to be a significant problem, not enough to be instawin.
 
 /obj/machinery/shuttle_scrambler/Initialize(mapload)
 	. = ..()
@@ -112,6 +112,7 @@
 			if(D)
 				var/siphoned = min(D.account_balance,siphon_per_tick)
 				D.adjust_money(-siphoned)
+				credits_stored += siphoned
 			interrupt_research()
 		else
 			return
@@ -137,6 +138,13 @@
 		send_notification()
 	else
 		dump_loot(user)
+
+/obj/machinery/shuttle_scrambler/AltClick(mob/user)
+	toggle_off()
+
+/obj/machinery/shuttle_scrambler/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It can be toggled off with an alt-click.</span>"
 
 //interrupt_research
 /obj/machinery/shuttle_scrambler/proc/interrupt_research()
@@ -352,6 +360,12 @@
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue
+
+		if(istype(AM, /mob/living/carbon/)) // Don't hostage our own pirate crew, please.
+			var/mob/living/carbon/C = AM
+			if(C.mind && C.mind.assigned_role == "Space Pirate")
+				continue
+
 		export_item_and_contents(AM, EXPORT_PIRATE | EXPORT_CARGO | EXPORT_CONTRABAND | EXPORT_EMAG, apply_elastic = FALSE, delete_unsold = FALSE, external_report = ex)
 
 	status_report = "Sold:<br>"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -97,7 +97,7 @@
 	var/active = FALSE
 	var/obj/item/gps/gps
 	var/credits_stored = 0
-	var/siphon_per_tick = 250 // Steals 7,500 per minute (on SSmachine's 2s tickrate). Enough to be a significant problem, not enough to be instawin.
+	var/siphon_per_tick = 200 // Steals 6000 per minute (on SSmachine's 2s tickrate). Enough to be a significant problem, not enough to be instawin.
 
 /obj/machinery/shuttle_scrambler/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. You can no longer send your own pirate crew to ~~Brazil~~ the cargo hold.
2. The credit siphon now genuinely stores and vends the credits you steal, also upped the rate to ~~7500~~ 6000/min.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rattle me bones

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Space Pirates can no longer ransom their own crew for 1k credits. (generally by accident)
fix: The space pirate credit siphon now siphons at 6000 cr/min. It also actually works now, and can be toggled off with an alt-click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
