### PR TITLE
Alien plant DNA manipulator is no longer a xenoarch reward

### DIFF
--- a/modular_skyrat/code/modules/research/xenoarch/artifact_list.dm
+++ b/modular_skyrat/code/modules/research/xenoarch/artifact_list.dm
@@ -66,7 +66,6 @@ GLOBAL_LIST_INIT(ult_artifact,list(	/obj/item/nuke_core/supermatter_sliver=1,
 									/obj/item/surgicaldrill/alien=1,
 									/obj/item/cautery/alien=1,
 									/obj/item/compressionkit=1,
-									/obj/item/circuitboard/machine/plantgenes/vault=1,
 									/obj/item/disk/design_disk/golem_shell=1,
 									/obj/item/disk/tech_disk/illegal=1
 									))


### PR DESCRIPTION
## About The Pull Request

Alien plant DNA manipulator is no longer a xenoarch reward

## Why It's Good For The Game

Upgrading a normal plant manipulator gets it to the equivalent of a Alien one , thus making the alien one simply worthless, ontop of it not providing alien tech
## Changelog
:cl:
del: Removed Alien Plant manipulator from the ultimate artifact reward list.
/:cl:

