### PR TITLE
Removes spacevine space spreading, removes spacevine door opening, adds spacevine player scalling

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spacevine
 	weight = 15
 	max_occurrences = 3
-	min_players = 10
+	min_players = 20
 
 /datum/round_event/spacevine
 	fakeable = FALSE
@@ -414,9 +414,9 @@
 	var/list/vine_mutations_list
 	var/mutativeness = 1
 
-#define MINIMUM_SPACEVINES_EFFECTIVENESS 0.4
-#define MAXIMUM_SPACEVINES_EFFECTIVENESS 1.5
-#define SPACEVINES_PLAYER_BALANCED_NUMBER 70
+#define MINIMUM_SPACEVINES_EFFECTIVENESS 0.4 //Minimum multiplier that the effectivess of vines can reach
+#define MAXIMUM_SPACEVINES_EFFECTIVENESS 1.3 //Maximum multiplier
+#define SPACEVINES_PLAYER_BALANCED_NUMBER 70 //The multiplier is balanced around this, and will be 1 if amount of players is equal to this
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
 	spread_multiplier *= clamp((length(GLOB.joined_player_list) / SPACEVINES_PLAYER_BALANCED_NUMBER), MINIMUM_SPACEVINES_EFFECTIVENESS, MAXIMUM_SPACEVINES_EFFECTIVENESS)
@@ -512,7 +512,7 @@
 			SM.process_mutation(SV)
 		if(SV.energy < 2) //If tile isn't fully grown
 			//if(prob(20)) // SKYRAT EDIT - VINES (ORIGINAL)
-			if(prob(50)) // SKYRAT EDIT - VINES
+			if(prob(35)) // SKYRAT EDIT - VINES
 				SV.grow()
 		else //If tile is fully grown
 			SV.entangle_mob()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -414,7 +414,13 @@
 	var/list/vine_mutations_list
 	var/mutativeness = 1
 
+#define MINIMUM_SPACEVINES_EFFECTIVENESS 0.4
+#define MAXIMUM_SPACEVINES_EFFECTIVENESS 1.5
+#define SPACEVINES_PLAYER_BALANCED_NUMBER 70
+
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
+	spread_multiplier *= clamp((length(GLOB.joined_player_list) / SPACEVINES_PLAYER_BALANCED_NUMBER), MINIMUM_SPACEVINES_EFFECTIVENESS, MAXIMUM_SPACEVINES_EFFECTIVENESS)
+	spread_cap *= clamp((length(GLOB.joined_player_list) / SPACEVINES_PLAYER_BALANCED_NUMBER), MINIMUM_SPACEVINES_EFFECTIVENESS, MAXIMUM_SPACEVINES_EFFECTIVENESS)
 	vines = list()
 	growth_queue = list()
 	var/obj/structure/spacevine/SV = spawn_spacevine_piece(location, null, muts)
@@ -428,6 +434,10 @@
 	if(production != null)
 		spread_cap *= production / 5
 		spread_multiplier /= production / 5
+
+#undef MINIMUM_SPACEVINES_EFFECTIVENESS
+#undef MAXIMUM_SPACEVINES_EFFECTIVENESS
+#undef SPACEVINES_PLAYER_BALANCED_NUMBER
 
 /datum/spacevine_controller/vv_get_dropdown()
 	. = ..()
@@ -545,26 +555,13 @@
 /obj/structure/spacevine/proc/spread()
 	var/direction = pick(GLOB.cardinals)
 	var/turf/stepturf = get_step(src,direction)
-	//SKYRAT EDIT START - VINES
-	var/area/steparea = get_area(stepturf)
-	for(var/obj/machinery/door/D in stepturf.contents)
-		if(prob(50))
-			D.open()
-	//if (!isspaceturf(stepturf) && stepturf.Enter(src)) // SKYRAT EDIT - VINES (ORIGINAL)
-	if (stepturf.Enter(src)) //SKYRAT EDIT - VINES
-		if(istype(steparea, /area/space/station_ruins))
-			return
-	//SKYRAT EDIT END - VINES
+	if (!isspaceturf(stepturf) && stepturf.Enter(src))
 		for(var/datum/spacevine_mutation/SM in mutations)
 			SM.on_spread(src, stepturf)
 			stepturf = get_step(src,direction) //in case turf changes, to make sure no runtimes happen
 		if(!locate(/obj/structure/spacevine, stepturf))
 			if(master)
 				master.spawn_spacevine_piece(stepturf, src)
-				//SKYRAT EDIT START - VINES
-				if(istype(stepturf, /turf/open/space))
-					stepturf.ChangeTurf(/turf/open/floor/plating/airless/kudzu)
-				//SKYRAT EDIT END - VINES
 
 /obj/structure/spacevine/ex_act(severity, target)
 	if(istype(target, type)) //if its agressive spread vine dont do anything
@@ -595,14 +592,3 @@
 		if(istype(M, /mob/living/simple_animal/hostile/venus_human_trap))
 			return TRUE
 	return FALSE
-
-/turf/open/floor/plating/airless/kudzu
-	name = "kudzu flooring"
-	icon = 'modular_skyrat/icons/turf/smooth/_smooth.dmi'
-	icon_state = "grass"
-
-/turf/open/floor/plating/airless/kudzu/attackby(obj/item/C, mob/user, params)
-	if(istype(C, /obj/item/wirecutters))
-		ChangeTurf(/turf/open/space)
-	else
-		return ..()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -419,7 +419,7 @@
 #define SPACEVINES_PLAYER_BALANCED_NUMBER 70 //The multiplier is balanced around this, and will be 1 if amount of players is equal to this
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
-	spread_multiplier *= clamp((length(GLOB.joined_player_list) / SPACEVINES_PLAYER_BALANCED_NUMBER), MINIMUM_SPACEVINES_EFFECTIVENESS, MAXIMUM_SPACEVINES_EFFECTIVENESS)
+	spread_multiplier /= clamp((length(GLOB.joined_player_list) / SPACEVINES_PLAYER_BALANCED_NUMBER), MINIMUM_SPACEVINES_EFFECTIVENESS, MAXIMUM_SPACEVINES_EFFECTIVENESS)
 	spread_cap *= clamp((length(GLOB.joined_player_list) / SPACEVINES_PLAYER_BALANCED_NUMBER), MINIMUM_SPACEVINES_EFFECTIVENESS, MAXIMUM_SPACEVINES_EFFECTIVENESS)
 	vines = list()
 	growth_queue = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title - also changes the fulltile growth % from 50 to 35 to not grow as fast. (used to be 20 originally). 
Added scalling that can be easily changed with the defined values. Currently its balanced around 70 people, more people  can make the vines be up to 130% effective, less people can make them be as effective as 40%. Also moved the event start cap to atleast 20 people, because chances are that its a colossal pain/nuisance for a 10 man crew.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More balanced spacevines, also player scalling which should be very helpful for downstreams. The doors can be opened by venus traps so its not that much of an issue

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced spacevines, they cant open doors or spread to space, their effectiveness is player number scalled, they also fully grow slower, and the event itself can only start from a minimum of 20 people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
