### PR TITLE
Adds Psychologist, Mining Foreman and Mining Technician into related loadout role defines

### DIFF
--- a/modular_skyrat/code/modules/client/loadout/_defines.dm
+++ b/modular_skyrat/code/modules/client/loadout/_defines.dm
@@ -1,7 +1,7 @@
 // Everyone, but Civilian and Service
 #define NOCIV_ROLES list(\
 						"Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster",\
-						"Medical Doctor", "Chemist", "Paramedic", "Virologist", "Geneticist", "Scientist", "Roboticist",\
+						"Medical Doctor", "Chemist", "Paramedic", "Virologist", "Geneticist", "Scientist", "Roboticist", "Psychologist",\
 						"Atmospheric Technician", "Station Engineer", "Warden", "Detective", "Security Officer", "Blueshield", "Brig Physician",\
 						"Cargo Technician", "Shaft Miner"\
 						)
@@ -9,7 +9,7 @@
 // Literally everyone, but Prisoners. Hopefully tempoary, until proper blacklist.
 #define NOPRISON_ROLES list(\
 							"Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster",\
-							"Medical Doctor", "Chemist", "Paramedic", "Virologist", "Geneticist", "Scientist", "Roboticist",\
+							"Medical Doctor", "Chemist", "Paramedic", "Virologist", "Geneticist", "Scientist", "Roboticist", "Psychologist",\
 							"Atmospheric Technician", "Station Engineer", "Warden", "Detective", "Security Officer", "Blueshield", "Brig Physician",\
 							"Cargo Technician", "Shaft Miner", "Bartender", "Botanist", "Cook", "Curator", "Chaplain", "Janitor",\
 							"Clown", "Mime", "Lawyer", "Assistant"\
@@ -17,7 +17,7 @@
 
 // Some of these might be left unused, but still it's nice to have them around.
 #define CMD_ROLES list("Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster")
-#define MED_ROLES list("Chief Medical Officer", "Medical Doctor", "Virologist", "Chemist", "Geneticist", "Paramedic", "Brig Physician")
+#define MED_ROLES list("Chief Medical Officer", "Medical Doctor", "Virologist", "Chemist", "Geneticist", "Paramedic", "Brig Physician", "Psychologist")
 #define SCI_ROLES list("Research Director", "Scientist", "Roboticist")
 #define SEC_ROLES list("Head of Security", "Security Officer", "Warden", "Brig Physician", "Blueshield")
 #define ENG_ROLES list("Chief Engineer", "Atmospheric Technician", "Station Engineer")
@@ -27,7 +27,7 @@
 
 // Hybrids. Might be left unused even more, aside from OrviTrek-like stuff. As for OPRS it is ENG+SEC+CRG.
 #define MEDSCI_ROLES list(\
-						"Chief Medical Officer", "Medical Doctor", "Virologist", "Chemist", "Geneticist", "Paramedic",\
+						"Chief Medical Officer", "Medical Doctor", "Virologist", "Chemist", "Geneticist", "Paramedic", "Psychologist",\
 						"Research Director", "Scientist", "Roboticist"\
 						)
 #define OPRS_ROLES list(\

--- a/modular_skyrat/code/modules/client/loadout/_defines.dm
+++ b/modular_skyrat/code/modules/client/loadout/_defines.dm
@@ -3,7 +3,7 @@
 						"Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster",\
 						"Medical Doctor", "Chemist", "Paramedic", "Virologist", "Geneticist", "Scientist", "Roboticist", "Psychologist",\
 						"Atmospheric Technician", "Station Engineer", "Warden", "Detective", "Security Officer", "Blueshield", "Brig Physician",\
-						"Cargo Technician", "Shaft Miner"\
+						"Cargo Technician", "Shaft Miner", "Mining Foreman", "Mining Technician"\
 						)
 
 // Literally everyone, but Prisoners. Hopefully tempoary, until proper blacklist.
@@ -11,7 +11,8 @@
 							"Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster",\
 							"Medical Doctor", "Chemist", "Paramedic", "Virologist", "Geneticist", "Scientist", "Roboticist", "Psychologist",\
 							"Atmospheric Technician", "Station Engineer", "Warden", "Detective", "Security Officer", "Blueshield", "Brig Physician",\
-							"Cargo Technician", "Shaft Miner", "Bartender", "Botanist", "Cook", "Curator", "Chaplain", "Janitor",\
+							"Cargo Technician", "Shaft Miner", "Mining Foreman", "Mining Technician",\
+							"Bartender", "Botanist", "Cook", "Curator", "Chaplain", "Janitor",\
 							"Clown", "Mime", "Lawyer", "Assistant"\
 							)
 
@@ -21,7 +22,7 @@
 #define SCI_ROLES list("Research Director", "Scientist", "Roboticist")
 #define SEC_ROLES list("Head of Security", "Security Officer", "Warden", "Brig Physician", "Blueshield")
 #define ENG_ROLES list("Chief Engineer", "Atmospheric Technician", "Station Engineer")
-#define CRG_ROLES list("Quartermaster", "Cargo Technician", "Shaft Miner")
+#define CRG_ROLES list("Quartermaster", "Cargo Technician", "Shaft Miner", "Mining Foreman", "Mining Technician")
 #define CIV_ROLES list("Head of Personnel", "Bartender", "Botanist", "Cook", "Curator", "Chaplain", "Janitor", "Clown", "Mime", "Lawyer", "Assistant")
 #define FUN_ROLES list("Clown", "Mime")
 
@@ -33,5 +34,5 @@
 #define OPRS_ROLES list(\
 						"Head of Security", "Security Officer", "Warden", "Brig Physician", "Blueshield",\
 						"Chief Engineer", "Atmospheric Technician", "Station Engineer",\
-						"Quartermaster", "Cargo Technician", "Shaft Miner"\
+						"Quartermaster", "Cargo Technician", "Shaft Miner", "Mining Foreman", "Mining Technician"\
 						)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR simply adds psychologist into loadout defines `MED_ROLES` and `MEDSCI_ROLES`, and Mining Foreman/Technician into `CRG_ROLES` and `OPRS_ROLES`. All mentioned are also went into `NOCIV_ROLES` and `NOPRISON_ROLES` define list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows people to choose loadout items related to their department.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Anonymous
fix: Psychologist now should be able to get medical loadout items.
fix: Mining Foreman and Mining Technicians now should be able to get cargo loadout items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
