### PR TITLE
Removes the SWAT bepis node, moves its contents to a new cargo pack, except for the baton

### DIFF
--- a/modular_skyrat/code/modules/cargo/packs/bloat.dm
+++ b/modular_skyrat/code/modules/cargo/packs/bloat.dm
@@ -21,6 +21,22 @@
 					/obj/item/gun/energy/e_gun/stun)
 	crate_name = "swat taser crate"
 
+/datum/supply_pack/security/armory/swat_tactical
+	name = "SWAT Tactical Operations crate"
+	desc = "Contains two sets of lightweight equipment for tactical operations. Each set contains a vest, night vision helmet, mask, combat belt, and combat gloves. Requires Armory access to open."
+	cost = 6000
+	contains = list(/obj/item/clothing/head/helmet/advanced,
+					/obj/item/clothing/head/helmet/advanced,
+					/obj/item/clothing/suit/armor/vest/advanced,
+					/obj/item/clothing/suit/armor/vest/advanced,
+					/obj/item/clothing/mask/gas/sechailer/swat,
+					/obj/item/clothing/mask/gas/sechailer/swat,
+					/obj/item/storage/belt/military/assault,
+					/obj/item/storage/belt/military/assault,
+					/obj/item/clothing/gloves/tackler/combat/insulated,
+					/obj/item/clothing/gloves/tackler/combat/insulated)
+	crate_name = "swat crate"
+
 /datum/supply_pack/security/armory/woodstock
 	name = "WoodStock Classic Shotguns Crate"
 	desc = "Contains three rustic, pump action shotguns. Requires Armory access to open."

--- a/modular_skyrat/code/modules/research/designs/weapon_designs.dm
+++ b/modular_skyrat/code/modules/research/designs/weapon_designs.dm
@@ -40,17 +40,6 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-//WT-550
-/datum/design/wt550
-	name = "WT-550"
-	desc = "An outdated, but timeless, design for an SMG."
-	id = "wt550"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 2500, /datum/material/silver = 2000, /datum/material/titanium = 6000)
-	build_path = /obj/item/gun/ballistic/automatic/wt550/nopin
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
 //Black police baton
 /datum/design/blackbaton
 	name = "Black Police Baton"
@@ -59,49 +48,5 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/titanium = 5000, /datum/material/iron = 2000)
 	build_path = /obj/item/melee/classic_baton/black
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
-//Advanced armor vest
-/datum/design/adv_vest
-	name = "Advanced Armor Vest"
-	desc = "Future of law enforcement."
-	id = "adv_armor_vest"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/titanium = 5000, /datum/material/plasma = 5000, /datum/material/plastic = 2000)
-	build_path = /obj/item/clothing/suit/armor/vest/advanced
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
-//Advanced techarmor vest
-/datum/design/adv_techvest
-	name = "Advanced Techarmor Vest"
-	desc = "Post-Future of law enforcement."
-	id = "adv_armor_vest_tech"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/titanium = 9000, /datum/material/plasma = 6000, /datum/material/plastic = 3000)
-	build_path = /obj/item/clothing/suit/space/hardsuit/security_armor/cloaker
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
-//Advanced night vision helmet
-/datum/design/adv_helmet
-	name = "Night-Vision Helmet"
-	desc = "Fear of the dark."
-	id = "nv_helmet"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/titanium = 2000, /datum/material/uranium = 4000, /datum/material/plastic = 3000)
-	build_path = /obj/item/clothing/head/helmet/advanced
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
-//Combat tackle gloves
-/datum/design/gorilla_gloves
-	name = "Gorilla Gloves"
-	desc = "The best way to tackle your problems."
-	id = "tackle_combat"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/titanium = 2000, /datum/material/gold = 3000, /datum/material/plastic = 5000)
-	build_path = /obj/item/clothing/gloves/tackler/combat
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/modular_skyrat/code/modules/research/techweb/all_nodes.dm
+++ b/modular_skyrat/code/modules/research/techweb/all_nodes.dm
@@ -73,6 +73,7 @@
 
 /datum/techweb_node/syndicate_basic/New()
 	design_ids += "armblade"
+	design_ids += "blackbaton"
 	. = ..()
 
 /datum/techweb_node/illegal_mechs

--- a/modular_skyrat/code/modules/research/techweb/nodes/bepis_nodes.dm
+++ b/modular_skyrat/code/modules/research/techweb/nodes/bepis_nodes.dm
@@ -7,13 +7,3 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 16000)
 	hidden = TRUE
 	experimental = TRUE
-
-/datum/techweb_node/special_weapons_and_tactics
-	id = "swat_weapons"
-	display_name = "Special Weapons And Tactics"
-	description = "Sometimes, standard protocol isn't enough."
-	prereq_ids = list("ballistic_weapons", "NVGtech")
-	design_ids = list("wt550", "tackle_combat", "blackbaton", "nv_helmet", "adv_armor_vest", "adv_armor_vest_tech")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 8000)
-	hidden = TRUE
-	experimental = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The baton goes to the illegal tech node, as it's quite strong.
The crate is called "SWAT Tactical Operations crate", and much like the SWAT crate, it contains 2 sets of tactical equipment, but no weapons

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bepis node was too easily acquirable

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the black baton to illegal technology node
add: Added a tactical SWAT cargo pack, with the advanced vest, night visor helmet and other tactical equipment
del: Removed SWAT bepis node
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
