### PR TITLE
Stunbatons no longer knockdown

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -15,9 +15,9 @@
 	attack_verb = list("beaten")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-	var/stamforce = 35
+	var/stamforce = 55
 	var/turned_on = FALSE
-	var/knockdown = TRUE
+	var/knockdown = FALSE
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 750
 	var/throw_hit_chance = 35


### PR DESCRIPTION
## About The Pull Request

Stunbatons can no longer knockdown , they deal 55 stamina damage now.

## Why It's Good For The Game

The stunbaton in its current state will end most fights , the knockdown combined with 35 stun damage will doom any traitor that gets hit by it , because while on the ground you cannot parry ,you get reduced hit damage , and because security will dance around you at sprinting speed. This change makes it so the stunbatons deal much more stamina damage but no longer knockdown , which will result  in more action as now traitors get an actual chance to run away or fight against security.
## Changelog
:cl:
balance: Stunbatons no longer knockdown  , they now deal 55 stamina damage per hit
/:cl: