### PR TITLE
Improvements to unconsciouness messages on examine

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -203,6 +203,7 @@
 	
 	//CONSCIOUSNESS
 	var/dist = get_dist(user, src)
+	var/damage = (getBruteLoss() + getFireLoss()) //If we are very damaged, it's easier to recognize whether or not we are dead
 	var/consciousness = LOOKS_CONSCIOUS
 
 	var/mob/living/carbon/human/H = user
@@ -216,13 +217,13 @@
 	if(has_health_hud)
 		if(IsSleeping())
 			consciousness = LOOKS_SLEEPY
-			consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+			consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be asleep."
 		if(InCritical())
 			consciousness = LOOKS_UNCONSCIOUS
-			consciousness_msg = "<span class='warning'>[t_His] life signs are shallow and labored[lying ? ", and [t_he] is unconscious" : ""].</span>"
+			consciousness_msg = "<span class='warning'>[t_His] life signs are shallow and labored[IsUnconscious() ? ", and [t_he] is unconscious" : ""].</span>"
 		if(InFullCritical())
 			consciousness = LOOKS_VERYUNCONSCIOUS
-			consciousness_msg = "<span class='warning'>[t_His] life signs are very shallow and labored, [lying ? "[t_he] is completely unconscious and " : ""][t_he] appears to be undergoing shock.</span>"
+			consciousness_msg = "<span class='warning'>[t_His] life signs are very shallow and labored, [IsUnconscious() ? "[t_he] is completely unconscious and " : ""][t_he] appears to be undergoing shock.</span>"
 		if(stat == DEAD)
 			consciousness = LOOKS_DEAD
 			consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[(length(bleeding_limbs) && !(mob_biotypes & MOB_UNDEAD)) || (length(bleeding_limbs) && (mob_biotypes & MOB_UNDEAD) && (stat == DEAD)) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
@@ -235,25 +236,27 @@
 	else
 		if(IsSleeping() || HAS_TRAIT(src, TRAIT_LOOKSSLEEPY) || (consciousness == LOOKS_SLEEPY))
 			consciousness = LOOKS_SLEEPY
-			if((dist <= 3) || (dist <= 7 && lying))
-				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+			if(dist <= 2)
+				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be asleep."
+			else if(dist <= 10)
+				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 		if(InCritical() || HAS_TRAIT(src, TRAIT_LOOKSUNCONSCIOUS) || (consciousness == LOOKS_UNCONSCIOUS))
 			consciousness = LOOKS_UNCONSCIOUS
-			if(dist <= 1 && is_face_visible() && !HAS_TRAIT(src, TRAIT_NOBREATH))
-				consciousness_msg = "<span class='warning'>[t_His] breathing is shallow and labored[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
-			else if((dist <= 3) || (dist <= 7 && lying))
+			if((dist <= 2 && is_face_visible() && !HAS_TRAIT(src, TRAIT_NOBREATH)) || (damage >= 75))
+				consciousness_msg = "<span class='warning'>[t_His] breathing is shallow and labored[IsUnconscious() ? ", and [t_he] seems to be unconscious" : ""].</span>"
+			else if((dist <= 10) && IsUnconscious())
 				consciousness = LOOKS_SLEEPY
-				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 		if(InFullCritical() || HAS_TRAIT(src, TRAIT_LOOKSVERYUNCONSCIOUS) || (consciousness == LOOKS_VERYUNCONSCIOUS))
 			consciousness = LOOKS_VERYUNCONSCIOUS
-			if(dist <= 1)
-				consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable pulse[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
-			else if((dist <= 3) || (dist <= 7 && lying))
+			if((dist <= 2) || (damage >= 75))
+				consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable breath[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
+			else if((dist <= 10) && IsUnconscious())
 				consciousness = LOOKS_SLEEPY
-				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 		if((stat == DEAD) || (mob_biotypes & MOB_UNDEAD) || HAS_TRAIT(src, TRAIT_LOOKSDEAD) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || (consciousness == LOOKS_DEAD))
 			consciousness = LOOKS_DEAD
-			if((dist <= 1) || ((dist <= 3) && (mob_biotypes & MOB_UNDEAD)) || ((dist <= 7) && (mob_biotypes & MOB_UNDEAD) && lying))
+			if((dist <= 2) || (damage >= 75))
 				consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[(length(bleeding_limbs) && !(mob_biotypes & MOB_UNDEAD)) || (length(bleeding_limbs) && (mob_biotypes & MOB_UNDEAD) && (stat == DEAD)) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
 				if(suiciding)
 					consciousness_msg += "\n<span class='deadsay'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
@@ -261,8 +264,8 @@
 					consciousness_msg += "\n<span class='deadsay'>[t_His] soul seems to have been ripped out of [t_his] body.  Revival is impossible.</span>"
 				if(!getorgan(/obj/item/organ/brain) || (!key && !get_ghost(FALSE)))
 					consciousness_msg += "\n<span class='deadsay'>[t_His] body seems empty, [t_his] soul has since departed.</span>"
-			else if((dist <= 3) || (dist <= 7 && lying))
-				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+			else if(dist <= 10 && (lying || IsUnconscious()))
+				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 		
 		if(HAS_TRAIT(src, TRAIT_LOOKSCONSCIOUS))
 			consciousness = LOOKS_CONSCIOUS

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -250,13 +250,13 @@
 		if(InFullCritical() || HAS_TRAIT(src, TRAIT_LOOKSVERYUNCONSCIOUS) || (consciousness == LOOKS_VERYUNCONSCIOUS))
 			consciousness = LOOKS_VERYUNCONSCIOUS
 			if((dist <= 2) || (damage >= 75))
-				consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable breath[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
+				consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable breath[IsUnconscious() ? ", and [t_he] seems to be unconscious" : ""].</span>"
 			else if((dist <= 10) && IsUnconscious())
 				consciousness = LOOKS_SLEEPY
 				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 		if((stat == DEAD) || (mob_biotypes & MOB_UNDEAD) || HAS_TRAIT(src, TRAIT_LOOKSDEAD) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || (consciousness == LOOKS_DEAD))
 			consciousness = LOOKS_DEAD
-			if((dist <= 2) || (damage >= 75))
+			if((dist <= 2) || (damage >= 75) || (mob_biotypes & MOB_UNDEAD))
 				consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[(length(bleeding_limbs) && !(mob_biotypes & MOB_UNDEAD)) || (length(bleeding_limbs) && (mob_biotypes & MOB_UNDEAD) && (stat == DEAD)) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
 				if(suiciding)
 					consciousness_msg += "\n<span class='deadsay'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -203,8 +203,8 @@
 	
 	//CONSCIOUSNESS
 	var/dist = get_dist(user, src)
-	var/damage = (getBruteLoss() + getFireLoss()) //If we are very damaged, it's easier to recognize whether or not we are dead
 	var/consciousness = LOOKS_CONSCIOUS
+	var/damage = (getBruteLoss() + getFireLoss()) //If we are very damaged, it's easier to recognize whether or not we are dead
 
 	var/mob/living/carbon/human/H = user
 	var/has_health_hud = FALSE

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -483,13 +483,13 @@
 			if(InFullCritical() || HAS_TRAIT(src, TRAIT_LOOKSVERYUNCONSCIOUS) || (consciousness == LOOKS_VERYUNCONSCIOUS))
 				consciousness = LOOKS_VERYUNCONSCIOUS
 				if((dist <= 2) || (damage >= 75))
-					consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable breath[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
+					consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable breath[IsUnconscious() ? ", and [t_he] seems to be unconscious" : ""].</span>"
 				else if((dist <= 10) && IsUnconscious())
 					consciousness = LOOKS_SLEEPY
 					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 			if((stat == DEAD) || (mob_biotypes & MOB_UNDEAD) || HAS_TRAIT(src, TRAIT_LOOKSDEAD) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || (consciousness == LOOKS_DEAD))
 				consciousness = LOOKS_DEAD
-				if((dist <= 2) || (damage >= 75))
+				if((dist <= 2) || (damage >= 75) || (mob_biotypes & MOB_UNDEAD))
 					consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[(length(bleeding_limbs) && !(mob_biotypes & MOB_UNDEAD)) || (length(bleeding_limbs) && (mob_biotypes & MOB_UNDEAD) && (stat == DEAD)) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
 					if(suiciding)
 						consciousness_msg += "\n<span class='deadsay'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -449,16 +449,16 @@
 		if(has_health_hud)
 			if(IsSleeping())
 				consciousness = LOOKS_SLEEPY
-				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+				consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be asleep."
 			if(InCritical())
 				consciousness = LOOKS_UNCONSCIOUS
-				consciousness_msg = "<span class='warning'>[t_His] life signs are shallow and labored[lying ? ", and [t_he] is unconscious" : ""].</span>"
+				consciousness_msg = "<span class='warning'>[t_His] life signs are shallow and labored[IsUnconscious() ? ", and [t_he] is unconscious" : ""].</span>"
 			if(InFullCritical())
 				consciousness = LOOKS_VERYUNCONSCIOUS
-				consciousness_msg = "<span class='warning'>[t_His] life signs are very shallow and labored, [lying ? "[t_he] is completely unconscious and " : ""][t_he] appears to be undergoing shock.</span>"
+				consciousness_msg = "<span class='warning'>[t_His] life signs are very shallow and labored, [IsUnconscious() ? "[t_he] is completely unconscious and " : ""][t_he] appears to be undergoing shock.</span>"
 			if(stat == DEAD)
 				consciousness = LOOKS_DEAD
-				consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[length(bleeding_limbs) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
+				consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[(length(bleeding_limbs) && !(mob_biotypes & MOB_UNDEAD)) || (length(bleeding_limbs) && (mob_biotypes & MOB_UNDEAD) && (stat == DEAD)) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
 				if(suiciding)
 					consciousness_msg += "\n<span class='deadsay'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
 				if(hellbound)
@@ -468,44 +468,36 @@
 		else
 			if(IsSleeping() || HAS_TRAIT(src, TRAIT_LOOKSSLEEPY) || (consciousness == LOOKS_SLEEPY))
 				consciousness = LOOKS_SLEEPY
-				if((dist <= 3) || (dist <= 7 && lying))
-					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+				if(dist <= 2)
+					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be asleep."
+				else if(dist <= 10)
+					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 			if(InCritical() || HAS_TRAIT(src, TRAIT_LOOKSUNCONSCIOUS) || (consciousness == LOOKS_UNCONSCIOUS))
 				consciousness = LOOKS_UNCONSCIOUS
-				if(dist <= 1 && is_face_visible() && !HAS_TRAIT(src, TRAIT_NOBREATH))
-					consciousness_msg = "<span class='warning'>[t_His] breathing is shallow and labored[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
-				else if((dist <= 3) || (dist <= 7 && lying))
+				if((dist <= 2 && is_face_visible() && !HAS_TRAIT(src, TRAIT_NOBREATH)) || (damage >= 75))
+					consciousness_msg = "<span class='warning'>[t_His] breathing is shallow and labored[IsUnconscious() ? ", and [t_he] seems to be unconscious" : ""].</span>"
+				else if((dist <= 10) && IsUnconscious())
 					consciousness = LOOKS_SLEEPY
-					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 			if(InFullCritical() || HAS_TRAIT(src, TRAIT_LOOKSVERYUNCONSCIOUS) || (consciousness == LOOKS_VERYUNCONSCIOUS))
 				consciousness = LOOKS_VERYUNCONSCIOUS
-				var/thicc = FALSE
-				var/obj/item/clothing/clothes = wear_suit
-				if(clothes?.clothing_flags & THICKMATERIAL)
-					thicc = TRUE
-				else
-					clothes = w_uniform
-					if(clothes?.clothing_flags & THICKMATERIAL)
-						thicc = TRUE
-				if(NOBLOOD in dna?.species?.species_traits)
-					thicc = TRUE
-				if(dist <= 1 && !thicc)
-					consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable pulse[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
-				else if((dist <= 3) || (dist <= 7 && lying))
+				if((dist <= 2) || (damage >= 75))
+					consciousness_msg = "<span class='warning'>[t_He] seems to have no identifiable breath[lying ? ", and [t_he] seems to be unconscious" : ""].</span>"
+				else if((dist <= 10) && IsUnconscious())
 					consciousness = LOOKS_SLEEPY
-					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 			if((stat == DEAD) || (mob_biotypes & MOB_UNDEAD) || HAS_TRAIT(src, TRAIT_LOOKSDEAD) || HAS_TRAIT(src, TRAIT_FAKEDEATH) || (consciousness == LOOKS_DEAD))
 				consciousness = LOOKS_DEAD
-				if((dist <= 1) || ((dist <= 3) && (mob_biotypes & MOB_UNDEAD)) || ((dist <= 7) && (mob_biotypes & MOB_UNDEAD) && lying))
+				if((dist <= 2) || (damage >= 75))
 					consciousness_msg = "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.[(length(bleeding_limbs) && !(mob_biotypes & MOB_UNDEAD)) || (length(bleeding_limbs) && (mob_biotypes & MOB_UNDEAD) && (stat == DEAD)) ? "\n[t_His] bleeding has pooled, and is not flowing." : ""]</span>"
 					if(suiciding)
 						consciousness_msg += "\n<span class='deadsay'>[t_He] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>"
 					if(hellbound)
-						consciousness_msg += "\n<span class='deadsay'>[t_His] soul seems to have been ripped out of [t_his] body. Revival is impossible.</span>"
+						consciousness_msg += "\n<span class='deadsay'>[t_His] soul seems to have been ripped out of [t_his] body.  Revival is impossible.</span>"
 					if(!getorgan(/obj/item/organ/brain) || (!key && !get_ghost(FALSE)))
 						consciousness_msg += "\n<span class='deadsay'>[t_His] body seems empty, [t_his] soul has since departed.</span>"
-				else if((dist <= 3) || (dist <= 7 && lying))
-					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious..."
+				else if(dist <= 10 && (lying || IsUnconscious()))
+					consciousness_msg = "[t_He] [t_is]n't responding to anything around [t_him] and seems to be either asleep or unconscious. Hard to tell without getting closer."
 			
 			if(HAS_TRAIT(src, TRAIT_LOOKSCONSCIOUS))
 				consciousness = LOOKS_CONSCIOUS

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -436,6 +436,7 @@
 	//CONSCIOUSNESS
 	var/dist = get_dist(user, src)
 	var/consciousness = LOOKS_CONSCIOUS
+	var/damage = (getBruteLoss() + getFireLoss()) //If we are very damaged, it's easier to recognize whether or not we are dead
 
 	var/mob/living/carbon/human/H = user
 	var/has_health_hud = FALSE


### PR DESCRIPTION
## About The Pull Request

Title.

What this entaills is:
Thick clothing no longer impacts the message displayed. It was a fun gimmick, but now i realize it's not a good one.
It's easier to identify someone in critical condition, or dead, if their body is very visibly damaged (>= 75 brute and burn damage combined).
The text tells you to get closer if you want to get a more accurate look.
Distance for getting the simple "get closer if possible" message has been expanded from 7 to 10.
You only need to be at least 2 tiles near a person to get the more accurate message.

Other things such as having a health hud always telling you the most informative and accurate info are still true.

## Why It's Good For The Game

More informative, while still keeping it grounded in the fact that knowing whether someone is dead or alive isn't that simple.

## Changelog
:cl:
balance: Made a few changes to unconsciousness messages, to make them more informative and less confusing.
/:cl: