### PR TITLE
A new trait/quirk, that prevents automatic tailwag from the headpats

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -228,6 +228,7 @@
 #define TRAIT_LOOKSUNCONSCIOUS	"looks_unconscious" //fake fainting
 #define TRAIT_LOOKSVERYUNCONSCIOUS	"looks_very_unconscious" //fake shock
 #define TRAIT_LOOKSDEAD			"looks_dead" //fake death
+#define TRAIT_STERN				"nopats" //will not wag from headpats
 //
 
 // mobility flag traits

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -353,7 +353,7 @@
 						target_message = "<span class='notice'>[M] gives you a pat on the head to make you feel better!</span>")
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "headpat", /datum/mood_event/headpat)
 			friendly_check = TRUE
-			if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail())
+			if(S?.can_wag_tail(src) && !dna.species.is_wagging_tail() && !HAS_TRAIT(src, TRAIT_STERN)) // Skyrat Edit to restrict auto-tailwags.
 				var/static/list/many_tails = list("tail_human", "tail_lizard", "mam_tail")
 				for(var/T in many_tails)
 					if(S.mutant_bodyparts[T] && dna.features[T] != "None")

--- a/modular_skyrat/code/datums/traits/neutral.dm
+++ b/modular_skyrat/code/datums/traits/neutral.dm
@@ -211,3 +211,10 @@
 	gain_text = "<span class='notice'>Your spirit gets too scarred to accept revival.</span>"
 	lose_text = "<span class='notice'>You can feel your soul healing again.</span>"
 	mob_trait = TRAIT_DNR
+
+//no tailwag from the pats
+/datum/quirk/stern
+	name = "Stern"
+	desc = "Headpats will not cause your tail to wag, if you have any."
+	value = 0
+	mob_trait = TRAIT_STERN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR will make code check for `TRAIT_STERN` before determining whenever subject will wag their tail or not upon headpats. Related quirk is added.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
```
ANOTHER F!@#ING TAILWAG
DEBATE ON THE MAIN TALK
```
Alternative to #3534. Thank @Owai-Seek for an idea.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Anonymous
add: Stern quirk allows you to stop automatic tail-wagging from headpats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
