### PR TITLE
Boxstation Security - New Prison & Aesthetic Overhaul

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -3458,6 +3458,8 @@
 	light_color = "#e8eaff"
 	},
 /obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aih" = (
@@ -9253,15 +9255,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"avx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "avy" = (
 /obj/machinery/door/airlock{
 	id_tag = "Room One";
@@ -51921,6 +51914,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dcd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -53028,10 +53045,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"eyX" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "ezG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -54072,13 +54085,6 @@
 /obj/item/bedsheet/rd/royal_cape,
 /turf/open/floor/plasteel/vaporwave,
 /area/security/prison)
-"fIa" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "fIs" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -54430,6 +54436,17 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"ggM" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ggZ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -55297,6 +55314,11 @@
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/security/prison)
+"hhS" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "hiE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56523,6 +56545,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"iOL" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "iPt" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58651,6 +58677,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"lDr" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lEk" = (
 /obj/machinery/door/window/brigdoor/security/cell/westright{
 	id = "genpopcell1"
@@ -58939,6 +58972,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"lZb" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lZl" = (
 /obj/structure/closet,
 /obj/item/coin/gold,
@@ -63728,11 +63770,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tkm" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/brig)
 "tkq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64597,13 +64634,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/pool)
-"uEM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "uFp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65282,30 +65312,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"vEG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "vEM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66182,6 +66188,13 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
+"wXx" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "wYs" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -66521,10 +66534,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/security/brig)
-"xDB" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xDM" = (
 /obj/machinery/camera{
@@ -93463,7 +93472,7 @@ agj
 aii
 ajD
 aig
-xDB
+ggM
 agj
 hkH
 akl
@@ -93975,7 +93984,7 @@ aeT
 ryK
 agj
 ovZ
-tkm
+hhS
 akP
 ryK
 kGl
@@ -96282,9 +96291,9 @@ lPa
 aeZ
 aeZ
 aeZ
-eyX
+iOL
 bdM
-fIa
+wXx
 ahX
 afb
 agH
@@ -96538,11 +96547,11 @@ aaZ
 lPy
 bdM
 mDZ
-uEM
+lDr
 mZM
 agU
 ahp
-vEG
+dcd
 ovC
 afd
 ahB
@@ -96798,7 +96807,7 @@ agS
 mPO
 abI
 acM
-avx
+lZb
 adM
 afe
 agI

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -2287,9 +2287,22 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "afZ" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Purple Wing";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "aga" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
@@ -2513,10 +2526,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "agE" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_officer,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/security/main)
 "agF" = (
@@ -2819,16 +2829,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_officer,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahi" = (
@@ -3203,6 +3214,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahN" = (
@@ -3670,7 +3685,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiD" = (
@@ -3801,6 +3815,9 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiP" = (
@@ -4541,10 +4558,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Brig West";
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5644,6 +5657,10 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Brig West";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -52094,19 +52111,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "dvA" = (
-/obj/effect/turf_decal/tile/purple{
-	alpha = 255;
-	dir = 1;
-	name = "strong purple corner"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Prison -  Purple Wing";
-	dir = 10;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "dwZ" = (
 /obj/effect/turf_decal/tile/purple{
@@ -53235,6 +53244,20 @@
 	dir = 8
 	},
 /area/security/prison)
+"eYN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/main)
 "eYT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56293,6 +56316,7 @@
 /area/security/prison)
 "iID" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
 	},
@@ -57081,6 +57105,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jHD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jHF" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -58436,6 +58469,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -58608,6 +58642,7 @@
 	network = list("ss13","prison");
 	start_active = 1
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -59124,6 +59159,16 @@
 /obj/item/target,
 /turf/open/floor/plating,
 /area/security/range)
+"mrv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "mrI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -59849,11 +59894,13 @@
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
 "nsR" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/checker,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/prison)
 "ntc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59861,6 +59908,10 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Entrance";
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -61151,15 +61202,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/main)
-"oWN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "oZc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -61188,6 +61230,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"pbx" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
 "pek" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62435,6 +62484,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rpK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rqf" = (
 /obj/machinery/light{
 	dir = 1
@@ -65892,6 +65947,19 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"wSg" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "wSs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -66528,7 +66596,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "xVi" = (
-/obj/machinery/camera,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -90444,7 +90511,7 @@ kdS
 ryK
 adG
 aiE
-aiE
+wSg
 oAf
 aiE
 aih
@@ -90962,7 +91029,7 @@ adG
 adG
 adG
 agj
-oWN
+jHD
 ajX
 afM
 agj
@@ -91703,7 +91770,7 @@ eCO
 fbx
 abu
 fho
-nsR
+yaU
 geS
 gLZ
 yaU
@@ -93002,9 +93069,9 @@ xjL
 aaR
 vFf
 vFf
+dvA
 vFf
-vFf
-fJC
+nsR
 vFf
 iID
 biZ
@@ -93496,7 +93563,7 @@ aft
 ano
 asS
 bpD
-dvA
+dwZ
 abu
 epL
 fkW
@@ -93519,7 +93586,7 @@ lul
 edO
 lLD
 sSF
-edO
+mrv
 wul
 bjD
 eOg
@@ -94267,7 +94334,7 @@ agJ
 anp
 asQ
 bzr
-dkx
+afZ
 abu
 abu
 abu
@@ -98925,7 +98992,7 @@ afh
 agZ
 ahd
 ahd
-ahI
+eYN
 akO
 abp
 ajj
@@ -99950,7 +100017,7 @@ afs
 acL
 acS
 afk
-afZ
+agQ
 agE
 ahh
 ahM
@@ -100208,7 +100275,7 @@ abq
 abq
 agl
 afU
-afU
+pbx
 ahg
 ahL
 aiu
@@ -100717,7 +100784,7 @@ aag
 aaf
 aaf
 adk
-abm
+rpK
 adR
 aeA
 afl

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -369,7 +369,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abI" = (
-/obj/effect/turf_decal/loading_area,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abJ" = (
@@ -567,20 +569,23 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "acm" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Armory Storage";
-	req_access_txt = "63"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/shieldwallgen{
+	name = "Shield Generator";
+	req_access = null
+	},
+/obj/machinery/door/window/eastright{
+	name = "Storage"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -762,7 +767,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "acM" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -1219,11 +1224,38 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "adP" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/flashbang{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/storage/box/medipens{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adQ" = (
@@ -1576,13 +1608,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/shieldwallgen{
 	name = "Shield Generator";
 	req_access = null
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1722,13 +1761,20 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeW" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/shieldwallgen{
 	name = "Shield Generator";
 	req_access = null
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -1759,11 +1805,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet{
-	name = "contraband locker";
-	req_access_txt = "3"
+/obj/effect/turf_decal/loading_area{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeZ" = (
@@ -2698,7 +2742,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agS" = (
-/obj/effect/turf_decal/tile/red,
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agT" = (
@@ -2717,10 +2772,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agU" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agV" = (
@@ -2924,26 +2977,12 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "ahp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3131,11 +3170,9 @@
 /area/security/main)
 "ahG" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/westright{
-	name = "Brig Operations";
-	req_one_access_txt = "4; 1"
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahH" = (
 /obj/structure/disposalpipe/junction/yjunction{
@@ -3420,9 +3457,8 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aih" = (
 /turf/closed/wall,
@@ -4142,9 +4178,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajD" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/storage/box,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -4172,7 +4209,7 @@
 /area/security/brig)
 "ajG" = (
 /turf/open/floor/plasteel/dark/side{
-	dir = 1
+	dir = 9
 	},
 /area/security/brig)
 "ajH" = (
@@ -4241,6 +4278,17 @@
 /area/security/brig)
 "ajL" = (
 /obj/structure/table,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/storage/box/zipties{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajM" = (
@@ -4382,11 +4430,9 @@
 /area/security/brig)
 "ajY" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/westleft{
-	name = "Brig Operations";
-	req_one_access_txt = "4; 1"
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4802,9 +4848,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akP" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "akQ" = (
 /obj/structure/cable{
@@ -4849,9 +4895,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akU" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/rnd/production/techfab/department/security,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/security/brig)
 "akV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5135,10 +5181,26 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alx" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/area/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/shieldwallgen{
+	name = "Shield Generator";
+	req_access = null
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Storage"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "aly" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7428,6 +7490,7 @@
 	pixel_y = 20
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/sensor_device,
 /turf/open/floor/wood,
 /area/security/warden)
 "aqO" = (
@@ -9190,6 +9253,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"avx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "avy" = (
 /obj/machinery/door/airlock{
 	id_tag = "Room One";
@@ -47761,19 +47833,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"csK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/window/northright{
-	name = "Brig Operations";
-	req_one_access_txt = "4; 1"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/brig)
 "csM" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing/horizontal,
@@ -52969,6 +53028,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"eyX" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ezG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -54009,6 +54072,13 @@
 /obj/item/bedsheet/rd/royal_cape,
 /turf/open/floor/plasteel/vaporwave,
 /area/security/prison)
+"fIa" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "fIs" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -54714,15 +54784,10 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "gCm" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gCC" = (
 /obj/structure/sign/poster/contraband/tools,
@@ -58024,10 +58089,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/door/window/northleft{
-	name = "Brig Operations";
-	req_one_access_txt = "4; 1"
-	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -58662,7 +58723,13 @@
 /area/maintenance/disposal/incinerator)
 "lKL" = (
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "lLt" = (
 /obj/machinery/door/window/brigdoor/security/cell/westleft{
@@ -58730,6 +58797,12 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "lOi" = (
@@ -58768,12 +58841,6 @@
 /area/hallway/primary/port)
 "lPy" = (
 /obj/structure/closet/secure_closet/lethalshots,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
-/obj/item/ammo_box/c10mm,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -58784,6 +58851,12 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 32
 	},
+/obj/item/ammo_box/shotgun/loaded,
+/obj/item/ammo_box/shotgun/loaded,
+/obj/item/ammo_box/shotgun/loaded,
+/obj/item/ammo_box/shotgun/loaded/buckshot,
+/obj/item/ammo_box/shotgun/loaded/buckshot,
+/obj/item/ammo_box/shotgun/loaded/buckshot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "lQc" = (
@@ -58972,6 +59045,12 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -59326,34 +59405,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mBc" = (
-/obj/structure/table/reinforced,
-/obj/item/grenade/flashbang{
-	pixel_x = -8;
-	pixel_y = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/item/grenade/flashbang{
-	pixel_x = -4;
-	pixel_y = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/item/grenade/flashbang{
-	pixel_y = 10
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access_txt = "3"
 	},
-/obj/item/grenade/flashbang{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/storage/box/medipens{
-	pixel_x = 5;
-	pixel_y = 1
-	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mBH" = (
@@ -59571,23 +59633,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "mPO" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
 /obj/machinery/camera{
 	c_tag = "Security - Armoury";
 	dir = 9;
 	network = list("ss13","prison")
 	},
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mQI" = (
@@ -59686,10 +59737,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "mZM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "nac" = (
@@ -60812,19 +60860,19 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/cardboard/fifty,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ovZ" = (
-/obj/structure/table,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/item/storage/box/zipties{
-	pixel_x = -10;
-	pixel_y = 10
-	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "oxm" = (
@@ -63680,6 +63728,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tkm" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "tkq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64544,6 +64597,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/pool)
+"uEM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "uFp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65222,6 +65282,30 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"vEG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "vEM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66437,6 +66521,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
+/area/security/brig)
+"xDB" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xDM" = (
 /obj/machinery/camera{
@@ -93375,7 +93463,7 @@ agj
 aii
 ajD
 aig
-agp
+xDB
 agj
 hkH
 akl
@@ -93632,7 +93720,7 @@ agj
 ajL
 ajG
 akU
-ryK
+agp
 kGl
 alA
 hxc
@@ -93887,10 +93975,10 @@ aeT
 ryK
 agj
 ovZ
-iwi
+tkm
 akP
-alx
-csK
+ryK
+kGl
 kPY
 alB
 akT
@@ -95679,7 +95767,7 @@ aaZ
 aaZ
 aaZ
 aaZ
-aaZ
+alx
 acm
 aaZ
 aaZ
@@ -95937,7 +96025,7 @@ lNH
 mee
 mBc
 aeY
-adM
+aeY
 agR
 ahm
 ahA
@@ -96194,9 +96282,9 @@ lPa
 aeZ
 aeZ
 aeZ
-aeZ
-agS
-ahX
+eyX
+bdM
+fIa
 ahX
 afb
 agH
@@ -96450,11 +96538,11 @@ aaZ
 lPy
 bdM
 mDZ
-bdM
+uEM
 mZM
 agU
 ahp
-afd
+vEG
 ovC
 afd
 ahB
@@ -96706,11 +96794,11 @@ gXs
 aaZ
 lQZ
 lQZ
-lQZ
+agS
 mPO
 abI
 acM
-adM
+avx
 adM
 afe
 agI

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -308,11 +308,20 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "abt" = (
-/obj/machinery/pool/controller,
-/turf/open/floor/plasteel/yellowsiding{
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/area/security/prison)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "abu" = (
 /turf/closed/wall,
 /area/security/prison)
@@ -2742,7 +2751,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agS" = (
-/obj/machinery/flasher/portable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2754,6 +2762,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/shieldwallgen{
+	name = "Shield Generator";
+	req_access = null
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Storage"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agT" = (
@@ -4092,6 +4107,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/pool/controller,
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
@@ -5183,24 +5199,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alx" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/shieldwallgen{
-	name = "Shield Generator";
-	req_access = null
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Storage"
-	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aly" = (
@@ -51914,30 +51916,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dcd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "dce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -52693,6 +52671,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dZt" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eaP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54436,17 +54421,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
-"ggM" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = -5
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ggZ" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -55314,11 +55288,6 @@
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/security/prison)
-"hhS" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/security/brig)
 "hiE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56263,6 +56232,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"iuQ" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "iuR" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -56545,10 +56525,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
-"iOL" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "iPt" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58001,6 +57977,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark/side,
 /area/security/prison)
+"kzN" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "kzT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -58677,13 +58658,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
-"lDr" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lEk" = (
 /obj/machinery/door/window/brigdoor/security/cell/westright{
 	id = "genpopcell1"
@@ -58750,6 +58724,30 @@
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lJu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lJS" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
@@ -58972,15 +58970,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"lZb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lZl" = (
 /obj/structure/closet,
 /obj/item/coin/gold,
@@ -59458,6 +59447,10 @@
 	req_access_txt = "3"
 	},
 /obj/effect/spawner/lootdrop/armory_contraband,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"mBF" = (
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mBH" = (
@@ -60772,6 +60765,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"onH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oof" = (
 /obj/structure/table/wood,
 /obj/machinery/button/door{
@@ -66188,13 +66190,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
-"wXx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "wYs" = (
 /obj/machinery/chem_master/condimaster{
 	name = "HoochMaster 2000"
@@ -89580,7 +89575,7 @@ aaa
 aaa
 aaa
 afZ
-abt
+xSe
 xSe
 atX
 coi
@@ -93472,7 +93467,7 @@ agj
 aii
 ajD
 aig
-ggM
+iuQ
 agj
 hkH
 akl
@@ -93984,7 +93979,7 @@ aeT
 ryK
 agj
 ovZ
-hhS
+kzN
 akP
 ryK
 kGl
@@ -95776,7 +95771,7 @@ aaZ
 aaZ
 aaZ
 aaZ
-alx
+agS
 acm
 aaZ
 aaZ
@@ -96291,9 +96286,9 @@ lPa
 aeZ
 aeZ
 aeZ
-iOL
+mBF
 bdM
-wXx
+dZt
 ahX
 afb
 agH
@@ -96547,11 +96542,11 @@ aaZ
 lPy
 bdM
 mDZ
-lDr
+alx
 mZM
 agU
 ahp
-dcd
+lJu
 ovC
 afd
 ahB
@@ -96803,11 +96798,11 @@ gXs
 aaZ
 lQZ
 lQZ
-agS
+abt
 mPO
 abI
 acM
-lZb
+onH
 adM
 afe
 agI

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -2287,21 +2287,18 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "afZ" = (
-/obj/effect/turf_decal/tile/purple{
-	alpha = 255;
-	dir = 1;
-	name = "strong purple corner"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	c_tag = "Prison -  Purple Wing";
-	dir = 10;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "GenpopPool";
+	name = "Security Shutters"
 	},
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/plating,
 /area/security/prison)
 "aga" = (
 /obj/structure/sign/warning/pods{
@@ -6326,6 +6323,10 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "GenpopPool";
+	name = "Security Shutters"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "aor" = (
@@ -8614,6 +8615,11 @@
 "atX" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "GenpopPool";
+	name = "Shutter Control";
+	pixel_x = -25
 	},
 /turf/open/floor/plasteel/yellowsiding{
 	dir = 4
@@ -52111,11 +52117,16 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "dvA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "GenpopPool";
+	name = "Security Shutters"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "dwZ" = (
 /obj/effect/turf_decal/tile/purple{
@@ -52670,6 +52681,20 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"eeL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/main)
 "efO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53244,20 +53269,6 @@
 	dir = 8
 	},
 /area/security/prison)
-"eYN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/main)
 "eYT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53439,6 +53450,19 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
+"fhq" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "fjl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark/side,
@@ -56874,6 +56898,13 @@
 	dir = 4
 	},
 /area/security/prison)
+"jzf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "jzz" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -57105,15 +57136,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jHD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jHF" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -58280,6 +58302,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lgv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "lhd" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -58433,6 +58464,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lrW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lsk" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
@@ -59159,16 +59199,6 @@
 /obj/item/target,
 /turf/open/floor/plating,
 /area/security/range)
-"mrv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/security/prison)
 "mrI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -59894,13 +59924,21 @@
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
 "nsR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
 	},
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Purple Wing";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "ntc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61230,13 +61268,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"pbx" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
-/area/security/main)
 "pek" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62484,12 +62515,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rpK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "rqf" = (
 /obj/machinery/light{
 	dir = 1
@@ -62879,6 +62904,16 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
+/area/security/prison)
+"rYX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/security/prison)
 "rZB" = (
 /obj/machinery/door/window/brigdoor/security/cell{
@@ -64646,6 +64681,12 @@
 /obj/machinery/pool/drain,
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"uTp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uUd" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -65859,6 +65900,13 @@
 /obj/structure/bed,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"wGN" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
 "wHk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65947,19 +65995,6 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
-"wSg" = (
-/obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/genpop,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/range)
 "wSs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -89191,10 +89226,10 @@ aaa
 aaa
 aaa
 aEv
-aik
+dvA
 aoq
 vdU
-aik
+dvA
 aoq
 dXM
 fpP
@@ -89447,7 +89482,7 @@ aaa
 aaa
 aaa
 aaa
-ade
+afZ
 abt
 xSe
 atX
@@ -89704,7 +89739,7 @@ aaa
 aaa
 aaa
 aaa
-ade
+afZ
 psf
 psf
 auS
@@ -90218,7 +90253,7 @@ aaa
 aaa
 aaa
 aaa
-ade
+afZ
 psf
 psf
 aCf
@@ -90475,7 +90510,7 @@ aaa
 aaa
 aaa
 aaa
-ade
+afZ
 psf
 psf
 psf
@@ -90511,7 +90546,7 @@ kdS
 ryK
 adG
 aiE
-wSg
+fhq
 oAf
 aiE
 aih
@@ -91029,7 +91064,7 @@ adG
 adG
 adG
 agj
-jHD
+lrW
 ajX
 afM
 agj
@@ -93069,9 +93104,9 @@ xjL
 aaR
 vFf
 vFf
-dvA
+jzf
 vFf
-nsR
+lgv
 vFf
 iID
 biZ
@@ -93586,7 +93621,7 @@ lul
 edO
 lLD
 sSF
-mrv
+rYX
 wul
 bjD
 eOg
@@ -94334,7 +94369,7 @@ agJ
 anp
 asQ
 bzr
-afZ
+nsR
 abu
 abu
 abu
@@ -98992,7 +99027,7 @@ afh
 agZ
 ahd
 ahd
-eYN
+eeL
 akO
 abp
 ajj
@@ -100275,7 +100310,7 @@ abq
 abq
 agl
 afU
-pbx
+wGN
 ahg
 ahL
 aiu
@@ -100784,7 +100819,7 @@ aag
 aaf
 aaf
 adk
-rpK
+uTp
 adR
 aeA
 afl

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -61151,6 +61151,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/main)
+"oWN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oZc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -90953,7 +90962,7 @@ adG
 adG
 adG
 agj
-vyc
+oWN
 ajX
 afM
 agj

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -57,127 +57,42 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"aai" = (
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"aaj" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "aak" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space North";
-	dir = 1;
-	name = "aft camera"
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aal" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/door/poddoor/shutters/preopen{
+	desc = "Why does this place even have windows?!";
+	id = "GenpopBath";
+	name = "Bathroom Privacy Shutters"
 	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aam" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aan" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aao" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aap" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaq" = (
-/obj/structure/weightmachine/weightlifter,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aar" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/jukebox{
-	req_one_access = null
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aas" = (
-/obj/structure/punching_bag,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aat" = (
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aau" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aav" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaw" = (
-/obj/structure/sign/poster/official/random,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"aax" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aay" = (
 /turf/open/floor/plating,
 /area/security/prison)
 "aaz" = (
@@ -206,87 +121,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aaA" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "aaD" = (
-/obj/structure/holohoop,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/button/door{
+	id = "lockdown1";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"aaE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"aaF" = (
-/obj/machinery/computer/arcade,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aaG" = (
-/obj/effect/landmark/start/prisoner/prilate,
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aaH" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"aaI" = (
-/turf/open/floor/circuit/green,
-/area/security/prison)
-"aaJ" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aaK" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -332,21 +188,29 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "aaP" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge West";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown1";
+	name = "Lockdown"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aaQ" = (
 /turf/closed/wall,
 /area/security/warden)
 "aaR" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
-/turf/open/floor/wood,
 /area/security/prison)
 "aaS" = (
 /obj/structure/grille,
@@ -359,57 +223,34 @@
 /turf/open/space,
 /area/space/nearstation)
 "aaU" = (
-/turf/open/floor/wood,
-/area/security/prison)
-"aaV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/security/prison)
-"aaW" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"aaX" = (
-/turf/open/floor/plasteel/elevatorshaft,
+/turf/open/floor/plasteel/dark/corner,
 /area/security/prison)
 "aaY" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/secure/weapon{
-	desc = "A secure clothing crate.";
-	name = "formal uniform crate";
-	req_access = "3"
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = -6
 	},
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/officer/formal,
-/obj/item/clothing/under/rank/security/warden/formal,
-/obj/item/clothing/under/rank/security/head_of_security/formal,
-/obj/item/clothing/suit/armor/navyblue,
-/obj/item/clothing/suit/armor/navyblue,
-/obj/item/clothing/suit/armor/navyblue,
-/obj/item/clothing/suit/armor/navyblue,
-/obj/item/clothing/suit/armor/navyblue,
-/obj/item/clothing/suit/armor/vest/warden/navyblue,
-/obj/item/clothing/suit/armor/hos/navyblue,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navyofficer,
-/obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/beret/sec/navyhos,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
+/obj/item/tank/internals/plasmaman/belt{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = -6
+	},
+/obj/item/tank/internals/nitrogen/belt,
+/obj/item/tank/internals/nitrogen/belt{
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/weldingtool,
+/turf/open/floor/plating,
+/area/security/prison)
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
@@ -418,76 +259,18 @@
 /obj/structure/grille/broken,
 /turf/open/space,
 /area/space/nearstation)
-"abb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
 "abc" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
-"abd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
-"abe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
-"abf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/vending/kink,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
-"abh" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abi" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/security/prison)
 "abk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/closet/bombcloset/security,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/main)
-"abl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -495,8 +278,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abn" = (
+/obj/effect/turf_decal/box,
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abo" = (
@@ -525,52 +308,14 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "abt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/pool/controller,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"abu" = (
-/obj/machinery/door/poddoor{
-	id = "executionspaceblast"
-	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"abv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"abw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "executionflash";
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"abx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
 /area/security/prison)
-"aby" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+"abu" = (
+/turf/closed/wall,
+/area/security/prison)
 "abz" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology South";
@@ -583,117 +328,81 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"abA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"abB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abD" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "abE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "abF" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "abG" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/ai_monitored/security/armory)
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -8
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 8
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 12
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/security/prison)
 "abH" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abI" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abJ" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "abK" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"abL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abM" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Lounge East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abN" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "abO" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -708,10 +417,18 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "abR" = (
-/obj/machinery/vending/security,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
-/area/security/main)
+/area/security/prison)
 "abS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -778,27 +495,43 @@
 /turf/open/space,
 /area/solar/port/fore)
 "aca" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/table,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"acb" = (
-/obj/machinery/sparker{
-	id = "executionburn";
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/line{
+/area/security/prison)
+"acc" = (
+/obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"acc" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"acd" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "ace" = (
 /obj/structure/closet,
@@ -833,116 +566,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"ack" = (
-/obj/structure/table/reinforced,
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 8;
-	name = "Armory APC";
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"acl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "acm" = (
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"acn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory Storage";
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"aco" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"acp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "acq" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -1024,23 +665,17 @@
 /obj/item/stack/cable_coil/random,
 /turf/open/space,
 /area/space/nearstation)
-"acz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
 "acA" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "acB" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "acC" = (
 /obj/effect/decal/cleanable/oil,
@@ -1048,23 +683,24 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "acD" = (
-/obj/machinery/plate_press,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"acE" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
+"acE" = (
+/obj/effect/landmark/start/prisoner,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "acF" = (
 /obj/machinery/light_switch{
@@ -1076,53 +712,43 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"acG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "acH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acI" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
+/obj/machinery/button/door{
+	desc = "At least Nanotrasen is giving criminals the option of privacy.";
+	id = "GenpopBath";
+	name = "Bathroom Shutters";
+	pixel_x = 24;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Transfer Room";
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"acK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "executionflash";
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"acJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "acL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -1136,8 +762,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "acM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -1192,10 +818,14 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "acT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "acU" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -1220,88 +850,75 @@
 /turf/open/space,
 /area/solar/port/fore)
 "acX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"acY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"acZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"ada" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"adb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
-"adc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
-"add" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ade" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
+"ada" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
 	dir = 8;
-	pixel_x = 24
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"adb" = (
+/obj/machinery/door/poddoor{
+	id = "executionspaceblast"
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"adc" = (
+/obj/machinery/sparker{
+	id = "executionburn";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"ade" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "adf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "sec_changingroom"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "adg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -1309,59 +926,37 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
-"adh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "adi" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/storage/toolbox/drone{
+	pixel_x = 2;
+	pixel_y = -2
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adj" = (
-/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
+/obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "adk" = (
-/obj/machinery/recharger,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "sec_changingroom"
+	},
+/turf/open/floor/plating,
 /area/security/main)
 "adl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -1380,12 +975,19 @@
 	pixel_x = 29
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "adn" = (
@@ -1500,95 +1102,62 @@
 /turf/open/space,
 /area/solar/port/fore)
 "adB" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Arrivals";
-	dir = 8;
-	name = "aft camera"
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"adC" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/razor,
-/obj/item/toy/plush/borgplushie{
-	desc = "A horrible abomination to God in plushie form. Legends say this is used to torture prisoners by repeatedly beating them in the head with it.. ..It feels sorta heavy.";
-	force = 1;
-	name = "dogborg plushie";
-	throwforce = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"adD" = (
-/obj/machinery/button/flasher{
-	id = "executionflash";
-	pixel_x = 24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "executionspaceblast";
-	name = "Vent to Space";
-	pixel_x = 25;
-	pixel_y = -5;
-	req_access_txt = "7"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"adE" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/assembly/flash/handheld,
-/obj/item/reagent_containers/spray/pepper,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "adF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"adG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/security/prison)
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
+"adG" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "adH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"adI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"adJ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/conveyor/auto{
 	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "prisonconveyor";
+	name = "Conveyor Shutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"adJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/electrochromatic{
+	id = "sec_changingroom";
+	name = "Window Privacy Control";
+	pixel_x = -26;
+	pixel_y = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "sec_changingroom1";
+	name = "Changing Room Shutter";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "adK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -1621,9 +1190,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adN" = (
@@ -1653,28 +1219,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "adP" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "adQ" = (
@@ -1758,73 +1307,12 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "aea" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"aeb" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"aec" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/deepfryer,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"aed" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/button/ignition{
-	id = "executionburn";
-	pixel_x = 24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "executionfireblast";
-	name = "Transfer Area Lockdown";
-	pixel_x = 25;
-	pixel_y = -5;
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"aee" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"aef" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aeg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "aeh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -1835,101 +1323,79 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"aei" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aej" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/door/poddoor/preopen{
+	id = "executionfireblast"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "Transfer Room";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Pressing Room";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"aek" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"ael" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
-"aem" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aen" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"aek" = (
+/obj/item/reagent_containers/food/snacks/grown/coconut,
+/obj/item/reagent_containers/food/snacks/grown/cocoapod,
+/obj/item/reagent_containers/food/snacks/grown/onion/red,
+/obj/item/reagent_containers/food/snacks/grown/onion,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/grass,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/reishi,
+/obj/item/reagent_containers/food/snacks/grown/garlic,
+/obj/item/reagent_containers/food/snacks/grown/eggplant,
+/obj/item/reagent_containers/food/snacks/grown/coffee/robusta,
+/obj/item/reagent_containers/food/snacks/grown/coffee,
+/obj/item/reagent_containers/food/snacks/grown/koibeans,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle,
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"aeo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aep" = (
+"aem" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/closed/wall/r_wall,
+/area/security/prison)
+"aen" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison";
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeq" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "aer" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/door/airlock/grunge{
+	name = "Maintenance"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/prison";
-	dir = 4;
-	name = "Prison Wing APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/prison)
 "aes" = (
 /obj/machinery/airalarm{
@@ -1939,7 +1405,10 @@
 	pixel_x = 30
 	},
 /obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine/longrange{
+	icon_state = "fax";
+	name = "fax machine"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aet" = (
@@ -1975,26 +1444,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"aev" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aew" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -2005,10 +1459,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aex" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	name = "Changing Room"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "sec_changingroom1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aey" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -2047,14 +1510,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aeB" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	id = "sec_changingroom1";
+	name = "Changing Room Shutter";
+	pixel_x = -25;
+	pixel_y = 25;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aeC" = (
 /obj/machinery/camera{
@@ -2072,42 +1544,44 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aeE" = (
-/obj/structure/closet/secure_closet/lethalshots,
-/obj/effect/turf_decal/tile/neutral{
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeF" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/firingpins{
-	pixel_x = 6
+/obj/machinery/shieldwallgen{
+	name = "Shield Generator";
+	req_access = null
 	},
-/obj/item/storage/box/firingpins{
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -2121,90 +1595,6 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
 "aeH" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"aeI" = (
-/obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/tank/internals/anesthetic{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"aeJ" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"aeK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"aeL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"aeM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aeN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2219,69 +1609,88 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"aeO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"aeI" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/machinery/camera{
+	c_tag = "Prison - Kitchen";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"aeJ" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lemon{
+	pixel_y = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aeP" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/item/reagent_containers/food/snacks/grown/parsnip,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/machinery/light{
+/obj/item/reagent_containers/food/snacks/grown/citrus/lime{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"aeM" = (
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"aeO" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"aeP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aeQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/table,
+/obj/item/razor,
+/obj/item/toy/plush/borgplushie{
+	desc = "A horrible abomination to God in plushie form. Legends say this is used to torture prisoners by repeatedly beating them in the head with it.. ..It feels sorta heavy.";
+	force = 1;
+	name = "dogborg plushie";
+	throwforce = 1
 	},
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "aeR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"aeS" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aeT" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2289,15 +1698,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeU" = (
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -2317,84 +1722,51 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aeW" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
+/obj/machinery/shieldwallgen{
+	name = "Shield Generator";
+	req_access = null
 	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/item/storage/lockbox/loyalty,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "aeY" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access_txt = "3"
 	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aeZ" = (
-/obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afa" = (
@@ -2416,27 +1788,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"afc" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "afd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -2450,6 +1801,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afe" = (
@@ -2459,14 +1819,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aff" = (
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -2479,7 +1835,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "afg" = (
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -2489,7 +1844,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "afh" = (
-/obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2503,12 +1857,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2523,18 +1879,23 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2545,7 +1906,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "afm" = (
 /obj/structure/disposalpipe/segment{
@@ -2558,16 +1919,25 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"afn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "afo" = (
-/obj/item/toy/beach_ball/holoball,
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
 "afp" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -2580,20 +1950,20 @@
 /turf/open/space/basic,
 /area/space)
 "afq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/security/prison)
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
 "afr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2604,10 +1974,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/effect/landmark/start/security_officer,
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afs" = (
@@ -2619,76 +1992,36 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "aft" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"afu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"afv" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"afw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	layer = 2.4
-	},
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Armory";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
-"afx" = (
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"afy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"afz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"afA" = (
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"afw" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
+/obj/effect/spawner/lootdrop/soap,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "afB" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -2698,11 +2031,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "afC" = (
 /obj/structure/cable{
@@ -2724,7 +2055,23 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
+/obj/structure/table/glass,
+/obj/item/storage/fancy/donut_box{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/storage/fancy/donut_box{
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/food/drinks/bottle/kahlua{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	layer = 3.1;
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "afE" = (
@@ -2740,73 +2087,27 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"afG" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "afH" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/syringe{
-	name = "steel point"
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
+/obj/structure/closet/secure_closet/brig_phys,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/clothing/under/rank/medical/doctor/blue,
+/obj/item/clothing/under/rank/medical/doctor/purple,
+/obj/item/clothing/under/rank/medical/doctor/green,
+/obj/item/sensor_device,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/brig)
-"afJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 1;
-	pixel_y = -27
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"afK" = (
-/obj/structure/chair/stool,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"afL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2817,32 +2118,87 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/rack,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 8
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/storage/box/bodybags,
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"afK" = (
+/obj/machinery/button/flasher{
+	id = "executionflash";
+	pixel_x = 24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "executionspaceblast";
+	name = "Vent to Space";
+	pixel_x = 25;
+	pixel_y = -5;
+	req_access_txt = "7"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
+"afL" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/machinery/vending/wallmed{
+	pixel_x = 24;
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afM" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
 "afN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "afO" = (
 /obj/machinery/door/airlock/command{
@@ -2872,27 +2228,20 @@
 /turf/open/floor/plating,
 /area/security/main)
 "afS" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig EVA Storage";
-	req_access_txt = "3"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/brig)
 "afT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -2903,13 +2252,22 @@
 /area/security/main)
 "afV" = (
 /obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/assembly/timer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = -3
+	},
+/obj/item/assembly/flash/handheld,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "afW" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afX" = (
@@ -2917,21 +2275,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "afY" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/vending/dinnerware/prisoner,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "afZ" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aga" = (
@@ -2941,7 +2297,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/gun/energy/laser/practice,
+/obj/machinery/syndicatebomb/training,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "agb" = (
 /obj/structure/disposalpipe/segment,
@@ -2966,95 +2325,41 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "age" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/range)
-"agf" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal,
-/obj/item/storage/box/bodybags,
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair,
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
 /area/security/execution/transfer)
-"agg" = (
-/obj/structure/closet/secure_closet/injection,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/execution/transfer";
-	name = "Prisoner Transfer Centre";
-	pixel_y = -27
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"agh" = (
-/obj/structure/table,
-/obj/item/electropack,
-/obj/item/screwdriver,
-/obj/item/wrench,
-/obj/item/clothing/head/helmet,
-/obj/item/assembly/signaler,
-/obj/machinery/light/small,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution/transfer)
-"agi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "agj" = (
 /turf/closed/wall,
 /area/security/brig)
 "agk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/brig)
+"agl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"agl" = (
-/obj/structure/table,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "agm" = (
 /obj/machinery/light{
 	dir = 8
@@ -3081,16 +2386,12 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "agp" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
 /area/security/brig)
 "agq" = (
 /obj/effect/turf_decal/delivery,
@@ -3100,9 +2401,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agr" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "ags" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3111,34 +2414,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "agt" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"agu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"agv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/processing)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "agw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3173,33 +2453,38 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "agz" = (
-/obj/structure/closet/secure_closet{
-	name = "nonlethal ammunition";
-	req_access = "list(3)"
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -7;
+	pixel_y = -2
 	},
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agA" = (
@@ -3219,54 +2504,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"agB" = (
-/obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/main)
 "agC" = (
-/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/security/main)
-"agD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "agE" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 10
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/item/storage/fancy/donut_box,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = -10
-	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "agF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/execution/transfer)
 "agG" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -3301,42 +2563,40 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agJ" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "agK" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/chair/comfy/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "agL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3372,61 +2632,66 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agN" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
-"agO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Infirmary";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "agP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
 	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"agQ" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
+"agR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"agQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"agR" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4;
-	pixel_x = -3
+/obj/machinery/camera/motion{
+	c_tag = "Armory Motion Sensor";
+	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/gun/energy/temperature/security,
+/obj/item/clothing/suit/armor/laserproof,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agS" = (
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agT" = (
@@ -3445,7 +2710,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agU" = (
-/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agV" = (
@@ -3473,12 +2741,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "agX" = (
-/obj/machinery/button/door{
-	id = "armory2";
-	name = "Armory Shutters";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/window{
 	id = "armory2"
@@ -3486,24 +2748,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agY" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/bodybags,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/reagent_containers/blood,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "agZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -3517,19 +2768,24 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "ahc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahd" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahe" = (
@@ -3537,6 +2793,7 @@
 	dir = 4;
 	sortType = 8
 	},
+/obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahf" = (
@@ -3547,34 +2804,31 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/wood,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahh" = (
-/obj/item/paper_bin/bundlenatural{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain,
-/obj/item/folder/red,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/pen,
-/obj/structure/table,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahi" = (
@@ -3635,19 +2889,33 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/item/gun/energy/ionrifle,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = -1;
-	pixel_y = 1
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"ahn" = (
+/turf/closed/wall,
+/area/maintenance/fore/secondary)
+"aho" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/turf/open/floor/plating,
+/area/security/prison)
+"ahp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3658,70 +2926,47 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"ahn" = (
-/turf/closed/wall,
-/area/maintenance/fore/secondary)
-"aho" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"ahp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"ahq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/rack,
-/obj/item/storage/box/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ahr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ahs" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/closet/secure_closet/injection,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/security/execution/transfer";
+	name = "Prisoner Transfer Centre";
+	pixel_y = -27
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light_switch{
+	pixel_x = 25
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "aht" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/processor,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "ahu" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -3741,42 +2986,37 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/decal/cleanable/salt,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "ahw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/airlock/security{
+	name = "Infirmary";
+	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ahx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig EVA Storage";
+	req_access_txt = "3"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -3799,47 +3039,32 @@
 /area/security/brig)
 "ahA" = (
 /obj/structure/rack,
-/obj/structure/window/reinforced,
-/obj/item/storage/box/teargas{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/item/melee/baton/loaded{
+	pixel_y = -4
 	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/item/melee/baton/loaded{
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/item/shield/riot{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/shield/riot{
+	pixel_y = 2
+	},
+/obj/item/shield/riot{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	pixel_x = -30
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahB" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/gun/energy/e_gun/dragnet{
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3851,6 +3076,19 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/advtaser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/advtaser,
+/obj/item/gun/energy/e_gun/advtaser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahC" = (
@@ -3866,23 +3104,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahD" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"ahE" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ahF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3896,16 +3122,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahG" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/westright{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ahH" = (
 /obj/structure/disposalpipe/junction/yjunction{
@@ -3917,6 +3139,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahI" = (
@@ -3942,6 +3168,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahK" = (
@@ -3995,15 +3225,18 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/obj/structure/table/wood,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel,
+/area/security/main)
 "ahP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
+/area/security/main)
 "ahQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -4011,138 +3244,73 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ahR" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/plating,
+/area/security/prison)
 "ahS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera{
-	c_tag = "Brig Infirmary";
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/brig_phys,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "ahT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"ahU" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "ahV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/computer/security/labor{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ahW" = (
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = 8;
+	pixel_y = 7
+	},
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/ai_monitored/security/armory";
+	dir = 8;
+	name = "Armory APC";
+	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -4236,6 +3404,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aig" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/brig)
+"aih" = (
+/turf/closed/wall,
+/area/security/range)
+"aii" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas/sechailer{
 	pixel_x = -3;
@@ -4254,95 +3434,25 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aih" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "armory2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"aii" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aij" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleeper Hallway";
-	dir = 1;
-	network = list("ss13","prison")
-	},
+/obj/effect/decal/cleanable/flour,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aik" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/gun/energy/laser/practice,
-/obj/machinery/syndicatebomb/training,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
-"ail" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
-"aim" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plating,
 /area/security/prison)
-"ain" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced,
+"ail" = (
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4353,13 +3463,50 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/item/storage/box/bodybags{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"aim" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"ain" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "armory3";
+	name = "Armory Shutters";
+	pixel_x = -25;
+	pixel_y = -7;
+	req_access_txt = "3"
+	},
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/gun/energy/e_gun/dragnet{
+	pixel_x = 2;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aio" = (
@@ -4391,7 +3538,6 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ais" = (
-/obj/structure/filingcabinet,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -4432,28 +3578,15 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiv" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/bot,
+/obj/vehicle/ridden/secway,
+/obj/item/key/security,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aiw" = (
@@ -4464,9 +3597,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/structure/chair/sofa/left{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4505,9 +3635,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/chair/sofa{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiA" = (
@@ -4526,9 +3653,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/structure/chair/sofa/right{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4550,54 +3674,44 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/processing)
 "aiE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "aiF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Security Docking";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/button/electrochromatic{
+	id = "medsec";
+	name = "Window Privacy Control";
+	pixel_x = -26;
+	pixel_y = 25;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aiG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4623,35 +3737,42 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiI" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aiJ" = (
 /mob/living/simple_animal/pet/dog/cheems,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aiK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aiM" = (
@@ -4663,26 +3784,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aiN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiO" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -4693,7 +3800,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiP" = (
@@ -4703,13 +3810,16 @@
 /turf/closed/wall/r_wall,
 /area/security/main)
 "aiQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/range)
 "aiR" = (
-/obj/structure/closet/l3closet/security,
+/obj/machinery/computer/security,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -4717,22 +3827,15 @@
 /obj/item/stack/rods,
 /turf/open/space,
 /area/space/nearstation)
-"aiT" = (
-/turf/closed/wall,
-/area/security/processing)
-"aiU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/processing)
 "aiV" = (
-/obj/machinery/plate_chute/inputchute{
-	pixel_y = -25
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/range)
 "aiW" = (
-/obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiX" = (
@@ -4810,11 +3913,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/wood,
 /area/lawoffice)
-"ajg" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "ajh" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -4910,17 +4008,14 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "ajs" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/range)
 "ajt" = (
 /obj/machinery/camera{
 	c_tag = "Law Office";
@@ -4931,9 +4026,6 @@
 /area/lawoffice)
 "aju" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4942,10 +4034,15 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plasteel/checker,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
+	},
 /area/security/prison)
 "ajw" = (
 /obj/structure/disposalpipe/segment{
@@ -4988,30 +4085,35 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ajz" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
-"ajA" = (
-/obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/door/airlock/security{
+	name = "Infirmary";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"ajA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Pressing Room"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/checker,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "ajC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5026,17 +4128,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "ajE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -5062,14 +4157,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajG" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "ajH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5105,11 +4196,18 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5119,17 +4217,16 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajL" = (
-/obj/machinery/computer/security,
-/obj/effect/turf_decal/bot,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajM" = (
@@ -5264,26 +4361,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajY" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/westleft{
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5302,14 +4391,18 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akb" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/button/door{
+	id = "armory2";
+	name = "Armory Shutters";
+	pixel_y = -26;
+	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "armory2"
 	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "akc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5323,12 +4416,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akd" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/range)
 "ake" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -5359,8 +4449,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aki" = (
@@ -5378,11 +4469,16 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "akj" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Prison -  Exercise Room";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "akk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -5394,7 +4490,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "akl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -5403,7 +4499,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akm" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akn" = (
@@ -5466,13 +4564,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/computer/security/telescreen/interrogation{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aks" = (
@@ -5486,19 +4577,18 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akt" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/range)
 "aku" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5537,9 +4627,6 @@
 "akx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -5602,20 +4689,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/range)
 "akE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5632,27 +4709,34 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/processing)
 "akH" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/item/toy/cards/deck,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/range)
 "akI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/labor{
+	icon_keyboard = "laptop_key";
+	icon_screen = "medlaptop";
+	icon_state = "laptop";
+	name = "Labour Shuttle Control";
+	pixel_x = 5
+	},
+/obj/item/storage/box/prisoner{
+	pixel_x = -12;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -5670,16 +4754,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akK" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "akL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/meter,
@@ -5707,23 +4789,13 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "akP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
+/area/security/brig)
 "akQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5742,8 +4814,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akS" = (
@@ -5758,7 +4828,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -5770,29 +4839,23 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akU" = (
-/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
-"akW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 10
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/range)
+"akW" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/range)
 "akX" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -5823,7 +4886,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ala" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5883,13 +4946,14 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alf" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/range)
 "alg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -5947,25 +5011,26 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alm" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/photo_album,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aln" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/item/instrument/accordion,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/button/electrochromatic{
+	id = "medsec";
+	name = "Window Privacy Control";
+	pixel_x = -26;
+	pixel_y = -25;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "alo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -5980,9 +5045,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/security/warden)
-"alp" = (
-/turf/open/floor/plating,
-/area/security/processing)
 "alq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5993,12 +5055,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "alr" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "als" = (
 /obj/machinery/door_timer{
@@ -6023,17 +5082,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/vg_decals/department/sec,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alu" = (
 /obj/machinery/nuclearbomb/selfdestruct,
@@ -6071,26 +5121,14 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/vg_decals/department/sec,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "alx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "aly" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6098,9 +5136,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -6161,7 +5196,7 @@
 	pixel_x = -24;
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "alF" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
@@ -6233,11 +5268,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "alM" = (
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "alN" = (
 /obj/machinery/computer/prisoner/management,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "alO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6278,15 +5313,26 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "alV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "alW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Sleepers"
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/rawbacon,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "alX" = (
 /obj/machinery/button/door{
@@ -6306,11 +5352,15 @@
 	dir = 8
 	},
 /obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "alZ" = (
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -32
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ama" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -6326,9 +5376,17 @@
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "amc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/range)
 "amd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -6365,25 +5423,26 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "amh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ami" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
+"ami" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "amj" = (
 /obj/machinery/door_timer{
 	id = "Cell 2";
@@ -6404,10 +5463,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aml" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/security/prison)
 "amm" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -6429,29 +5484,6 @@
 	name = "brig shutters"
 	},
 /turf/open/floor/plating,
-/area/security/brig)
-"amo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"amp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "amr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6562,58 +5594,21 @@
 /obj/item/coin/diamond,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"amG" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"amH" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"amI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amK" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
-/area/security/processing)
 "amL" = (
-/turf/open/floor/plasteel/dark,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/security/brig)
 "amN" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -6639,32 +5634,31 @@
 	name = "Reception Desk";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "amO" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/security/brig)
 "amP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"amQ" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"amQ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "amR" = (
 /obj/structure/cable{
@@ -6687,8 +5681,27 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "amT" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 4;
+	name = "strong purple corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "amU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6697,15 +5710,15 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "amV" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "amW" = (
 /obj/effect/landmark/start/warden,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "amX" = (
 /obj/structure/chair{
@@ -6748,7 +5761,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "and" = (
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access_txt = "2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ane" = (
@@ -6822,23 +5840,35 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ano" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/wood,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "anp" = (
-/obj/structure/filingcabinet,
-/obj/machinery/camera{
-	c_tag = "Permabrig Library";
-	network = list("ss13","prison")
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 8;
+	name = "strong purple corner"
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/musician/piano{
+	icon_state = "piano";
+	name = "Grand Piano"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "anq" = (
 /obj/structure/chair{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -6853,7 +5883,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "ant" = (
 /obj/machinery/door/firedoor,
@@ -6861,7 +5891,7 @@
 	name = "Evidence Storage";
 	req_access_txt = "3"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "anu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -6888,12 +5918,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "anx" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole,
-/turf/open/floor/wood,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool,
+/obj/effect/spawner/lootdrop/seeds,
+/obj/effect/spawner/lootdrop/seeds,
+/obj/effect/spawner/lootdrop/soap/twentyfive_percent,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool,
+/obj/effect/spawner/lootdrop/space_cash/medium_chance,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/weldingtool,
+/turf/open/floor/plating,
 /area/security/prison)
 "any" = (
-/obj/effect/landmark/event_spawn,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6901,7 +5937,26 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/brig)
 "anz" = (
 /turf/open/floor/plasteel,
@@ -6916,15 +5971,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -6935,7 +5981,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "anC" = (
 /obj/effect/spawner/structure/window,
@@ -7002,9 +6050,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -7023,27 +6068,36 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "anN" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/storage/bag/trash,
-/obj/item/radio/off,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/gulag_teleporter,
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"anO" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
-"anO" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
-	},
-/turf/open/space/basic,
-/area/space)
 "anP" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7054,14 +6108,21 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "anQ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "anR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -7222,58 +6283,63 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoo" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/monkey_recycler,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"aop" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/seeds,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool,
+/obj/item/pda,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/plasmaman/belt,
-/obj/item/tank/internals/nitrogen/belt/full,
-/obj/item/tank/internals/nitrogen/belt/full,
+/turf/open/floor/plating,
+/area/security/prison)
+"aop" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "aoq" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "aor" = (
 /obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
-/obj/item/folder/red,
-/obj/machinery/light_switch{
-	pixel_y = -24
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/item/flashlight/lamp{
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aos" = (
-/obj/machinery/vr_sleeper{
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/processing)
 "aot" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aou" = (
 /obj/structure/cable{
@@ -7378,7 +6444,9 @@
 /area/hallway/primary/fore)
 "aoF" = (
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -7508,7 +6576,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoY" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -7520,7 +6587,7 @@
 	pixel_x = 24;
 	pixel_y = -28
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aoZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -7541,18 +6608,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "apb" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/processing)
 "apc" = (
 /obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "apd" = (
 /turf/closed/wall,
@@ -7705,17 +6765,18 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "apw" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space East";
-	dir = 4;
-	name = "aft camera"
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "apx" = (
 /obj/machinery/door/airlock/atmos/abandoned{
 	name = "Atmospherics Maintenance";
@@ -7813,7 +6874,7 @@
 	pixel_y = -24;
 	req_access_txt = "2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "apI" = (
 /obj/structure/disposalpipe/segment{
@@ -7825,9 +6886,6 @@
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "apK" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -7883,24 +6941,14 @@
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/vg_decals/department/sec,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "apS" = (
 /obj/structure/cable{
@@ -8156,7 +7204,7 @@
 	id = "Secure Brig Control";
 	name = "brig shutters"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aqs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -8232,10 +7280,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aqB" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
+	},
 /area/security/prison)
 "aqC" = (
 /obj/effect/turf_decal/tile/red{
@@ -8282,14 +7332,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqG" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/bed,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aqH" = (
 /obj/machinery/light{
@@ -8302,8 +7346,26 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Security Docking";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -8343,13 +7405,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /obj/item/radio/intercom{
 	pixel_x = 32;
 	pixel_y = 20
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "aqO" = (
 /obj/structure/closet,
@@ -8377,28 +7438,36 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqS" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aqT" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "1"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "aqU" = (
-/obj/item/paper/fluff/jobs/security/beepsky_mom,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/computer/shuttle/labor{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "aqV" = (
 /mob/living/simple_animal/sloth/paperwork,
 /turf/open/floor/plasteel,
@@ -8451,9 +7520,15 @@
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
 "arc" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/taperecorder,
+/obj/item/folder/red,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "are" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -8466,10 +7541,7 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "arg" = (
-/obj/item/bedsheet/red,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Officer Beepsky"
-	},
+/obj/item/paper/fluff/jobs/security/beepsky_mom,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "arh" = (
@@ -8497,16 +7569,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "arl" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/potato{
-	name = "\improper Beepsky's emergency battery"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "arm" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -8518,18 +7585,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "arn" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/processing";
-	dir = 8;
-	name = "Labor Shuttle Dock APC";
-	pixel_x = -24
+/obj/item/melee/baton/cattleprod,
+/obj/item/stock_parts/cell/high,
+/obj/item/electropack,
+/obj/structure/closet/secure_closet{
+	name = "Persuasion Storage";
+	req_access = "list(2)"
 	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aro" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -8558,10 +7622,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ars" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/turf/closed/wall,
 /area/security/prison)
 "art" = (
 /obj/machinery/light/small{
@@ -8625,7 +7688,7 @@
 	c_tag = "Brig Control";
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "arz" = (
 /obj/item/coin/gold,
@@ -8643,32 +7706,30 @@
 /area/hallway/secondary/entry)
 "arC" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
 "arD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "arE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -8762,11 +7823,8 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "arQ" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "arR" = (
@@ -8777,12 +7835,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "arS" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "arT" = (
@@ -9004,22 +8057,6 @@
 	},
 /turf/open/floor/plating,
 /area/blueshield)
-"asp" = (
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 8;
-	network = list("interrogation")
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "asq" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch{
@@ -9050,28 +8087,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/wood,
 /area/security/warden)
-"asr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ass" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "ast" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -9085,19 +8102,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asv" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -9128,14 +8134,11 @@
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "asC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "asD" = (
 /obj/structure/table/wood,
@@ -9149,17 +8152,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"asG" = (
-/obj/structure/bed,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "asH" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -9203,12 +8195,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"asL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "asN" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -9221,44 +8207,41 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asP" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the purple cell block.";
+	name = "Cell - Purple"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "asQ" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/prison)
 "asR" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin/towel,
+/obj/item/soap,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "asS" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"asT" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "asU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"asV" = (
-/obj/structure/bed,
-/obj/effect/landmark/start/prisoner,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
+/area/security/processing)
 "asW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -9266,27 +8249,31 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "asX" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/kink{
+	premium = list(/obj/item/clothing/accessory/skullcodpiece/fake = 3, /obj/item/reagent_containers/glass/bottle/hexacrocin = 10, /obj/item/clothing/under/pants/chaps = 5, /obj/item/crowbar = 1, /obj/item/weldingtool = 1)
+	},
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Security Prison - North Hallway";
+	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/structure/sign/poster/official/fashion{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "asY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/prison)
 "asZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -9379,18 +8366,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "atk" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/security/prison)
 "atl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/wood,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "atm" = (
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -9401,8 +8387,10 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "ato" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
 /area/security/prison)
 "atp" = (
 /obj/machinery/door/airlock/external{
@@ -9426,16 +8414,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ats" = (
-/obj/machinery/newscaster,
-/turf/closed/wall,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool,
+/obj/effect/spawner/lootdrop/soap/twentyfive_percent,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/item/poster/random_contraband,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
 /area/security/prison)
 "att" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "atu" = (
-/obj/item/caution,
-/obj/item/caution,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "atw" = (
@@ -9456,12 +8449,17 @@
 	},
 /area/maintenance/starboard/fore)
 "atz" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "fore bay 1";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
 	},
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/space/basic,
+/area/space)
 "atA" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -9562,56 +8560,47 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "atQ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/obj/machinery/vr_sleeper{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/processing)
 "atR" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "atS" = (
 /turf/closed/wall,
 /area/space/nearstation)
 "atT" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "atU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atV" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "atW" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atX" = (
-/obj/machinery/shower{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
 /area/security/prison)
 "atZ" = (
 /obj/effect/turf_decal/tile/red{
@@ -9653,16 +8642,12 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aud" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/security/processing)
 "aue" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -9707,14 +8692,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/blueshield)
-"auj" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -9760,16 +8737,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aup" = (
-/obj/structure/toilet{
-	contents = newlist(/obj/item/toy/snappop/phoenix);
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "auq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -9784,12 +8751,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"aus" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aut" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -9800,13 +8761,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"auu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "auv" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -9839,13 +8793,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"auy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "auz" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck"
@@ -9859,11 +8806,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "auA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of a colour coded cell bock. This is an orange cell.";
+	name = "Cell - Orange"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "auB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -9881,11 +8831,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "auC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "auD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -9948,14 +8902,15 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "auN" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "auO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -9990,19 +8945,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "auS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/pool/ladder{
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
+/turf/open/pool,
 /area/security/prison)
 "auT" = (
 /obj/structure/cable{
@@ -10011,20 +8957,24 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auU" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "auV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "auW" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/secure_closet/chemical,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "auX" = (
 /obj/structure/mirror{
 	icon_state = "mirror_broke";
@@ -10064,19 +9014,23 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avd" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/structure/closet/secure_closet/chemical,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ave" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/plasticflaps,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/fore)
 "avf" = (
-/obj/machinery/space_heater,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/security/prison)
+/area/maintenance/fore)
 "avg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm5";
@@ -10121,12 +9075,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "avm" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "avn" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm6";
@@ -10185,16 +9138,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avu" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Showers";
-	dir = 4;
-	network = list("ss13","prison")
+/obj/item/bedsheet/red,
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Officer Beepsky"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "avv" = (
 /obj/machinery/camera{
 	c_tag = "Dorms West"
@@ -10259,12 +9208,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/potato{
+	name = "\improper Beepsky's emergency battery"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "avC" = (
 /obj/structure/chair{
 	dir = 8
@@ -10477,35 +9430,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"awd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"awe" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "awf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/power/apc{
+	areastring = "/area/security/processing";
+	dir = 8;
+	name = "Labor Shuttle Dock APC";
+	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "awg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10646,18 +9583,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aws" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/mob/living/simple_animal/hostile/retaliate/goose{
+	desc = "Some evil loose goose.";
+	name = "Cere"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "awt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/sign/warning/fire{
@@ -10698,18 +9629,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aww" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "awx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10877,16 +9799,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"awN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "awO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10970,12 +9882,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"awX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/prison)
 "awY" = (
 /obj/machinery/light{
 	dir = 1
@@ -11039,13 +9945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"axd" = (
-/obj/structure/bookcase/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "axe" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -11101,11 +10000,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "axn" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -11150,13 +10048,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axs" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/security/prison)
+/obj/structure/chair/stool,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "axt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11185,13 +10080,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"axv" = (
-/obj/structure/closet/crate/trashcart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "axw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -11204,15 +10092,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"axx" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "axy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11333,12 +10212,6 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axR" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/security/prison)
 "axS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -11352,22 +10225,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"axV" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/soap/homemade,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "axW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -11378,33 +10235,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 2";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"axZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aya" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -11586,22 +10416,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ayB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Permabrig East Hallway 2";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ayC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -11609,16 +10423,6 @@
 "ayE" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore)
-"ayF" = (
-/obj/machinery/light,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/security/prison)
 "ayG" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
@@ -11813,15 +10617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"azd" = (
-/obj/machinery/door/airlock/glass{
-	name = "Storage"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "aze" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -11859,12 +10654,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "azj" = (
-/obj/machinery/atmospherics/components/binary/valve{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
 /area/security/prison)
 "azk" = (
 /obj/structure/disposalpipe/segment,
@@ -12090,15 +10884,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"azP" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space West";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "azQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12154,13 +10939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"azV" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
 "azW" = (
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -12214,27 +10992,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aAf" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/prison)
-"aAg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aAh" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet)
@@ -12271,15 +11028,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aAm" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aAn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12314,21 +11062,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aAu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aAv" = (
 /obj/structure/closet,
 /obj/effect/landmark/blobstart,
@@ -12466,14 +11199,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aAM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aAN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -12813,14 +11538,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aBD" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aBE" = (
 /obj/item/clothing/under/misc/mailman,
 /obj/item/clothing/head/mailman,
@@ -12869,13 +11586,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aBM" = (
-/obj/machinery/deepfryer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aBN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -12908,15 +11618,6 @@
 "aBR" = (
 /turf/closed/wall/r_wall,
 /area/storage/primary)
-"aBS" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aBT" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white,
@@ -13023,11 +11724,8 @@
 /turf/closed/wall,
 /area/crew_quarters/toilet)
 "aCf" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/pool/drain,
+/turf/open/pool,
 /area/security/prison)
 "aCg" = (
 /obj/structure/cable{
@@ -13066,17 +11764,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aCm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
-	network = list("ss13","prison")
-	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aCn" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -13089,11 +11776,24 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aCo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/obj/machinery/vending/dinnerware/prisoner,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/chair/comfy{
+	color = "#e8a768";
+	name = "orange comfy chair"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aCp" = (
 /obj/machinery/camera{
@@ -13109,12 +11809,11 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aCq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/pool/ladder{
+	dir = 8;
+	pixel_x = 4
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/white,
+/turf/open/pool,
 /area/security/prison)
 "aCr" = (
 /turf/closed/wall,
@@ -13170,15 +11869,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"aCx" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -13342,23 +12032,6 @@
 "aCR" = (
 /turf/closed/wall,
 /area/chapel/main)
-"aCS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aCT" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -13370,28 +12043,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"aCU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/washing_machine,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aCV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aCW" = (
 /obj/effect/spawner/blocker,
 /turf/open/floor/plating,
@@ -13603,16 +12254,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"aDu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aDv" = (
 /obj/structure/chair/stool,
 /obj/structure/window,
@@ -13734,10 +12375,22 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "aDJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aDK" = (
 /obj/machinery/door/airlock/public/glass{
@@ -13787,10 +12440,15 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aDO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/yellowsiding{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aDP" = (
 /obj/machinery/shower{
@@ -13816,10 +12474,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aDS" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aDT" = (
 /obj/item/soap,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -13838,13 +12492,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aDV" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aDW" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aDY" = (
 /obj/structure/window{
 	dir = 4
@@ -13878,23 +12525,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aEb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aEc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13997,105 +12627,21 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
-"aEo" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aEp" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aEq" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Laundry"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aEr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aEs" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aEt" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aEu" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
+/obj/structure/bed,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aEv" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aEw" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aEx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aEy" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "aEz" = (
 /obj/machinery/power/apc{
@@ -14372,68 +12918,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aFf" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aFg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aFh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cell Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aFi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aFj" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/closet/crate/trashcart,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aFk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -14505,10 +13004,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aFt" = (
-/obj/machinery/smartfridge/food,
-/turf/closed/wall,
-/area/security/prison)
 "aFu" = (
 /turf/closed/wall,
 /area/library)
@@ -14561,26 +13056,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aFD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aFF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig West Hallway 1";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aFG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -14725,10 +13200,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aFS" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aFT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -14826,11 +13297,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"aGe" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -14899,14 +13365,6 @@
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"aGn" = (
-/obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aGo" = (
 /obj/structure/table,
 /obj/item/stack/sheet/rglass{
@@ -14925,9 +13383,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aGp" = (
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aGq" = (
 /obj/item/stack/sheet/plasteel{
 	amount = 10
@@ -15147,14 +13602,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGK" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aGL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15195,19 +13642,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/chapel/office)
-"aGP" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/biogenerator/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aGQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -15220,16 +13654,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aGR" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aGS" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -15329,16 +13753,6 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/wood,
 /area/library)
-"aHc" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients/prisoner,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aHd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -15431,53 +13845,10 @@
 	dir = 4
 	},
 /area/chapel/main)
-"aHp" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/hatchet,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aHq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/main)
-"aHr" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aHs" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aHt" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/snacks/hotdog,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aHu" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
@@ -15718,12 +14089,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aHU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aHV" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15742,16 +14107,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"aHW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aHX" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aHY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -15835,15 +14190,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aIi" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aIj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16004,12 +14350,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"aIA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aIB" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "crematoriumChapel"
@@ -16035,34 +14375,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"aIF" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aIG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aIH" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -16237,17 +14549,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aJd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aJe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16573,13 +14874,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"aJN" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aJO" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -16681,10 +14975,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aKb" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aKc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -16730,33 +15020,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aKg" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aKh" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	dir = 4;
-	network = list("ss13","prison")
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aKi" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aKj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -16823,22 +15086,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
-"aKt" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aKu" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
-"aKv" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aKw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16863,11 +15114,16 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aKx" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
@@ -17151,16 +15407,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/library)
-"aLh" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aLi" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17230,15 +15476,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aLs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aLt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -17342,16 +15579,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aLJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aLK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -17408,16 +15635,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aLS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aLT" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
@@ -17567,19 +15784,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aMp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aMq" = (
 /obj/structure/sign/poster/contraband/space_cola{
 	pixel_x = -32
@@ -17613,14 +15817,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aMv" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aMw" = (
 /obj/machinery/vending/dinnerware{
 	contraband = list(/obj/item/reagent_containers/food/condiment/flour = 4);
@@ -17699,31 +15895,19 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMH" = (
-/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/prison)
 "aMI" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aMJ" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aMK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aML" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -17798,12 +15982,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aMW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aMX" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -17885,10 +16063,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aNn" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aNo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -17918,16 +16092,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aNt" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aNu" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff{
@@ -18018,22 +16182,6 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aNG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aNH" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aNI" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -18042,16 +16190,6 @@
 /obj/machinery/prize_counter,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aNJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Garden"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aNK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -18301,14 +16439,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOu" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Prison -  Orange Wing";
+	dir = 1;
+	network = list("ss13","prison");
+	start_active = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
 /area/security/prison)
 "aOv" = (
 /obj/structure/cable{
@@ -18450,16 +16592,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aOK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aOL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -18588,23 +16720,13 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
 /area/library)
-"aPh" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aPi" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aPj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "aPk" = (
 /turf/open/floor/plasteel/chapel{
@@ -18666,16 +16788,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aPw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aPx" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -18766,9 +16878,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPP" = (
-/obj/structure/chair/stool,
-/obj/machinery/light,
-/turf/open/floor/plasteel/cafeteria,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
 /area/security/prison)
 "aPQ" = (
 /turf/closed/wall,
@@ -19033,14 +17150,6 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/carpet,
 /area/library)
-"aQt" = (
-/obj/structure/table,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aQu" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -19198,13 +17307,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aQQ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "aQR" = (
 /obj/machinery/vending/cola/pwr_game,
 /obj/structure/sign/poster/contraband/pwr_game{
@@ -19466,24 +17568,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aRv" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"aRw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aRx" = (
 /obj/machinery/computer/arcade/minesweeper,
 /turf/open/floor/wood,
@@ -19748,14 +17832,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aSj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aSk" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -19780,33 +17856,6 @@
 /obj/item/extinguisher,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
-"aSo" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/structure/closet/crate/bin,
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aSp" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aSq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -19930,13 +17979,6 @@
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aSG" = (
-/obj/machinery/requests_console{
-	department = "Prison";
-	departmentType = 1
-	},
-/turf/closed/wall,
-/area/security/prison)
 "aSH" = (
 /obj/machinery/light{
 	dir = 1
@@ -20128,14 +18170,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aTa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aTb" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -20203,37 +18237,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"aTp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aTq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "permalock2"
-	},
-/obj/machinery/button/door{
-	id = "soli1";
-	name = "Solitary Cell 1";
-	pixel_x = 26;
-	pixel_y = 10;
-	req_access_txt = "3"
-	},
-/obj/machinery/door_timer{
-	id = "soli1";
-	name = "Solitary 1 door timer";
-	pixel_x = 31;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aTr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac{
@@ -20273,17 +18276,6 @@
 /obj/item/clothing/under/costume/kilt,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aTx" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Visitation - Prisoners"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "visitexit"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aTy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -20309,20 +18301,25 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
 	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aTB" = (
@@ -20542,13 +18539,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"aUf" = (
-/obj/structure/window/reinforced,
-/obj/machinery/conveyor/auto{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aUg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -20632,18 +18622,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aUq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aUr" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aUs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20730,16 +18708,6 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
 /area/library)
-"aUC" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 1";
-	network = list("ss13","prison")
-	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "aUD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -20808,20 +18776,6 @@
 "aUO" = (
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"aUP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/flasher{
-	id = "visitflash";
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aUQ" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -20857,19 +18811,6 @@
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aUV" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aUW" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -21155,26 +19096,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aVw" = (
-/obj/structure/lattice,
-/obj/machinery/camera,
-/turf/open/space,
-/area/space/nearstation)
 "aVx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
 	dir = 4;
-	layer = 2.9
+	name = "engineering corner"
 	},
-/obj/machinery/conveyor/auto{
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21259,18 +19197,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"aVG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aVH" = (
 /obj/machinery/biogenerator,
 /obj/machinery/door/firedoor,
@@ -21344,8 +19270,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aVP" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -21564,12 +19493,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aWw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aWx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -22094,12 +20017,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"aXs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aXt" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -22149,19 +20066,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
 	dir = 4;
-	layer = 2.9
+	name = "engineering corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aXy" = (
@@ -22177,12 +20097,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main)
-"aXA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aXB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -22226,15 +20140,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aXH" = (
-/obj/machinery/button/door{
-	id = "permalock2";
-	name = "Perma Secure Airlock";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aXI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -22283,14 +20188,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"aXO" = (
-/obj/machinery/door/poddoor{
-	id = "soli2"
-	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "aXP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -22369,16 +20266,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
-"aYa" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Iso Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/structure/bed,
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
-/area/security/prison)
 "aYb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22438,12 +20325,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"aYh" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "sexroom"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aYi" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/structure/disposalpipe/segment{
@@ -22678,19 +20559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aYH" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
-"aYI" = (
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aYJ" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -22797,20 +20665,6 @@
 "aYW" = (
 /turf/open/floor/carpet,
 /area/library)
-"aYX" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aYY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -23197,23 +21051,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bae" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Perma Wing";
-	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/poddoor/preopen{
-	id = "locklock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "baf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -23655,12 +21492,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "bbr" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "visit"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "bbs" = (
 /obj/structure/window/reinforced{
@@ -23808,14 +21643,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
-"bbN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window,
-/obj/machinery/door/poddoor/shutters{
-	id = "visit"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bbO" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -23856,12 +21683,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"bbU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
 "bbV" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23887,11 +21708,6 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"bbZ" = (
-/obj/item/bedsheet/rd/royal_cape,
-/obj/structure/bed/pod,
-/turf/open/floor/plasteel/vaporwave,
-/area/security/prison)
 "bca" = (
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
@@ -24145,13 +21961,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
-"bcO" = (
-/obj/machinery/flasher{
-	id = "permalock";
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bcP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -24177,33 +21986,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"bcT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
-/obj/item/clothing/head/helmet/space/plasmaman/prisoner,
-/obj/item/clothing/under/plasmaman/prisoner,
-/obj/item/clothing/under/plasmaman/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bcU" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/vg_decals/numbers/three,
@@ -24219,9 +22001,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"bcW" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/ai_monitored/security/armory)
 "bcX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -24550,14 +22329,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "bdM" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "Chief Medical Office";
-	dir = 8;
-	network = list("ss13","medbay");
-	pixel_y = -22
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bdO" = (
 /obj/machinery/door/airlock/maintenance{
@@ -24623,25 +22398,6 @@
 /obj/item/reagent_containers/glass/bottle/vial/small,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"bdV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"bdW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bdX" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
@@ -24757,15 +22513,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"bei" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bej" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
@@ -25194,40 +22941,13 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bfk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Processing";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/off,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "bfl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -25490,6 +23210,15 @@
 "bgc" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
+"bgd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bge" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -25539,10 +23268,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bgl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bgm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -25630,11 +23355,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bgx" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bgy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -25754,22 +23474,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bgR" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Visitor-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "sexroom";
-	name = "Conjugal Visits";
-	pixel_x = 27;
-	pixel_y = 1;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bgS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26110,24 +23814,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bhK" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/plasticflaps,
-/obj/machinery/conveyor/auto{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bhL" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -26161,16 +23847,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bhP" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/conveyor/auto{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bhQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -26408,6 +24084,17 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"biC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "biE" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
@@ -26466,11 +24153,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown5";
+	name = "Lockdown"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/button/door{
+	id = "lockdown5";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "biN" = (
 /obj/structure/table/reinforced,
@@ -26606,33 +24308,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "biZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/turnstile{
+	req_one_access_txt = "1;4;63;69"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/table/reinforced,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bja" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -26879,12 +24560,16 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjD" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/machinery/turnstile{
+	dir = 1;
+	req_one_access_txt = "1;4;63;70"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bjE" = (
 /obj/machinery/airalarm{
@@ -26960,14 +24645,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bjW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bjX" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -26995,20 +24672,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bke" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/button/door{
-	id = "visitexit";
-	name = "Visitation Prisoner Lockdown";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bkf" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27021,13 +24684,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"bkg" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bki" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -27063,25 +24719,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"bkl" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/button/flasher{
-	id = "visitflash";
-	pixel_x = 24;
-	pixel_y = 5;
-	req_access_txt = "3"
-	},
-/obj/machinery/button/door{
-	id = "visit";
-	name = "Visitation Shutters";
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bkm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -27203,19 +24840,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bkA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bkB" = (
 /obj/machinery/button/door{
 	id = "Disposal Exit";
@@ -27269,21 +24893,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bkI" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Prisoner Processing";
-	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/conveyor/auto{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "bkJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -27741,16 +25355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"blN" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Visitation - Visitors";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "blO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -27790,20 +25394,21 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "blT" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "permalock";
-	pixel_x = 6;
-	pixel_y = 36;
-	req_access_txt = "3"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "blU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -27953,13 +25558,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bml" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bmm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28021,36 +25619,28 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bmu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "locklock";
-	name = "Perma Airlock Lockdown";
-	pixel_y = 26;
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "bmv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/arrows{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "bmx" = (
 /turf/closed/wall,
@@ -28207,28 +25797,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
-"bnd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/camera,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bne" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bnf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -28549,11 +26117,15 @@
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bnU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "bnV" = (
 /obj/structure/cable{
@@ -28663,15 +26235,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bop" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "bor" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
@@ -28715,8 +26292,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bot" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -28726,9 +26301,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/machinery/vending/wallmed{
-	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -29213,6 +26785,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bpD" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "bpE" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
@@ -33080,7 +30668,6 @@
 	},
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
 /turf/open/floor/plating,
@@ -33139,6 +30726,19 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"bzr" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "bzs" = (
 /turf/closed/wall,
 /area/maintenance/aft)
@@ -34963,6 +32563,24 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"bDF" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "bDG" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow,
@@ -36244,6 +33862,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bGS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/security/prison)
 "bGV" = (
 /obj/structure/sink{
 	dir = 4;
@@ -44692,6 +42324,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"cbX" = (
+/obj/effect/spawner/lootdrop/wall/seventyfive_percent_falsewall,
+/turf/open/floor/plating,
+/area/security/prison)
 "cca" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -47584,6 +45220,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cjn" = (
+/obj/effect/spawner/lootdrop/prison_safe,
+/turf/open/floor/plating,
+/area/security/prison)
 "cjo" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -49185,6 +46825,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"coi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/security/prison)
 "con" = (
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
@@ -49366,6 +47012,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"coN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 8
+	},
+/area/security/prison)
 "coT" = (
 /obj/machinery/computer/nanite_chamber_control,
 /turf/open/floor/engine,
@@ -49514,6 +47166,15 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cpt" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/poppy/geranium{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy/lily,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "cpC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
@@ -50086,7 +47747,9 @@
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "csM" = (
 /obj/structure/lattice,
@@ -51830,7 +49493,19 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "cxP" = (
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "cxU" = (
@@ -51856,7 +49531,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cya" = (
-/obj/machinery/light/small,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "cyb" = (
@@ -51889,6 +49564,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"cyi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cyl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -53038,6 +50719,10 @@
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"cFc" = (
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cGz" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
@@ -53321,6 +51006,12 @@
 /obj/structure/sign/poster/official/cohiba_robusto_ad,
 /turf/closed/wall,
 /area/lawoffice)
+"cJL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "cJW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit,
@@ -53338,6 +51029,12 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"cKx" = (
+/obj/structure/table,
+/obj/item/soap,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "cKG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -53361,6 +51058,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"cMg" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "cMC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -53413,6 +51127,25 @@
 "cNd" = (
 /turf/open/space/basic,
 /area/space/station_ruins)
+"cNq" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/mirror{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "cNE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -53545,6 +51278,12 @@
 "cOe" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cOt" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cOw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -54034,6 +51773,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"cYf" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown5";
+	name = "Lockdown"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"cYt" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "cZP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -54052,25 +51814,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "daA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
 /area/security/processing)
 "dbx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
 /obj/structure/rack,
@@ -54154,6 +51911,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"dhE" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "diq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -54165,11 +51936,47 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
-"dly" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"djJ" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"dkx" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"dly" = (
+/obj/item/radio/intercom{
+	pixel_y = 20
+	},
+/obj/structure/table,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
 /area/security/range)
 "dml" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54211,35 +52018,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"dqN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig Entrance";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
-	},
-/obj/machinery/button/door{
-	id = "soli2";
-	name = "Solitary Cell 2";
-	pixel_x = 26;
-	pixel_y = -10;
-	req_access_txt = "3"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/door_timer{
-	id = "soli2";
-	name = "Solitary 2 door timer";
-	pixel_x = 31;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "drK" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -54254,7 +52032,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "dsC" = (
 /obj/structure/chair/stool{
@@ -54313,6 +52093,30 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"dvA" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Prison -  Purple Wing";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"dwZ" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "dxe" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -54397,6 +52201,23 @@
 /obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"dCm" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "dCr" = (
 /obj/structure/pool/Rboard,
 /turf/open/floor/plasteel/yellowsiding{
@@ -54414,18 +52235,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/explab)
-"dCV" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
 "dDi" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical{
@@ -54441,22 +52250,56 @@
 /obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"dEE" = (
+/obj/effect/turf_decal/tile/purple{
+	alpha = 255;
+	dir = 1;
+	name = "strong purple corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"dEN" = (
+/obj/effect/spawner/lootdrop/wall/fifty_percent_falsewall,
+/turf/open/floor/plating,
+/area/security/prison)
+"dFD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/security/prison)
 "dFX" = (
 /turf/closed/wall,
 /area/crew_quarters/fitness/pool)
 "dHU" = (
-/obj/structure/bed/dogbed{
-	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
-	name = "pet bed"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "dIj" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/clothing/under/costume/kilt,
 /obj/item/clothing/under/rank/civilian/janitor/maid,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"dIs" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "dIP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54465,8 +52308,53 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/security/brig)
+"dJb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
+"dJp" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	layer = 2.4
+	},
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Armory";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"dJw" = (
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dJQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "dJY" = (
 /obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plasteel/stairs/medium,
@@ -54492,6 +52380,26 @@
 /obj/effect/turf_decal/vg_decals/radiation,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dKY" = (
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/obj/item/reagent_containers/food/snacks/sea_weed,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/potato/sweet,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/grapes/green,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/berries,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/obj/item/reagent_containers/food/snacks/grown/cherrybulbs,
+/obj/item/reagent_containers/food/snacks/grown/bluecherries,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/obj/item/reagent_containers/food/snacks/grown/carrot,
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "dLb" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
@@ -54539,17 +52447,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"dOj" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Sleepers";
+"dOn" = (
+/obj/structure/pool/ladder{
 	dir = 1;
-	network = list("ss13","prison")
+	pixel_y = -24
 	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/pool,
 /area/security/prison)
+"dOP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "dPk" = (
 /obj/structure/closet{
 	name = "Costume Closet"
@@ -54570,28 +52484,76 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dRt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
+"dRw" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown6";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"dSr" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown6";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown6";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dTI" = (
 /obj/structure/urinal{
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"dWM" = (
-/obj/structure/table,
+"dWe" = (
+/obj/structure/closet/crate,
+/obj/item/instrument/piano_synth,
+/obj/item/toy/cards/deck,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/obj/effect/spawner/lootdrop/prison_safe,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/turf/open/floor/plating,
+/area/security/prison)
+"dWg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/recharger,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plating,
+/area/security/prison)
 "dXq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -54611,6 +52573,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dXM" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "dXN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -54618,8 +52586,11 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "dXP" = (
-/turf/closed/wall/r_wall,
-/area/security/range)
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "medsec"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "dZo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54651,6 +52622,21 @@
 "ecI" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"ecJ" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/cherrycupcake,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "edA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54660,6 +52646,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"edO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "eer" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -54772,6 +52767,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"elO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/security/prison)
 "elW" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -54789,16 +52790,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"enB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/security/execution/transfer)
+"ent" = (
+/obj/structure/rack,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison)
 "enY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"eoD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison)
+"eoP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 1
+	},
+/area/security/prison)
 "epC" = (
 /obj/machinery/door/airlock{
 	desc = "To keep the station within regulations, space IKEA requires one storage cupboard for their Nanotrasen partnership to continue.";
@@ -54818,6 +52842,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"epL" = (
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"erB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/yellowsiding/corner{
+	dir = 1
+	},
+/area/security/prison)
 "esZ" = (
 /obj/machinery/door/airlock{
 	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
@@ -54836,6 +52881,28 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"eve" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"evx" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "evR" = (
 /turf/open/floor/plating,
 /area/maintenance/bar)
@@ -54856,6 +52923,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eyf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "eyM" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -54864,6 +52935,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"ezG" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eAb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54880,6 +52961,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"eBn" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "eBX" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/dark,
@@ -54909,27 +52994,10 @@
 /obj/item/clothing/under/rank/civilian/lawyer/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"eCQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/rack,
-/obj/item/storage/box/zipties{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/item/storage/box/zipties{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+"eCO" = (
+/obj/structure/punching_bag,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "eCR" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54947,6 +53015,25 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
+"eDF" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"eDW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eEe" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -54990,6 +53077,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eLk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
 "eMs" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -54998,6 +53092,33 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"eMR" = (
+/obj/structure/chair/sofa,
+/turf/open/floor/wood,
+/area/security/prison)
+"eND" = (
+/obj/structure/chair/sofa/corner,
+/obj/structure/sign/poster/contraband/scum{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"eOg" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/prison";
+	dir = 4;
+	name = "Prison Wing APC";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "eQb" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
@@ -55012,6 +53133,9 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"eRk" = (
+/turf/open/floor/plating,
+/area/security/prison)
 "eRz" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -55030,12 +53154,45 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eTZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "eUE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"eUL" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/caution,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/storage/bag/trash,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eVC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
@@ -55062,6 +53219,43 @@
 	},
 /turf/closed/wall,
 /area/medical/morgue)
+"eXR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/security/prison)
+"eYK" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"eYT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
+"eZm" = (
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"eZp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "fah" = (
 /obj/structure/sign/poster/official/medical_green_cross{
 	pixel_x = 32
@@ -55072,6 +53266,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fbx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"fcj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "fck" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating/airless,
@@ -55112,6 +53317,12 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"fet" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "feu" = (
 /obj/machinery/button/door{
 	id = "xenobio8";
@@ -55153,6 +53364,22 @@
 /obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"ffg" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"fgr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "fgG" = (
 /obj/structure/table/wood,
 /obj/machinery/requests_console{
@@ -55174,6 +53401,25 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"fho" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Cafeteria";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"fjl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "fjM" = (
 /turf/open/floor/plasteel/stairs/medium,
 /area/maintenance/bar)
@@ -55181,6 +53427,20 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"fkp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"fkW" = (
+/obj/effect/decal/cleanable/flour,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"fkY" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "flc" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -55197,6 +53457,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"flG" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/security/prison)
+"flK" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/wood,
+/area/security/prison)
 "fmR" = (
 /obj/structure/bed,
 /obj/machinery/light/small{
@@ -55232,10 +53501,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"fnP" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"fnX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "foi" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"fpa" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "fpl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -55269,12 +53558,65 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"fpP" = (
+/obj/item/reagent_containers/food/snacks/grown/coconut,
+/obj/item/reagent_containers/food/snacks/grown/cocoapod,
+/obj/item/reagent_containers/food/snacks/grown/onion/red,
+/obj/item/reagent_containers/food/snacks/grown/onion,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/grass,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/reishi,
+/obj/item/reagent_containers/food/snacks/grown/garlic,
+/obj/item/reagent_containers/food/snacks/grown/eggplant,
+/obj/item/reagent_containers/food/snacks/grown/coffee/robusta,
+/obj/item/reagent_containers/food/snacks/grown/coffee,
+/obj/item/reagent_containers/food/snacks/grown/koibeans,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle,
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"fqN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "fqT" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fqX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "frq" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/blue{
@@ -55290,35 +53632,49 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "fsj" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"fti" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/turf/open/floor/wood,
+/area/security/prison)
+"fts" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "ftE" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ftO" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "fup" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -55366,6 +53722,12 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"fwQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "fxe" = (
 /obj/structure/chair/sofa,
 /obj/structure/window{
@@ -55373,6 +53735,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"fxK" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fxV" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
@@ -55382,6 +53753,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fyA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "fyS" = (
 /obj/structure/pool/ladder{
 	dir = 1;
@@ -55412,6 +53792,36 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"fAA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"fAQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
+"fBc" = (
+/turf/open/floor/wood,
+/area/security/prison)
+"fBk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "fBy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -55435,6 +53845,41 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"fCa" = (
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton,
+/obj/item/seeds/onion/red,
+/obj/item/seeds/wheat/rice,
+/obj/item/seeds/wheat/oat,
+/obj/item/hatchet/saw,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fCx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -55446,12 +53891,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"fEj" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"fEb" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
 	},
-/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/food/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour = 90);
+	name = "large flour sack";
+	possible_transfer_amounts = list(1,5,10,15,30,60,90);
+	volume = 90
+	},
+/obj/item/reagent_containers/food/condiment/mayonnaise,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice = 90);
+	name = "large rice sack";
+	possible_transfer_amounts = list(1,5,10,15,20,25,30,50,60,90)
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/enzyme,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "fEw" = (
@@ -55462,7 +53924,22 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
 /area/security/brig)
 "fGa" = (
 /obj/structure/cable{
@@ -55480,14 +53957,54 @@
 "fHG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"fHL" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rd/royal_cape,
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison)
 "fIs" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"fIu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/wood,
+/area/security/prison)
+"fIQ" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/security/prison)
+"fJC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "fJQ" = (
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
+"fJT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"fJY" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "fKl" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/camera{
@@ -55511,6 +54028,18 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fLb" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fLE" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/insectguts,
@@ -55518,15 +54047,15 @@
 /turf/open/floor/plating,
 /area/maintenance/bar)
 "fLS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"fMT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fNG" = (
 /mob/living/carbon/monkey,
 /obj/effect/landmark/blobstart,
@@ -55560,6 +54089,10 @@
 /obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"fPw" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/security/prison)
 "fPy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -55581,6 +54114,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/psych)
+"fSJ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Clubroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"fSL" = (
+/obj/effect/spawner/lootdrop/wall/twentyfive_percent_falsewall,
+/turf/open/floor/plating,
+/area/security/prison)
 "fTg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55598,6 +54142,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"fTQ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  West";
+	dir = 4;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
 "fUj" = (
 /obj/machinery/button/door{
 	id = "telecap";
@@ -55607,11 +54169,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"fWK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fYb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/checker,
 /area/security/prison)
 "fZm" = (
 /obj/structure/chair/sofa/left,
@@ -55640,6 +54208,12 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"gbD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gbM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -55719,6 +54293,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"geS" = (
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gfr" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
@@ -55736,6 +54313,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"ggZ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ghq" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -55753,25 +54336,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"ghE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ghS" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"gjc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+"giL" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gjl" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -55815,6 +54393,15 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/central)
+"glr" = (
+/obj/machinery/prize_counter,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "gnf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55835,6 +54422,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"goJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "gpD" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -55845,6 +54440,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"gqR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "grA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -55855,14 +54458,41 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
+"gsh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"gsn" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
+"guj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  East";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "guS" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	name = "Prison Intercom (General)";
@@ -55880,7 +54510,18 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "gvp" = (
 /obj/effect/turf_decal/tile/red{
@@ -55900,6 +54541,23 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"gwq" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/security/prison)
+"gwA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "gxc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55916,6 +54574,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"gyc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "gys" = (
 /obj/machinery/button/door{
 	id = "xenobio9";
@@ -55951,6 +54615,9 @@
 /obj/structure/curtain,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
+"gzz" = (
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gAb" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin{
@@ -56001,15 +54668,14 @@
 /area/science/circuit)
 "gCm" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "gCC" = (
 /obj/structure/sign/poster/contraband/tools,
@@ -56058,6 +54724,10 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"gJf" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gJi" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -56083,6 +54753,19 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"gKj" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "gLl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -56121,6 +54804,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gLZ" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gMl" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -56129,6 +54818,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gMI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"gNv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "gNC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56146,6 +54848,20 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
+"gPu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"gPW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gQT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gQX" = (
 /obj/machinery/button/door{
 	desc = "Alright, GAMER! Want to take your PWRGAME addiction to the MAX? Just smash this button with your chubby chetto encrusted hands an- oh, you broke the switch. Good job, idiot.";
@@ -56178,6 +54894,12 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"gSN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gSS" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56186,6 +54908,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gSW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gTx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -56214,12 +54949,45 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"gVc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "workhouse";
+	name = "Work Room"
+	},
+/obj/machinery/button/door{
+	id = "workhouse";
+	name = "Work Room";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "gWd" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/construction)
+"gWQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "gXs" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -56235,6 +55003,12 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"gXZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "gYP" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/spider/stickyweb/genetic,
@@ -56248,18 +55022,18 @@
 	},
 /area/medical/sleeper)
 "gZQ" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig Infirmary";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "medsec"
+	},
+/turf/open/floor/plating,
 /area/security/brig)
+"gZT" = (
+/obj/machinery/jukebox{
+	req_one_access = null
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "hap" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -56306,9 +55080,20 @@
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"hbH" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/arcade/battle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hcb" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"hcn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "hcA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56335,6 +55120,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hdA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "hew" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56382,6 +55173,25 @@
 /obj/item/reagent_containers/food/snacks/cherrycupcake,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hgP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"hhB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"hiE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "hiG" = (
 /obj/structure/fans/tiny,
 /obj/structure/window/reinforced{
@@ -56438,28 +55248,122 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"hlz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "hlV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/crew_quarters/dorms)
+"hmg" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"hmo" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
+"hmX" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/plate_chute/inputchute{
+	pixel_x = -32;
+	pixel_y = -16
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Workroom";
+	dir = 10;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "hnl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/port)
-"hnU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"hpG" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Shooting Range"
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hpI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/range)
+/area/security/prison)
+"hqT" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"hrz" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown2";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown2";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hrE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56474,7 +55378,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "hrF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -56495,6 +55399,14 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"hso" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/arcade/tetris{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "htG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -56502,13 +55414,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"htK" = (
-/obj/machinery/door/poddoor{
-	id = "soli1"
+"hvb" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/computer/arcade/minesweeper{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white{
-	name = "secure isolation floor"
-	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"hvz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
 /area/security/prison)
 "hvD" = (
 /obj/effect/turf_decal/tile/blue,
@@ -56527,15 +55443,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -56546,7 +55453,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "hxc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -56557,11 +55466,60 @@
 "hxg" = (
 /turf/closed/wall/r_wall,
 /area/medical/psych)
+"hxh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/security/prison)
+"hxP" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Library"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"hyR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/security/prison)
+"hzu" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hzK" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
 	dir = 1
 	},
 /area/crew_quarters/fitness/pool)
+"hzM" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown4";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown4";
+	name = "Lockdown";
+	pixel_x = 25;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "hBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
@@ -56599,6 +55557,21 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hEj" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Cryogenics";
+	dir = 4;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "hEW" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -56610,6 +55583,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hFU" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
+"hGj" = (
+/obj/structure/bookcase/random/nonfiction,
+/obj/machinery/camera{
+	c_tag = "Prison -  Library";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "hGH" = (
 /obj/machinery/door/airlock{
 	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
@@ -56626,6 +55621,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hIA" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hIL" = (
 /obj/structure/sign/poster/contraband/space_up{
 	pixel_x = -32;
@@ -56645,6 +55646,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"hJk" = (
+/obj/machinery/pool/filter{
+	pixel_y = 24
+	},
+/turf/open/pool,
+/area/security/prison)
 "hJz" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Medical Officer";
@@ -56661,6 +55668,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"hKF" = (
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "hLo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -56679,16 +55689,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prisoner Processing";
-	dir = 8
-	},
-/obj/machinery/airalarm{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 24
+	pixel_x = 28
+	},
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -56740,6 +55747,12 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"hPY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "hRa" = (
 /obj/machinery/light{
 	dir = 8;
@@ -56774,6 +55787,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hTd" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "hVW" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -56798,6 +55821,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/port/fore)
+"hYr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"iak" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "iaX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56810,25 +55856,52 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"icv" = (
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"icy" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/window,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
 "icE" = (
 /obj/machinery/light/small,
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
-"idK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+"idJ" = (
+/obj/machinery/shower{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Firing Range";
-	dir = 1
+/obj/machinery/door/window/southright{
+	name = "shower"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"ifj" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "ifX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -56836,6 +55909,15 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iht" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "ihL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -56844,11 +55926,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"iiQ" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "iiW" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/corner,
@@ -56893,6 +55970,23 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iky" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
+"ilh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "imH" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -56906,6 +56000,15 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/theatre)
+"ioj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "iou" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -56914,6 +56017,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"ioH" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Cryogenics"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iph" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56925,6 +56037,17 @@
 	dir = 8
 	},
 /area/hallway/secondary/exit)
+"ipD" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/prisoner/prilate,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/security/prison)
 "iqT" = (
 /obj/machinery/door/airlock{
 	id_tag = "bardorm1";
@@ -56933,17 +56056,18 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"iqU" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
+"irv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plating,
-/area/security/processing)
+/obj/effect/landmark/start/prisoner/prilate,
+/turf/open/floor/carpet,
+/area/security/prison)
 "itK" = (
 /obj/structure/table,
 /obj/structure/light_construct{
@@ -56953,13 +56077,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "itQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/recharger,
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
+/turf/open/floor/plasteel,
 /area/security/range)
 "ium" = (
 /mob/living/simple_animal/bot/cleanbot{
@@ -56985,11 +56113,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_access_txt = "2"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Prisoner Processing";
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/computer/security/labor{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -57003,6 +56139,21 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"iwi" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/security/brig)
+"iwl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/brig)
 "iwm" = (
 /obj/machinery/vending/cola/random,
 /obj/structure/spider/stickyweb/genetic,
@@ -57044,12 +56195,52 @@
 "izK" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
+"iAt" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"iAE" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/security/prison)
+"iBf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "iBv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"iCs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "iCM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57090,11 +56281,52 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"iHl" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"iID" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
+/area/security/prison)
 "iLJ" = (
 /obj/item/reagent_containers/glass/bucket,
 /mob/living/simple_animal/pet/bumbles,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"iMg" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"iMj" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iMv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -57178,6 +56410,19 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"iPt" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "iQR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -57186,9 +56431,9 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "iSW" = (
-/mob/living/simple_animal/hostile/retaliate/goose{
-	desc = "Some evil loose goose.";
-	name = "Cere"
+/obj/structure/bed/dogbed{
+	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
+	name = "pet bed"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -57217,6 +56462,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"iVT" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iVU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57251,12 +56505,28 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"iZq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "iZs" = (
 /obj/structure/table,
 /obj/machinery/door/window,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jat" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "jaF" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -57309,13 +56579,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "jdL" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Visitations Prisoner-side";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
 /area/security/prison)
 "jex" = (
 /obj/machinery/smartfridge/organ/preloaded,
@@ -57331,6 +56601,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"jfU" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/security/prison)
 "jgm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57353,15 +56629,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"jhb" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+"jgG" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"jiD" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/wood,
+/area/security/prison)
+"jiJ" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/wood,
+/area/security/prison)
 "jiM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -57370,6 +56650,20 @@
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jiT" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jjv" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -57438,6 +56732,22 @@
 /obj/item/bedsheet/purple,
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
+"jmt" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jmV" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57448,6 +56758,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"jnm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jnF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"jrC" = (
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/wood,
+/area/security/prison)
 "jsw" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/stool,
@@ -57473,6 +56802,12 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"jvk" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/security/prison)
 "jvl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -57488,15 +56823,14 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jvO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "jvS" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"jwc" = (
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/wood,
+/area/security/prison)
 "jxF" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -57504,6 +56838,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jxX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "jzz" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -57516,10 +56862,38 @@
 "jAg" = (
 /turf/open/floor/engine,
 /area/science/mixing)
+"jAs" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jAD" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"jAI" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "jAN" = (
 /obj/machinery/vr_sleeper{
 	dir = 8
@@ -57548,6 +56922,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"jCb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Prison -  Central";
+	dir = 9;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "jCd" = (
 /obj/structure/window{
 	dir = 1
@@ -57568,6 +56954,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jDe" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/games,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jDH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/emcloset,
@@ -57578,11 +56972,6 @@
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"jDN" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "jEc" = (
 /obj/machinery/vr_sleeper{
 	dir = 8
@@ -57598,6 +56987,23 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness)
+"jEe" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/spawner/lootdrop/space_cash/very_low_chance,
+/obj/effect/spawner/lootdrop/prison_safe,
+/obj/item/toy/cards/deck,
+/obj/item/pen/fountain,
+/obj/item/pen/fourcolor,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/spawner/lootdrop/seeds/durathread,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jEf" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -57639,6 +57045,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jGz" = (
+/obj/structure/chair/comfy/green,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jGW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57681,6 +57091,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jIa" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "jIl" = (
 /obj/machinery/camera{
 	c_tag = "Virology Module";
@@ -57690,12 +57107,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jIr" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -57713,6 +57126,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jJW" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jKC" = (
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/shoes/sneakers/white,
@@ -57738,12 +57155,6 @@
 "jKV" = (
 /turf/closed/wall/mineral/titanium,
 /area/space/nearstation)
-"jLl" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/space,
-/area/space)
 "jLn" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Gravity Generator";
@@ -57797,6 +57208,10 @@
 /obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"jNJ" = (
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jNQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57813,6 +57228,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"jOL" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "jOY" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -57831,7 +57256,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "jPh" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock"
@@ -57842,6 +57267,25 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jPj" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"jRW" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "jSO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -57855,6 +57299,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jTy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "jTX" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses,
@@ -57899,6 +57354,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jXu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
 "jYL" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
@@ -57978,17 +57442,22 @@
 /obj/machinery/pool/controller,
 /turf/open/floor/plasteel/yellowsiding,
 /area/crew_quarters/fitness/pool)
-"kdP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/range)
 "kdS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kdZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "keg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58030,6 +57499,19 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"kfG" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "kfX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -58045,9 +57527,15 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "kgH" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/fore)
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "kgZ" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -58078,6 +57566,71 @@
 /obj/machinery/vending/cola/red,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"kjv" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown3";
+	name = "Lockdown"
+	},
+/obj/machinery/button/door{
+	id = "lockdown3";
+	name = "Lockdown";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"kjU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"kkj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"kkR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
+"klo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "kls" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -58128,6 +57681,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kor" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "koD" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -58145,6 +57702,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kpr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"kqG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kqI" = (
 /obj/structure/window,
 /turf/open/floor/wood,
@@ -58162,6 +57739,23 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ksK" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bossofthisprisongym";
+	name = "Private Area"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"ktm" = (
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/wrench,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/screwdriver,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/crowbar,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/weldingtool,
+/obj/structure/closet/crate/large,
+/obj/effect/spawner/lootdrop/soap/seventyfive_percent,
+/obj/effect/spawner/lootdrop/seeds,
+/turf/open/floor/plating,
+/area/security/prison)
 "ktA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58234,14 +57828,6 @@
 	dir = 4
 	},
 /area/crew_quarters/fitness)
-"kxG" = (
-/obj/item/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "kyB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -58259,10 +57845,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kzr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "kzT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"kzX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "kAt" = (
 /obj/machinery/button/door{
 	id = "xenobio4";
@@ -58328,6 +57931,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"kCL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"kCQ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
+"kEk" = (
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "lockdown3";
+	name = "Lockdown"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kEY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
@@ -58341,7 +57973,9 @@
 	name = "Brig Operations";
 	req_one_access_txt = "4; 1"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "kGJ" = (
 /obj/structure/cable{
@@ -58359,9 +57993,37 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kMt" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer,
-/turf/open/floor/plasteel,
+"kHT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"kIP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
+"kNf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/security/prison)
 "kNv" = (
 /obj/structure/cable{
@@ -58378,6 +58040,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kNZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "kOS" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -58396,6 +58068,24 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kPo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Green Wing";
+	dir = 1;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "kPY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58425,6 +58115,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"kSz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/lavendergrass{
+	max_integrity = 1;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "kTs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -58483,6 +58184,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"kXN" = (
+/obj/structure/chair/comfy/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kYk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/evac{
@@ -58497,20 +58204,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kZi" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of a colour coded cell bock. This is an orange cell.";
+	name = "Cell - Orange"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kZo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"laq" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+"lau" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/vr_sleeper{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lcu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58525,7 +58237,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "lfJ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -58549,7 +58261,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "lip" = (
 /obj/structure/closet{
@@ -58576,6 +58290,27 @@
 /obj/item/clothing/under/rank/civilian/lawyer/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"liW" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
+"ljf" = (
+/obj/machinery/door/airlock/grunge{
+	desc = "Part of the green cell block";
+	name = "Cell - Green"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lln" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58635,19 +58370,53 @@
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"lsg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"lrc" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "lsk" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"lsv" = (
+/obj/machinery/door_timer{
+	id = "genpopcell1";
+	name = "Punishment Cell"
+	},
+/turf/closed/wall,
+/area/security/prison)
+"lto" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ltK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -58660,6 +58429,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"lul" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "lun" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -58672,6 +58452,9 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/space,
 /area/space/nearstation)
+"lvT" = (
+/turf/open/floor/padded,
+/area/security/prison)
 "lvU" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -58680,6 +58463,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lwd" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "genpopcell1";
+	pixel_y = 24
+	},
+/turf/open/floor/padded,
+/area/security/prison)
 "lwX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -58687,7 +58478,10 @@
 /turf/closed/wall/r_wall,
 /area/security/main)
 "lAa" = (
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/security/range)
 "lAw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -58709,7 +58503,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "lCi" = (
 /obj/docking_port/stationary/public_mining_dock{
 	dir = 8
@@ -58722,6 +58516,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"lEk" = (
+/obj/machinery/door/window/brigdoor/security/cell/westright{
+	id = "genpopcell1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"lEN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "Chief Medical Office";
+	dir = 4;
+	network = list("ss13","medbay");
+	pixel_y = -22
+	},
+/turf/open/space/basic,
+/area/ai_monitored/security/armory)
 "lGi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58741,15 +58551,26 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"lIh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+"lIc" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#c45c57";
+	desc = "Remarkably soft, with plush cozy cushions, premium memory-foam and covered in stain-resistant fabric. Made by Kat-Kea???!";
+	dir = 8;
+	name = "Premium Cozy Chair"
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "lII" = (
 /obj/structure/disposalpipe/segment{
@@ -58765,19 +58586,32 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"lKA" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "lKL" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/security/brig)
+"lLt" = (
+/obj/machinery/door/window/brigdoor/security/cell/westleft{
+	id = "genpopcell1"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"lLD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  South";
+	dir = 8;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "lLR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -58785,18 +58619,98 @@
 "lMg" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"lNi" = (
+/obj/machinery/requests_console{
+	department = "Prison";
+	departmentType = 1
+	},
+/turf/closed/wall,
+/area/security/prison)
+"lNH" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/barrier{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/grenade/barrier{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/grenade/barrier{
+	pixel_y = 10
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/storage/box/teargas{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lOi" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "lOY" = (
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"lPa" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/firingpins{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/storage/box/firingpins{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lPr" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lPy" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/c10mm,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lQc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58816,6 +58730,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"lQZ" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "lRY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -58856,6 +58785,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"lYo" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "lZl" = (
 /obj/structure/closet,
 /obj/item/coin/gold,
@@ -58883,7 +58818,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "maC" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
@@ -58896,6 +58831,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"maM" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plating,
+/area/security/prison)
+"mbk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "mbU" = (
 /obj/machinery/vr_sleeper{
 	dir = 8
@@ -58912,8 +58858,15 @@
 	},
 /area/crew_quarters/fitness)
 "mcp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
 /area/security/range)
 "mdo" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
@@ -58928,11 +58881,41 @@
 /obj/structure/bed,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"mee" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/loyalty{
+	pixel_y = 12
+	},
+/obj/item/storage/box/trackimp{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/storage/box/chemimp{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mev" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mga" = (
+/obj/structure/closet/l3closet/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mgf" = (
 /obj/machinery/light{
 	dir = 4
@@ -58946,11 +58929,58 @@
 /obj/structure/bed,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"mhA" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"mhM" = (
+/obj/structure/table,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"mir" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "miw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mjn" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/security/prison)
+"mjU" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin/towel,
+/obj/item/soap,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mkv" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
@@ -58962,6 +58992,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"mkI" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/orange,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = 26;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mkO" = (
 /obj/machinery/door/airlock{
 	name = "Shower Room"
@@ -58969,15 +59027,42 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/toilet)
-"mnC" = (
-/obj/structure/target_stake,
-/obj/item/target/syndicate,
+"mnc" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/lootdrop/tenpercent_basic_tool/weldingtool,
+/obj/item/reagent_containers/food/snacks/grown/coffee/robusta,
+/obj/item/reagent_containers/food/snacks/grown/coffee,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/item/radio/off,
 /turf/open/floor/plating,
+/area/security/prison)
+"mnC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/range";
+	dir = 4;
+	name = "Firing Range APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/range)
 "mnQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "moD" = (
@@ -59014,6 +59099,35 @@
 	},
 /turf/open/floor/plating,
 /area/medical/psych)
+"mqH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"mqU" = (
+/obj/machinery/door/window/southleft{
+	name = "Target Storage"
+	},
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target,
+/obj/item/target,
+/turf/open/floor/plating,
+/area/security/range)
+"mrI" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/security/prison)
 "mrR" = (
 /obj/machinery/conveyor{
 	id = "oldstuff"
@@ -59024,6 +59138,15 @@
 "msI" = (
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"msX" = (
+/obj/machinery/conveyor/auto{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mvt" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -59031,6 +59154,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mwb" = (
+/obj/machinery/conveyor/auto{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mwV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -59063,9 +59195,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -59084,7 +59213,12 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/green,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "myX" = (
 /obj/effect/turf_decal/tile/red,
@@ -59116,6 +59250,50 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mBc" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/flashbang{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/storage/box/medipens{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"mBH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "mBO" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
@@ -59132,24 +59310,59 @@
 "mDb" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
+"mDZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mEu" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mGw" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
+"mGJ" = (
+/obj/structure/closet/crate/secure/weapon{
+	desc = "A secure clothing crate.";
+	name = "formal uniform crate";
+	req_access = "3"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/officer/formal,
+/obj/item/clothing/under/rank/security/warden/formal,
+/obj/item/clothing/under/rank/security/head_of_security/formal,
+/obj/item/clothing/suit/armor/navyblue,
+/obj/item/clothing/suit/armor/navyblue,
+/obj/item/clothing/suit/armor/navyblue,
+/obj/item/clothing/suit/armor/navyblue,
+/obj/item/clothing/suit/armor/navyblue,
+/obj/item/clothing/suit/armor/vest/warden/navyblue,
+/obj/item/clothing/suit/armor/hos/navyblue,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navyofficer,
+/obj/item/clothing/head/beret/sec/navywarden,
+/obj/item/clothing/head/beret/sec/navyhos,
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mHj" = (
 /obj/machinery/light{
 	dir = 8
@@ -59191,6 +59404,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mKX" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
+"mLj" = (
+/turf/open/floor/plasteel/dark/corner,
+/area/security/prison)
 "mMk" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -59215,6 +59437,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mNG" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "mNW" = (
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_y = 32
@@ -59268,6 +59495,29 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"mPO" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera{
+	c_tag = "Security - Armoury";
+	dir = 9;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"mQI" = (
+/turf/closed/wall,
+/area/security/execution/transfer)
 "mQS" = (
 /obj/machinery/light{
 	dir = 8;
@@ -59291,6 +59541,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"mTp" = (
+/obj/structure/curtain{
+	alpha = 240;
+	color = "#454545";
+	name = "Changing Room"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "mTG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -59307,6 +59565,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mTS" = (
+/obj/machinery/button/door{
+	id = "prisonconveyor";
+	name = "Conveyor Shutter Control";
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mVz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -59343,28 +59610,48 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"mZR" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
+"mZM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "nac" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nat" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/security/processing)
 "naI" = (
 /turf/open/space,
 /area/space/station_ruins)
+"nbt" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/item/reagent_containers/food/snacks/grown/pumpkin,
+/obj/item/reagent_containers/food/snacks/grown/pineapple,
+/obj/item/reagent_containers/food/snacks/grown/peach,
+/obj/item/reagent_containers/food/snacks/grown/peanut,
+/obj/item/reagent_containers/food/snacks/grown/redbeet,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/soybeans,
+/obj/item/reagent_containers/food/snacks/grown/tea,
+/obj/item/reagent_containers/food/snacks/grown/strawberry,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/watermelon,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/structure/closet/crate/hydroponics{
+	name = "raw produce"
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "nbK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -59388,6 +59675,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"ncR" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Janitorial"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "ndq" = (
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
@@ -59397,12 +59693,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"nea" = (
-/obj/structure/chair{
-	dir = 1
+"nej" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "neo" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
@@ -59455,6 +59751,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nkv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/security/brig)
 "nlz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59529,18 +59833,47 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"nrg" = (
-/obj/machinery/door/window/southright{
-	name = "Target Storage"
+"nrZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/range)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "nsA" = (
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
+"nsR" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"ntc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
+"nti" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "nuc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -59553,6 +59886,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"nus" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
 "nuD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -59561,12 +59911,31 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nuO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
+"nuX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "nvk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nwS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "nwX" = (
 /obj/machinery/nanite_programmer,
 /obj/structure/window/reinforced{
@@ -59611,14 +59980,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "nBb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/security/brig)
 "nBM" = (
 /obj/docking_port/stationary/random{
@@ -59643,6 +60011,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"nDL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "nEy" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -59693,6 +60075,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nGT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
+"nHG" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nLc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -59740,6 +60139,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"nMr" = (
+/obj/structure/table/glass,
+/obj/item/storage/bag/tray,
+/obj/item/kitchen/knife/combat/bone/plastic{
+	pixel_y = 4
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/storage/box/cups{
+	pixel_x = -5
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "nMv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Testing Lab Maintenance";
@@ -59747,6 +60165,15 @@
 	},
 /turf/open/floor/plating,
 /area/science/explab)
+"nME" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "nNF" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -59769,12 +60196,28 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "nQM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"nRa" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nRE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/brig)
 "nRG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -59805,17 +60248,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"nSN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/food/condiment/sugar,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "nTb" = (
 /obj/machinery/door/window/westleft{
 	name = "Monkey Pen";
@@ -59827,6 +60259,23 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"nUw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nUM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/snacks/cola_float{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nVk" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
@@ -59850,6 +60299,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nXd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"nXO" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nXT" = (
 /obj/structure/spider/stickyweb/genetic,
 /turf/open/floor/plating,
@@ -59880,6 +60349,10 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"nYQ" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "nZE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -59912,6 +60385,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"oaK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
 "oaZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -59926,7 +60410,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "oce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -59965,6 +60449,17 @@
 /obj/item/clothing/gloves/boxing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"ocM" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal,
+/obj/item/storage/box/bodybags,
+/obj/item/pen,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "odk" = (
 /obj/structure/chair{
 	dir = 1
@@ -59978,6 +60473,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"odq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "odx" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
@@ -60028,14 +60527,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"oiR" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/reagent_containers/glass/bowl,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
 "oiW" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -60045,17 +60536,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"okI" = (
-/obj/machinery/door/airlock/security{
-	name = "Firing Range";
-	req_access_txt = "2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/range)
+"ojO" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "old" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -60066,6 +60550,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"olf" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/machinery/biogenerator/prisoner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Prison -  Garden";
+	dir = 6;
+	network = list("ss13","prison");
+	start_active = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "omm" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
@@ -60144,6 +60656,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"otA" = (
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ouQ" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -60172,6 +60693,51 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ovC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"ovS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
+"ovZ" = (
+/obj/structure/table,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/storage/box/zipties{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oxm" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -60200,6 +60766,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"oyn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oyz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -60210,6 +60785,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"oyU" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oyX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -60231,6 +60817,19 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"oAf" = (
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "oAw" = (
 /obj/structure/window{
 	dir = 1
@@ -60274,6 +60873,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
+"oEn" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oEP" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -60305,6 +60910,19 @@
 "oHB" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
+"oHH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "prison blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "oHU" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -60342,6 +60960,15 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oKP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oLl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60351,20 +60978,26 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"oMS" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"oLq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/processing)
-"oMT" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/fortunecookie,
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"oMS" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oMZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -60377,6 +61010,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"oNp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "oNz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -60385,13 +61024,14 @@
 /area/hallway/primary/central)
 "oOt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "oPU" = (
@@ -60487,15 +61127,20 @@
 /obj/structure/pool/ladder,
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"oVv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "executionfireblast"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "oWe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -60535,12 +61180,7 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "pek" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
 "pem" = (
@@ -60559,10 +61199,16 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
 "pgn" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/range)
 "phe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60679,6 +61325,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"psf" = (
+/turf/open/pool,
+/area/security/prison)
 "psk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60739,6 +61388,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pyf" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
+"pyV" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pzk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -60749,6 +61415,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/closed/wall,
 /area/crew_quarters/fitness)
+"pDA" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "pEn" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -60763,6 +61440,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pFN" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pHl" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -60831,21 +61514,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pKR" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pLh" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -60873,6 +61555,32 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pNw" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"pNN" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pPi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60891,6 +61599,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"pQh" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pQp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -60945,6 +61659,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"pST" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"pSX" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "pTB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -60976,6 +61713,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pWG" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "pWM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -60987,19 +61736,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"pWX" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/security/prison)
-"pXK" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space southwest";
-	dir = 8;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qaY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -61081,28 +61817,12 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/miningdock)
-"qlX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/prize_counter,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qmg" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/bar)
-"qmV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "qmX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
@@ -61111,6 +61831,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"qng" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "qor" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61118,18 +61849,37 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "qpg" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/lattice,
+/turf/closed/wall,
 /area/maintenance/fore)
 "qpj" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"qpC" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qpR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -61158,13 +61908,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"qqx" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Southeast"
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/security/prison)
 "qsr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -61191,8 +61934,22 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "qxq" = (
-/turf/closed/wall,
-/area/security/range)
+/obj/structure/table,
+/obj/item/electropack,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/obj/item/clothing/head/helmet,
+/obj/item/assembly/signaler,
+/obj/machinery/light/small,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "qyb" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -61201,6 +61958,18 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /turf/closed/wall,
 /area/maintenance/fore)
+"qzQ" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/prison)
 "qBa" = (
 /obj/structure/bed/roller,
 /obj/machinery/button/door{
@@ -61219,15 +61988,25 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
-"qCC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+"qCb" = (
+/obj/machinery/plate_press,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qDZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafe"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/range)
+/turf/open/floor/plasteel/dark/side{
+	dir = 10
+	},
+/area/security/prison)
 "qGg" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -61253,8 +62032,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "qGR" = (
@@ -61286,15 +62065,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qLc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "qLR" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -61328,6 +62106,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"qNl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/security/brig)
 "qNZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -61348,6 +62137,25 @@
 	dir = 1
 	},
 /area/crew_quarters/fitness)
+"qOr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Security Prison - Janitorial";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_y = -32
+	},
+/obj/structure/bedsheetbin/color,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "qOB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61390,6 +62198,22 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/engine,
 /area/science/mixing)
+"qUU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "qVv" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
@@ -61494,13 +62318,55 @@
 /obj/item/radio/headset/headset_med,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"reX" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"riI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "rjQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rjZ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"rkJ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/holohoop,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rlS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -61535,6 +62401,24 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"roW" = (
+/obj/machinery/plate_press,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_y = 24;
+	prison_radio = 1
+	},
+/obj/machinery/button/door{
+	id = "Workroom1";
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rpf" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -61613,6 +62497,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"rtp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "rtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61680,6 +62589,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"ryK" = (
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "rzr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -61705,18 +62617,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"rDu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/item/razor{
-	pixel_x = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "rDU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -61791,7 +62691,15 @@
 /turf/open/floor/plating,
 /area/construction)
 "rKX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Shooting Range"
+	},
 /turf/open/floor/plating,
 /area/security/range)
 "rMn" = (
@@ -61824,6 +62732,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rPg" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 4;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rPH" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -61879,25 +62806,16 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"rYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"rYM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Workroom1"
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/open/floor/plating,
+/area/security/prison)
 "rZB" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -61954,13 +62872,28 @@
 	dir = 4
 	},
 /area/crew_quarters/fitness)
+"sck" = (
+/obj/machinery/button/door{
+	id = "bossofthisprisongym";
+	name = "Private Area";
+	pixel_x = -24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/security/prison)
 "sea" = (
-/obj/item/melee/baton/cattleprod,
-/obj/item/stock_parts/cell/high,
-/obj/item/electropack,
-/obj/structure/closet/secure_closet{
-	name = "Persuasion Storage";
-	req_access = "list(2)"
+/obj/machinery/camera{
+	c_tag = "Brig Interrogation";
+	dir = 8;
+	network = list("interrogation")
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -62008,6 +62941,15 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"sjX" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -62048,22 +62990,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/vg_decals/department/sec,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "spa" = (
 /obj/effect/decal/cleanable/glitter/pink,
@@ -62090,6 +63023,32 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
+"sro" = (
+/obj/machinery/button/ignition{
+	id = "executionburn";
+	pixel_x = 24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "executionfireblast";
+	name = "Transfer Area Lockdown";
+	pixel_x = 25;
+	pixel_y = -5;
+	req_access_txt = "2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium/white{
+	barefootstep = "carpetbarefoot";
+	desc = "Stops the mentally unfit from hurting themselves";
+	heavyfootstep = "carpetbarefoot";
+	name = "Padded Floor"
+	},
+/area/security/execution/transfer)
 "srG" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -62168,6 +63127,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"sxG" = (
+/obj/structure/rack,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/tank/internals/anesthetic{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "syJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -62190,6 +63164,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"szM" = (
+/obj/item/grown/log,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/stack/sheet/mineral/sandstone/thirty,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "sAq" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -62268,6 +63249,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"sHf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "sHx" = (
 /obj/structure/table,
 /obj/item/watertank,
@@ -62457,6 +63444,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"sSF" = (
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "sSS" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -62469,16 +63472,6 @@
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
-"sVr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "sVS" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -62507,6 +63500,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"sYE" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/vending/hydronutrients/prisoner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sYI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/blocker,
@@ -62549,12 +63560,12 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"tfG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+"tef" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafe"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tgH" = (
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
@@ -62619,13 +63630,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tmO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/camera{
+	c_tag = "Firing Range";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/security/range)
 "tmP" = (
 /obj/effect/turf_decal/tile/blue,
@@ -62634,6 +63649,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"tqd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "tqg" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -62710,11 +63735,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tvN" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/security/prison)
 "txm" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/crowbar/red,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"txn" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "tyX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -62724,6 +63770,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"tzc" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "tzQ" = (
 /obj/machinery/shower{
 	dir = 4
@@ -62883,6 +63935,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"tOB" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "tPT" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/insectguts,
@@ -62890,8 +63958,8 @@
 /area/maintenance/port/aft)
 "tQi" = (
 /obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/shoes/sneakers/white,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "tRe" = (
@@ -62932,10 +64000,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"tXk" = (
-/obj/machinery/gulag_teleporter,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "tXq" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -62963,6 +64027,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tZf" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "visitation"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "uap" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/blood,
@@ -62995,12 +64065,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "ubI" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -63047,6 +64113,32 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"ugO" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"ugT" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uha" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63179,10 +64271,28 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/closed/wall,
 /area/science/xenobiology)
-"usv" = (
-/obj/effect/turf_decal/tile/red{
+"urU" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	name = "shower"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/prison)
+"usi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
+"usv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -63191,8 +64301,7 @@
 /area/security/brig)
 "usK" = (
 /obj/structure/table/wood,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/shoes/sneakers/white,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "usO" = (
@@ -63202,10 +64311,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uto" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uua" = (
 /obj/machinery/atmospherics/components/binary/valve,
@@ -63224,6 +64330,12 @@
 /obj/item/coin/silver,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"uvj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "uvZ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -63503,6 +64615,15 @@
 "uYb" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
+"uYt" = (
+/obj/machinery/door/window/southright{
+	name = "Target Storage"
+	},
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/range)
 "uZJ" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -63566,22 +64687,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"vbS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "vcN" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"vcQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vcY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -63591,15 +64707,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"vda" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/range)
 "vdu" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -63609,15 +64716,8 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "vdU" = (
-/obj/machinery/door/window/southleft{
-	name = "Target Storage"
-	},
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target,
-/obj/item/target,
-/turf/open/floor/plating,
-/area/security/range)
+/turf/closed/wall/r_wall,
+/area/security/prison)
 "veS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -63855,19 +64955,9 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "vyc" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vyp" = (
@@ -64034,6 +65124,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vFf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/security/prison)
 "vFr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64049,6 +65145,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"vGR" = (
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 1;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	dir = 8;
+	name = "engineering corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	alpha = 170;
+	name = "engineering corner"
+	},
+/obj/structure/closet/crate/wooden,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/effect/spawner/lootdrop/soap/twentyfive_percent,
+/obj/item/instrument/eguitar,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vHj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics "
@@ -64080,23 +65201,31 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "vIi" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/range";
-	dir = 4;
-	name = "Firing Range APC";
-	pixel_x = 24
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera{
+	c_tag = "Brig Infirmary";
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/obj/structure/closet/secure_closet/brig_phys,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/epinephrine,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/reagent_containers/glass/bottle/charcoal,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vJu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -64128,6 +65257,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"vLO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/janitorialcart{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
+"vMm" = (
+/obj/structure/curtain,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"vNy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "executionfireblast"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "vOU" = (
 /obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -64210,10 +65368,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "wag" = (
 /obj/structure/chair/comfy/black{
@@ -64226,6 +65383,12 @@
 /obj/item/electropack/shockcollar,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"wbt" = (
+/obj/structure/flora/ausbushes/ywflowers{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "wbE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
@@ -64274,11 +65437,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "weW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/security/processing)
 "wfA" = (
 /obj/machinery/button/door{
@@ -64298,16 +65457,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"wgd" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northwest";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/security/brig)
 "wgh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light_switch{
@@ -64365,6 +65515,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"wkE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "wkN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
@@ -64516,11 +65678,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/security/brig)
+"wul" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/security/prison)
 "wuH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64534,10 +65702,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"wvA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
 "wvX" = (
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab Chamber";
@@ -64561,10 +65725,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"wxo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wxT" = (
 /obj/structure/chair/sofa/left,
 /obj/structure/window{
@@ -64583,6 +65743,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/violet/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"wAo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	max_integrity = 1
+	},
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
 "wAq" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -64622,19 +65791,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"wGf" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+"wCX" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "wHk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -64686,15 +65846,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wPh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wQc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64713,6 +65883,18 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"wSs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/brig)
 "wTf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -64742,10 +65924,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"wUV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "wUY" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -64753,13 +65931,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"wVh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
 "wVk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -64822,14 +65993,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "wZe" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/security/brig)
 "wZG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spider/stickyweb/genetic,
@@ -64868,19 +66039,11 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xez" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
+"xdL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Permabrig East";
-	dir = 8;
-	network = list("ss13","prison");
-	start_active = 1
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
 	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "xfb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -64996,6 +66159,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"xjL" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/security/prison)
 "xkd" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -65090,6 +66259,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xuH" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/security/prison)
+"xvN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Garden"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xvR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -65150,6 +66335,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "xDQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "xEu" = (
@@ -65265,6 +66466,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"xSe" = (
+/turf/open/floor/plasteel/yellowsiding{
+	dir = 4
+	},
+/area/security/prison)
 "xTy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65274,7 +66480,7 @@
 "xUe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/brig)
 "xUn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -65312,6 +66518,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"xVi" = (
+/obj/machinery/camera,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/closet/secure_closet/genpop,
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "xWT" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line,
@@ -65351,6 +66571,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"yab" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
+"yaG" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"yaU" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/plasteel/checker,
+/area/security/prison)
 "ybm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65358,6 +66612,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ybo" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ybT" = (
 /obj/machinery/vending/clothing,
 /obj/structure/spider/stickyweb/genetic,
@@ -65411,6 +66669,17 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ydO" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light,
+/turf/open/floor/plating/smooth/grass,
+/area/security/prison)
+"yeX" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "yfq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -65436,15 +66705,6 @@
 /obj/item/folder/blue,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"yin" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "Permabrig Space Northeast";
-	dir = 1;
-	name = "aft camera"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "ykU" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -77845,12 +79105,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78102,12 +79362,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78359,12 +79619,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78616,12 +79876,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78873,12 +80133,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79130,12 +80390,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79387,12 +80647,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79644,12 +80904,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79901,12 +81161,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80158,12 +81418,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80415,12 +81675,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80672,12 +81932,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80929,12 +82189,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81186,12 +82446,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81443,12 +82703,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81692,20 +82952,20 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81949,20 +83209,20 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82206,20 +83466,20 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82463,20 +83723,20 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82720,20 +83980,20 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82977,20 +84237,20 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83231,23 +84491,23 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83488,23 +84748,23 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83745,23 +85005,23 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -84002,23 +85262,23 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -84259,23 +85519,23 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -84511,28 +85771,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -84768,28 +86028,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -85020,11 +86280,11 @@ cNd
 cNd
 cNd
 cNd
-cNd
-cNd
-cNd
-cNd
-cNd
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -85276,7 +86536,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -85533,6 +86793,7 @@ cNd
 cNd
 cNd
 cNd
+cNd
 aaa
 aaa
 aaa
@@ -85585,7 +86846,6 @@ aaa
 aaa
 aaa
 aaa
-aae
 aaa
 aaa
 ali
@@ -85790,7 +87050,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -86047,7 +87307,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -86103,10 +87363,10 @@ aaa
 aaa
 aaa
 ali
-kxG
-anL
-aoo
-aoX
+ali
+ali
+alU
+alU
 arP
 arP
 arP
@@ -86299,6 +87559,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -86358,12 +87624,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-ali
-ali
-ali
-alU
-alU
 arP
 abK
 tYH
@@ -86556,6 +87816,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -86597,17 +87863,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aih
+aih
+aih
+akd
+aih
+aih
 aaa
 aaa
 aaa
@@ -86621,9 +87882,8 @@ aaa
 aaa
 aaa
 arP
-dHU
 iSW
-vQo
+aws
 kXd
 ecD
 awa
@@ -86813,6 +88073,32 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aho
+aik
+aik
+aik
+gwA
 aaa
 aaa
 aaa
@@ -86830,41 +88116,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mQI
+mQI
+nwS
+mQI
+mQI
+mqU
+aiQ
+akt
+akV
+aih
 aaa
 aaa
 aaa
@@ -86878,8 +88139,7 @@ aaa
 aaa
 aaa
 aqQ
-nea
-vQo
+avf
 jKC
 aqR
 aqR
@@ -87070,6 +88330,33 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+dWg
+eTZ
+eBn
+fJY
+eBn
+aop
+gwA
 aaa
 aaa
 aaa
@@ -87086,42 +88373,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-pXK
-gXs
-aaj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mQI
+pDA
+pNw
+txn
+mQI
+uYt
+aiV
+akD
+akW
+aih
 aaa
 aaa
 aaa
@@ -87137,7 +88398,6 @@ aaa
 aqQ
 aqR
 aqR
-iiQ
 usK
 tQi
 avZ
@@ -87327,6 +88587,34 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+dWg
+eTZ
+mbk
+hKF
+hKF
+hKF
+eBn
+aop
+gwA
 aaa
 aaa
 aaa
@@ -87341,44 +88629,17 @@ aaa
 aaa
 aaa
 aaa
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-gXs
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-gXs
-aaj
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mQI
+fts
+sjX
+dJp
+mQI
+aih
+aiV
+akH
+akW
+akd
 aaa
 aaa
 aaa
@@ -87392,9 +88653,8 @@ aaa
 aaa
 aaa
 aqQ
-nea
+avf
 vQo
-arP
 arP
 arP
 avZ
@@ -87584,6 +88844,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -87597,42 +88863,40 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-azP
-gXs
-gXs
-gXs
-gXs
-aai
-aGP
-aIi
-aKh
-aNt
-aRw
-aai
-gXs
-aaj
+ade
+yaG
+kSz
+hKF
+dKY
+hKF
+tzc
+eBn
+ahR
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aae
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+pyf
+adb
+adb
+adb
+mQI
+aeQ
+afV
+agt
+sxG
+aih
+aiV
+akH
+akW
+aih
 aaa
 aaa
 aaa
@@ -87642,18 +88906,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-anO
+atz
 aaa
 aaa
 arP
 abK
 aqR
 arP
-asQ
-aqR
+axs
 avW
 axr
 ayE
@@ -87841,6 +89101,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -87848,68 +89114,62 @@ aaa
 aaa
 aaa
 aaa
+aEv
+aik
+aoq
+vdU
+aik
+aoq
+dXM
+fpP
+oNp
+hKF
+tzc
+hKF
+hKF
+eBn
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+ktm
+eRk
+eRk
+eRk
+eRk
+riI
+usi
+uvj
+fnX
+oVv
+afo
+nGT
+oaK
+ocM
+aih
+aiV
+akH
+akW
+aih
 aaa
 aaa
 aaa
 aaa
+pek
+aos
+pek
 aaa
-aaa
-aaa
-aaj
-wgd
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aGR
-aat
-aKi
-aat
-aSj
-aai
-gXs
-aaj
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aiU
-iqU
-aiU
-aaa
-aiU
-oMS
-aiU
+pek
+atQ
+pek
 gXs
 arP
-tfG
+avm
 nqz
 arP
-asP
 cya
 awa
 axu
@@ -88098,6 +89358,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88105,63 +89371,57 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-acD
-aej
-aiV
-aai
-aqB
-atT
-avu
-aqB
-azV
-acd
-aCS
-aEb
-aEx
-acd
-aHc
-aIA
-aKt
-aNG
-aSj
-aai
-gXs
-aaj
-aaa
-aaa
-aaa
-aaa
-jLl
-aaa
-aaa
-aaa
+ade
+abt
+xSe
+atX
+coi
+dFD
+elO
+olf
+oNp
+szM
+hKF
+hKF
+wbt
+ydO
+abu
+aak
+aDJ
+abu
+aak
+jAs
+abu
+abu
+abu
+abu
+dEN
+abu
+acA
+acK
+wCX
+vbS
+vNy
+afq
+age
+agF
 qxq
-qxq
-qxq
+aih
+ajs
 rKX
-qxq
-qxq
+alf
+aih
 gXs
 gXs
 gXs
-aiU
-alp
-aiU
 gXs
-aiU
-alp
-aiU
-arP
+pek
+apb
+pek
+gXs
+pek
+apb
+pek
 arP
 arP
 arP
@@ -88355,6 +89615,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88362,65 +89628,59 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-acD
-aek
-ajs
-aai
-aqG
-atV
-atV
-axU
-aAf
-acd
-aCU
-aEo
-aEy
-acd
-aHp
-aei
-aat
-abC
-aSo
-aai
-gXs
-aaj
-aaa
-aaa
-aaa
-aaa
-abc
-abc
-abc
-afu
-abc
-vdU
+ade
+psf
+psf
+auS
+psf
+psf
+eoD
+fCa
+wAo
+hKF
+hKF
+nbt
+hKF
+eBn
+abu
+rPg
+lIc
+abu
+jmt
+lIc
+abu
+mjU
+abu
+cNq
+rjZ
+rjZ
+acB
+acT
+adc
+adB
+aej
+afK
+nus
+sro
+ahs
+aih
 itQ
 pgn
 tmO
-qxq
+aih
 xUe
-aiU
-aiT
+xUe
+xUe
 weW
 nat
-aiU
-amK
-aiU
+apw
+pek
+asU
 pek
 nQM
+aud
 arP
-asR
-vQo
+auW
 oRg
 cME
 jtV
@@ -88612,6 +89872,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88619,65 +89885,59 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aaj
-aaj
-gXs
-aai
+aem
+psf
+psf
+psf
+psf
+psf
+eoD
+sYE
+fqN
+dHU
+hKF
+hKF
+gyc
+eBn
+abu
+qpC
+mkI
+abu
+qpC
+mkI
+abu
+pSX
+vMm
+tOB
+tOB
+cMg
 acD
-ael
-ajv
-aai
-aqS
-atX
-atV
-axV
-atX
-acd
-aCU
-aEp
-aFf
-acd
-aHr
-aIF
-aKv
-aNH
-aSp
-aai
-gXs
-gXs
-aaa
-aaa
-aaa
-aaa
-abc
-aea
+adF
+adF
+adF
+adF
+nej
 aeH
-aft
-abc
-nrg
+pyf
+pyf
+aih
 dly
 mnC
 mcp
-qxq
-tXk
-xDQ
-akb
-ahq
+amc
+oKP
+oMS
+afM
+pek
 akI
-ahU
-aiT
+ubI
+aqU
 aiD
-akI
+atl
 ubI
 kgH
 qpg
-vQo
+avd
 aqR
 vQo
 vQo
@@ -88869,6 +90129,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88876,55 +90142,49 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-aai
-aai
-adf
-ajB
-aai
-ars
-acd
-avB
-awX
-acd
-acd
-ars
-aEq
-awX
-acd
-acd
-ars
-aFt
-aNJ
-aai
-aai
-gXs
-afA
+ade
+psf
+psf
+aCf
+psf
+psf
+eoD
+eXR
+abu
+abu
+xvN
 abu
 abu
 abu
-abc
-abc
-aec
-aeJ
-afw
-abc
-abc
-dly
+abu
+auA
+eoD
+abu
+auA
+eoD
+abu
+pSX
+abu
+abu
+abu
+abu
+abu
+eRk
+fSL
+ktm
+aiX
+nkv
+nRE
+agp
+agj
+aih
+aih
 lAa
-mcp
-rKX
-kMt
+aih
+aih
+vyc
 wZe
-wUV
+sAr
 ahr
 ahD
 ahV
@@ -88932,7 +90192,7 @@ agr
 oOt
 mnQ
 jIr
-arP
+auC
 arP
 arP
 arP
@@ -89124,6 +90384,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -89131,68 +90399,60 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aaj
-aaj
-gXs
-pWX
-aal
-aaw
-acE
-aen
-ajD
-amh
-asr
-aud
-awd
-axY
-aAg
-aAu
-asr
-awd
-aFg
-aFF
-awd
-aIG
-awd
+ade
+psf
+psf
+psf
+psf
+dOn
+aPi
+eYT
+asC
+bfk
+fLb
+fTQ
+gKj
+gXZ
+hqT
+eYK
+ifj
+iPt
+eYK
+jAI
+jOL
 aOu
-aai
-aai
-gXs
-abb
-abt
-aca
-acz
-acX
-adC
-aeb
-aeI
-afv
-agf
-abc
-dly
-lAa
-mcp
-qxq
-wGf
+asQ
+lrc
+pNN
+vGR
+fSL
+eRk
+vdU
+aiX
+aiX
+nrZ
+kdS
+ryK
+adG
+aiE
+aiE
+oAf
+aiE
+aih
+akm
 dIP
 wsI
 akG
-akG
+anN
 hMo
 iuJ
 daA
 cxP
-jIr
+atR
+auC
 arP
-aqU
 arg
-arP
+avu
 arP
 arP
 arP
@@ -89381,6 +90641,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -89388,70 +90656,62 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-aau
-abf
-aat
-acH
-aeo
-ajG
-ami
-asC
-auj
-awe
-auj
-asC
-auj
-asC
-auj
-awe
-auj
-auj
-aJd
+aem
+hJk
+psf
+aCq
+psf
+psf
+eoP
+eZp
+azj
+bbr
+fBk
+fWK
+aaU
+bbr
+hrz
+kpr
+iht
+kpr
+kpr
+iht
 aKx
-aOK
-aai
-gXs
-gXs
-abe
-abw
-acc
-acB
-acZ
-adE
-aee
-aeL
-afy
-agh
-abc
-qCC
-hnU
-vda
-dXP
-agv
-amM
+aPP
+kZi
+aTA
+aVx
+aXx
+abu
+eRk
+vdU
+mKX
+mTp
+qNl
+akl
+odq
+arS
+arS
+arS
+oEn
+arS
+oHH
+oLq
+aeT
+afM
 aiX
 aiX
 aiX
 aiX
 aiX
-rYg
 xDQ
-jIr
+atT
+auC
 arP
 aqR
-arl
+avB
 arP
-asS
-aqR
+aww
 aqR
 awb
 axt
@@ -89638,6 +90898,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -89645,70 +90913,62 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaj
-aaj
-aaj
-gXs
-aai
-aal
-aai
-abi
-aat
-acK
-aaJ
-akt
-aml
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-aLh
-aPh
-aai
-gXs
-gXs
-abd
-abv
-acb
-acA
-acI
-adD
-aed
-aeK
-afx
-agg
-abc
-dWM
-dCV
-idK
-age
-vyc
-agu
+aeq
+ajv
+aqB
+aDO
+coN
+coN
+erB
+fbx
+abu
+abu
+fLS
+qDZ
+fLS
+abu
+abu
+cOt
+nRa
+nRa
+nRa
+hIA
+aMH
+kzr
+abu
+abu
+abu
+abu
+abu
+lYo
+vdU
+aiX
 agj
-amL
+ntc
+hxc
+ryK
+adG
+adG
+adG
+adG
+adG
+agj
+vyc
+ajX
+afM
+agj
 apK
 amX
+amX
 aiX
-aiE
 aiK
 aiN
+auN
 arP
-arc
+ave
 arP
 arP
-jvO
-aqR
+axm
 aqR
 awb
 axt
@@ -89895,75 +91155,75 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-aau
-aax
-aaP
-aaB
-abL
-acT
-aeq
-akH
-acd
-asG
-aup
-acd
-asV
-aup
-acd
-asG
-aup
-acd
-asV
-aup
-acd
-aLs
-aat
-aai
-aai
-aai
-abg
-enB
-aby
-aby
-aby
-aby
-aeg
-aeN
-afA
-afA
-abc
-wVh
-laq
-kdP
-mGw
+vdU
+vdU
+vdU
+akj
+aqG
+aEu
+aqG
+abE
+abE
+fbx
+abu
+dIs
+mhA
+fYb
+dIs
+mhA
+abu
+rkJ
+abE
+icv
+abE
+dJw
+jPj
+kzX
+asQ
+lrc
+aCo
+jAs
+fSL
+eRk
+mhM
+aiX
+xVi
+vZS
+hxc
+ryK
+agj
+agj
+agj
+agj
+agj
+agj
 akm
 akr
 alZ
 amO
 arQ
 aor
+arc
 aiX
-aiF
 aqI
 asv
 aqT
+auU
 apS
-arn
-apS
+awf
 apS
 apS
 apS
@@ -90152,73 +91412,73 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aak
-pWX
-aal
-aaw
-aaA
-aat
-aaB
-aat
-acK
-aex
-akK
-acd
-asL
-aus
-acd
-asL
-aus
-acd
-asL
-aus
-acd
-asL
-aus
-acd
-aLs
-aat
-acd
+vdU
+aaY
+abu
+alm
+abE
+aVP
+cyi
+abE
+eve
+fcj
+abu
+ecJ
+mir
+gbD
+jgG
+yab
+abu
+pQh
+ggZ
+iVT
+ggZ
+ugT
+jRW
+aPP
+kZi
 aTA
 aVx
 aXx
-aYI
-aXx
-aVx
-bhK
-acd
-aef
-aeM
-afz
-okI
+abu
+maM
+mjn
+aiX
+kfG
+vZS
+hxc
+ryK
+agj
 ail
 wPh
 vIi
 fsj
-dXP
-vZS
+agj
+ami
 qUk
-jhb
+sAr
 and
 arS
 anq
+arl
 aiX
-aiT
-ass
-aiT
+weW
+atV
+weW
 arP
-aqR
 aqR
 nqz
 aqR
@@ -90409,69 +91669,69 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aal
-aap
-aat
-aaB
-aat
-aaB
-aat
-acK
-aaJ
-akt
-acd
-ars
-auu
-acd
-ars
-auu
-acd
-ars
-auu
-acd
-ars
-auu
-aml
-aLJ
-amG
-aSG
-aUf
-aVG
-rDu
-acd
-aXA
-bdV
-bhP
-acd
-blT
-aeO
-afJ
-dXP
-dXP
-dXP
-dXP
-dXP
-dXP
-gjc
-ajX
-agj
-amL
-asp
-sea
+vdU
+abc
+aer
+alm
+aqS
+bgd
+cFc
+abE
+eCO
+fbx
+abu
+fho
+nsR
+geS
+gLZ
+yaU
+abu
+abu
+dEN
+abu
+abu
+abu
+aaD
+aaP
+abu
+abu
+abu
+abu
+abu
+eRk
+mnc
 aiX
-qmV
+adG
+nti
+nUw
+ryK
+dXP
+aiF
+ajB
+akK
+aln
+dXP
+vyc
+ajX
+amL
+agj
+uto
+sea
+arn
+aiX
 anz
 aov
 aph
@@ -90666,69 +91926,69 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aam
-aaq
-aat
-aaC
-aaR
-abj
-aaR
-acY
-aeQ
-akP
-amo
-asT
-auy
-awf
-asT
-auy
-acG
-aCV
-auy
-aFh
-asT
-auy
-amo
-aLS
-acG
-aTa
-aUq
-acG
-acG
-aYX
-acG
-aeo
-biM
-bkA
-bml
-aeO
-amq
-agj
+vdU
+abG
+abu
+alr
+ars
+biC
+cJL
+bbr
+bbr
+fet
+abu
+fpa
+fpa
+geS
+geS
+geS
+hbH
+abu
+vLO
+mqH
+eUL
+asQ
+qzQ
+fjl
+lau
+abu
+lvT
+lvT
+abu
+eRk
+mrI
+aiX
+adG
+vZS
+hxc
+ryK
+dXP
 afH
 agY
 ahS
 aiI
-afn
+dXP
 usv
-akD
+xCp
+amP
 agj
 agj
 agj
 agj
 aiX
-vcQ
 anz
 aov
 cCi
@@ -90923,56 +92183,56 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aam
-aar
-aat
-aaD
-aaU
-abx
-aaU
-ada
-afo
-akV
-amG
-aei
-abC
-aat
-aei
-abC
-abh
-aei
-abC
-aat
-aei
-abC
-amG
-aLs
-aat
-aTp
-aat
-aat
-aXH
-acd
-bcO
-abh
-aat
-acd
-bmu
-acp
-uto
-agO
+vdU
+abu
+abu
+abu
+abu
+biM
+cYf
+abu
+abu
+ffg
+abu
+fqX
+fqX
+geS
+sHf
+geS
+hso
+abu
+eDW
+ezG
+qOr
+abu
+gsh
+hhB
+lau
+abu
+lwd
+lvT
+abu
+dEN
+abu
+aiX
+mTS
+vZS
+hxc
+ryK
+dXP
 afI
 ahb
 ahZ
@@ -90982,7 +92242,7 @@ akg
 oWe
 aly
 anP
-sAr
+dOP
 mym
 pWM
 aqC
@@ -91180,56 +92440,56 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aan
-aas
-aav
-aaE
-aaV
-abA
-aaV
-adb
-afq
-akW
-amH
-aep
-auA
-aws
-aep
-auA
-aAM
-aep
-auA
+vdU
+abJ
+aeM
+amQ
+asP
+blT
+cYt
+abu
+afY
+aij
+aht
+aim
+nUM
+fpa
+gMI
+geS
+hvb
+abu
 aFi
-aep
-auA
-amH
-aMp
-acJ
-aTq
-acJ
-dqN
-acJ
-bae
-acJ
-bdW
-acJ
+kdZ
+qng
+abu
+jTy
+hhB
+lau
+abu
+lvT
+lvT
+abu
+gzz
+msX
+adH
 bkI
 bmv
-bop
-alC
-agj
+hxc
+ryK
+ahw
 bot
 bpg
 aid
@@ -91239,7 +92499,7 @@ alz
 xCp
 alg
 rZB
-uto
+wSs
 drO
 aou
 aqC
@@ -91437,61 +92697,61 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aao
-aaq
-aat
-aaB
-aat
-aaB
-aat
-acK
-afK
-alf
-aml
-ars
-auu
-acd
-ars
-auu
-acd
-ars
-auu
-acd
-ars
-auu
-acd
-aLJ
-amG
-acd
-htK
-acd
-aXO
-acd
-aUr
-bei
-aVP
-acd
-aem
-fLS
-afG
+vdU
+abR
+aeO
+amT
+asQ
+bmu
+dhE
+abu
+aea
+fgr
+ahv
+aim
+fqX
+fpa
+gMI
+gZT
+abu
+abu
+abu
+ncR
+abu
+abu
+gsh
+hhB
+lau
+lsv
+lEk
+lLt
+lNi
+gzz
+mwb
+aiX
+uto
+vZS
+rFw
+ojO
 agj
 afL
 ahu
 aie
 aiO
-afn
+agj
 iaX
 agL
 akT
@@ -91694,55 +92954,55 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-pWX
-aao
-aaw
-aaA
-aat
-aaB
-aat
-acK
-agl
-alm
-acd
-asU
-auC
-acd
-asU
-auC
-acd
-asU
-auC
-acd
-asU
-auC
-acd
-aLs
-aat
-acd
-aUC
-acd
-aYa
-acd
-bcT
-bfk
+vdU
+abu
+abu
+abu
+abu
+bop
+djJ
+abu
+aim
+aim
+cpt
+aim
+fqX
+fpa
+gNv
+hcn
+hvz
+xdL
+iky
+iZq
+fJC
+vFf
+xjL
+aaR
+vFf
+vFf
+vFf
+vFf
+fJC
+vFf
+iID
 biZ
-acd
-vZS
-aeO
-afG
+eyf
+nuO
+kdS
+ryK
 agj
 agj
 agj
@@ -91951,58 +93211,58 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-aau
-aaF
-aat
-aaB
-aat
-adc
-agt
-aln
-acd
-asV
-auN
-acd
-asG
-auN
-acd
-asV
-auN
-acd
-asG
-auN
-acd
-aLs
-aPi
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-acd
-bnd
-aeO
-ahE
+aal
+acc
+aeX
+abu
+asR
+bop
+dkx
+abu
+aek
+fkp
+cKx
+fAQ
+fMT
+ghE
+gPu
+hdA
+tef
+abE
+ilh
+abE
+jnm
+abE
+ilh
+kCL
+abE
+lto
+abE
+abE
+jnm
+abE
+eZm
+aen
+nHG
+dJb
+oyn
+ryK
 agj
 aii
-afM
+ajD
 aig
 agp
 agj
@@ -92010,7 +93270,7 @@ hkH
 akl
 akM
 amm
-sAr
+tqd
 anM
 dys
 aqC
@@ -92208,66 +93468,66 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aaj
-aaj
-gXs
-aai
-aao
-aaW
-qlX
-aat
-acK
-afK
-alf
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-acd
-aml
-aLs
-aPh
-aai
-aLs
-aat
-aaJ
-bbr
-aaJ
-aat
+aal
+acE
+aft
+ano
+asS
+bpD
+dvA
+abu
+epL
+fkW
+dJQ
+aim
+abu
+giL
+geS
+hgP
+hxh
+hyR
+ioj
+jat
+jnF
+jCb
+jXu
+kCQ
+liW
+lul
+edO
+lLD
+sSF
+edO
+wul
 bjD
-acd
-bne
-aev
-aeS
+eOg
+nuX
+amM
+ryK
 agj
-ajg
-afM
+ajL
+ajG
 akU
-afM
+ryK
 kGl
 alA
 hxc
 alg
 dmX
-uto
+hlz
 lhh
 seP
 aqC
@@ -92465,66 +93725,66 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-aau
-abB
-abM
-add
-agD
-alr
-amP
+aal
+acH
+afw
+abu
 asX
-auS
-aww
-axZ
-axZ
-asX
-axZ
-asX
-aFj
-axZ
-asX
-axZ
-aMv
-aPj
-aTx
-aLS
-aWw
-aaJ
-bbN
-aaJ
-bgl
-bjW
-blN
+bop
+dkx
+abu
+nMr
+aim
+aim
+fkW
+fPw
+abu
+tef
+eoD
+abu
+abu
+ioH
+eoD
+abu
+abu
+kjv
+kEk
+abu
+abu
+abu
+abu
+tZf
+abu
+abu
+vdU
+vdU
 nBb
 aeT
-ahE
+ryK
 agj
-ajL
-akj
-afM
-afM
+ovZ
+iwi
+akP
+alx
 csK
 kPY
 alB
 akT
 uwq
-fEw
+rtp
 anB
 amR
 aqC
@@ -92722,55 +93982,55 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aaj
-aaj
-gXs
-pWX
-aao
-aaw
-ade
-agF
-alx
-amQ
-asY
-alx
-awN
-ayB
-aAm
-asY
-awN
-aEr
-amQ
-xez
-asY
-alx
-awN
-aPw
-amc
-aUP
-aXs
-aat
-acd
-abL
-bgx
-bke
-adG
+vdU
+vdU
+abu
+abu
+abu
+bop
+dkx
+abu
+aeI
+aeJ
+alW
+fEb
+abu
+glr
+abE
+hhB
+abu
+hEj
+ipD
+jdL
+abu
+jDe
+nME
+wkE
+abu
+ugO
+urU
+abu
+otA
+pFN
+yeX
+abE
+vdU
 bnU
 aeV
-agj
+ryK
 agj
 agj
 gCm
@@ -92979,52 +94239,52 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-aai
-adf
-abC
-aai
-acd
-ars
-auU
-awX
-awX
-acd
-ars
-aDu
-acd
-acd
-acd
-ars
-aJN
-awX
-acd
-aai
-aLs
-aat
-aaJ
-bbN
-aaJ
-aat
-bkg
-acd
+vdU
+agJ
+anp
+asQ
+bzr
+dkx
+abu
+abu
+abu
+abu
+abu
+abu
+alm
+abE
+hhB
+abu
+hFU
+irv
+jfU
+abu
+jEe
+kjU
+kHT
+ljf
+reX
+pyV
+abu
+xuH
+ybo
+gJf
+mLj
+aen
 aeP
 afC
 agk
@@ -93038,7 +94298,7 @@ aku
 akl
 amk
 amm
-sAr
+dRt
 guS
 dys
 aqC
@@ -93236,55 +94496,55 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-aai
-aai
-aai
-aai
-adf
-agN
-aai
-amT
-atk
-aaU
-axd
-axd
-acd
-aBD
-aDJ
-aEs
-acd
-aFS
-aHs
-aGp
-aMH
-aPP
-aai
-aUV
-jdL
-aaJ
-bbr
-aaJ
-bgR
-bkl
-acd
-aer
+vdU
+agK
+acX
+asP
+blT
+dwZ
+abu
+eDF
+fkY
+fti
+fBc
+abu
+alm
+gPW
+fjl
+abu
+abu
+abu
+abu
+abu
+abu
+nME
+kIP
+asQ
+nXO
+evx
+abu
+alr
+pWG
+ars
+mNG
+vdU
+iwi
 afB
-agi
+iwl
 qLc
 afN
 ajK
@@ -93295,7 +94555,7 @@ akv
 kdS
 alg
 nVk
-uto
+qUU
 anQ
 seP
 aqC
@@ -93493,61 +94753,61 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-aaG
-aaI
-abD
-aaG
-add
-agQ
-aai
-ano
-atl
-aaU
-axm
-fYb
-acd
-aBM
-aDJ
-aEt
-acd
-aGe
-aHt
-aGp
-aMJ
-aQt
-aai
-aai
-aai
-aYh
-aai
-aYh
-aai
-aai
-aai
-aaZ
-aaZ
+vdU
+agN
+ada
+abu
+bop
+dkx
+abu
+eLk
+flG
+ftO
+fIu
+fSJ
+goJ
+abE
+hhB
+abu
+hGj
+iAt
+jiD
+jrC
+abu
+kkj
+wkE
+abu
+abu
+abu
+abu
+abu
+ksK
+vdU
+vdU
+vdU
+aiX
+aiX
 aiX
 aiX
 afS
 ahx
 aiX
-aiX
-eCQ
+alV
+ajc
 akx
 ybm
 akT
@@ -93750,61 +95010,61 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-aaI
-aaX
-aaX
-aaI
-aei
-ahs
-aai
-amT
-amT
-auW
-amT
-axd
-acd
-aBS
-aDJ
-aEu
-acd
-jDN
-fEj
-aGp
-oiR
-oMT
-aai
-aaa
-aai
-aYH
-bbU
-bcW
-aaZ
+vdU
+abu
+abu
+abu
+bDF
+dhE
+abu
+eMR
+flK
+ftO
+fIQ
+abu
+gqR
+gQT
+hiE
+hxP
+hPY
+fBc
+fBc
+jvk
+abu
+kkR
+kNZ
+abu
+ugO
+urU
+abu
+ent
+sck
+vdU
 aeF
-ack
-agJ
-aaZ
+aeF
+aiX
+nXd
 adK
 aew
 afT
 ahy
 aiX
 aiR
-ajc
+amh
 akz
 hxc
 als
@@ -94007,54 +95267,54 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-gDl
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-aaI
-aaX
-aaX
-aaI
-aei
-aht
-aai
-anp
-aaU
-aaU
-aaU
-ayF
-acd
-aCf
-aDO
-aEv
-acd
-aGn
-aHs
-aGp
-aMH
-aFS
-aai
-aaa
-aai
-aYH
-bbZ
-bcW
-aaZ
-aeW
-acl
+vdU
 agJ
-aaZ
+aca
+asQ
+bzr
+dkx
+abu
+eND
+fnP
+fwQ
+fBc
+abu
+gqR
+gSN
+hmg
+asQ
+hTd
+iAE
+jiJ
+jwc
+abu
+kjU
+kHT
+ljf
+reX
+pyV
+abu
+jIa
+fHL
+vdU
+aeW
+aeF
+aiX
+adL
 adL
 adL
 ago
@@ -94066,7 +95326,7 @@ akz
 hxc
 alg
 alt
-amp
+aot
 aot
 apR
 aqE
@@ -94267,50 +95527,50 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-aaG
-aaI
-abE
-aaG
-adB
-ahv
-aai
-anx
-ato
-avd
-axs
-fYb
-acd
-aCm
-aDS
-aDV
-aFt
-aGp
-aHU
-aKb
-aMK
-aQQ
-aai
-aaf
-aai
-aYH
-aYH
-bcW
-aaZ
-aeX
-acm
+vdU
 agK
+acX
+asP
+blT
+dwZ
+abu
+abu
+abu
+fxK
+abu
+abu
+gsh
+abE
+hhB
+abu
+abu
+abu
+abu
+abu
+abu
+nME
+kIP
+asQ
+nXO
+evx
+aaZ
+aaZ
+aaZ
+aaZ
+aaZ
+acm
+aaZ
 aaZ
 aaZ
 aaZ
@@ -94323,8 +95583,8 @@ akz
 rFw
 alg
 eRh
-amI
-alg
+aot
+aot
 alv
 aqE
 anS
@@ -94524,49 +95784,49 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaj
-gXs
-aai
-aai
-aai
-aai
-aai
-adf
+vdU
 agN
-aai
-acd
-ats
-acd
-acd
-azd
-acd
-nSN
-aDV
-aDV
-aFD
-aGp
-aHW
-aGp
-aMW
-aGp
-aai
-aaT
-aai
-aai
-aai
+ada
+abu
+bop
+dCm
+dRw
+vFf
+vFf
+fyA
+fJC
+vFf
+gsn
+fWK
+aaR
+hzu
+hYr
+iBf
+mBH
+hYr
+hYr
+kNf
+kPo
+vdU
+vdU
+vdU
 aaZ
-aaZ
+lNH
+mee
+mBc
 aeY
-acn
+adM
 agR
 ahm
 ahA
@@ -94580,7 +95840,7 @@ ajC
 akC
 akX
 alw
-amJ
+aot
 aoY
 soA
 aqE
@@ -94781,55 +96041,55 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+vdU
+vdU
+abu
+asY
+bGS
+dEE
+dSr
+edO
+edO
+fAA
+fJT
+edO
+guj
+gSW
+hmo
+hzM
+iak
+iCs
+tvN
+jxX
+jxX
+klo
+nDL
+vdU
 aaa
-aaa
-aaa
-aaj
-gXs
-gXs
-gXs
-gXs
-gXs
-aai
-adF
-ahw
-aai
-anN
-atu
-ave
-axv
-wvA
-acd
-aCo
-aDV
-aDV
-aFD
-aGp
-aGp
-aGp
-aGp
-aGp
-aai
-aVw
-aaf
-aaT
-gXs
-abG
+lEN
 aaZ
+lPa
 aeZ
-aco
+aeZ
+aeZ
+aeZ
 agS
-aho
+ahX
 ahX
 afb
 agH
-agH
+oyU
 aip
 aja
 lCf
@@ -95038,6 +96298,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -95045,46 +96310,41 @@ aaa
 aaa
 aaa
 aaa
+vdU
+anx
+atk
+cbX
+abu
+abu
+abu
+cbX
+abu
+abu
+abu
+abu
+gVc
+eoD
+abu
+abu
+iHl
+eoD
+abu
+jGz
+kor
+kXN
+vdU
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-iDo
-yin
-aai
-adH
-ahO
-aai
-aop
-aay
-aay
-lKA
-azj
-acd
-aCq
-aDV
-aDV
-aFD
-aGp
-aGp
-aGp
-aGp
-aRv
-aai
-aaf
-aaf
-abY
-gXs
-bdM
+gJi
 aaZ
-afc
-aco
+lPy
+bdM
+mDZ
+bdM
+mZM
 agU
 ahp
 afd
-afd
+ovC
 afd
 ahB
 aiq
@@ -95295,6 +96555,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -95302,44 +96567,39 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-iDo
+aho
+anO
+ato
+cjn
+dEN
+dWe
+eRk
+eRk
+eRk
+eRk
+fSL
+gwq
+gWQ
+hmX
+abu
+icy
+iMg
+jiT
+abu
+jJW
+kor
+kXN
+vdU
 gXs
-aai
-lsg
-ahP
-aai
-aoq
-atz
-avf
-axx
-lIh
-acd
-aCx
-aDW
-aEw
-acd
-aGK
-aHX
-aKg
-aNn
-aNn
-aai
-aaf
-aaf
-adR
-abo
-adR
-adR
-adR
+gXs
+aaZ
+lQZ
+lQZ
+lQZ
+mPO
 abI
 acM
-adh
+adM
 adM
 afe
 agI
@@ -95552,6 +96812,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -95559,48 +96824,43 @@ aaa
 aaa
 aaa
 aaa
+ahR
+aoo
+ats
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+roW
+qCb
+hpG
+fSL
+idJ
+iMj
+evx
+abu
+jNJ
+kqG
+gzz
+vdU
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-iDo
-gXs
-aai
-adI
-ahP
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aaT
-aaT
 adR
-aaY
-abJ
-abR
+adR
+adR
+adR
 adR
 acq
 ahX
 adi
 adP
+ovS
 ahK
 ahK
-ahR
 aiv
 adg
 oaZ
@@ -95809,6 +97069,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -95816,48 +97081,43 @@ aaa
 aaa
 aaa
 aaa
+vdU
+aop
+atu
+vdU
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-iDo
+vdU
+rYM
+pST
+hpI
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
+vdU
 gXs
-aai
-adI
-ahP
-aai
-aos
-atQ
-aat
-aos
-aos
-aai
-mZR
 gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-aaf
-aaf
-aaa
 abo
 abk
-abk
-abk
+mga
+mGJ
 adR
 agq
 agV
 aaZ
 aaZ
-aih
-agX
 aaZ
+agX
+akb
 aaZ
 aaZ
 lZR
@@ -96066,6 +97326,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -96079,29 +97344,24 @@ aaa
 aaa
 aaa
 aaa
-iDo
-gXs
-aai
-adJ
-aij
-alV
-acG
-acG
-aWw
-aat
-aat
-aai
-mZR
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaj
-aaT
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 adR
 abO
@@ -96114,7 +97374,7 @@ adj
 afQ
 afr
 akc
-aik
+akc
 akh
 adR
 oMZ
@@ -96323,6 +97583,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -96336,19 +97601,6 @@ aaa
 aaa
 aaa
 aaa
-iDo
-gXs
-aai
-adI
-ahP
-alW
-aat
-xUe
-xUe
-xUe
-dOj
-aai
-qqx
 aaa
 aaa
 aaa
@@ -96358,7 +97610,15 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 abo
 abO
@@ -96367,7 +97627,7 @@ abO
 abO
 abO
 abO
-adk
+nYQ
 abo
 afD
 afU
@@ -96580,6 +97840,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -96593,21 +97858,6 @@ aaa
 aaa
 aaa
 aaa
-iDo
-gXs
-aai
-lsg
-aim
-amc
-wxo
-wxo
-aXs
-aat
-aat
-aai
-mZR
-eRz
-ktS
 aaa
 aaa
 aaa
@@ -96615,14 +97865,24 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 adR
 qGA
-abN
-abN
-abN
-abl
+qGA
+qGA
+qGA
+qGA
 acO
 adl
 aet
@@ -96837,6 +98097,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -96850,21 +98115,16 @@ aaa
 aaa
 aaa
 aaa
-iDo
-gXs
-aai
-sVr
-aiQ
-aai
-apb
-atR
-avm
-axR
-axR
-aai
-mZR
-eRz
-ktS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97094,6 +98354,11 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -97107,21 +98372,16 @@ aaa
 aaa
 aaa
 aaa
-iDo
-gXs
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-aai
-mZR
-eRz
-ktS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97364,21 +98624,21 @@ aaa
 aaa
 aaa
 aaa
-iDo
-gXs
-gXs
-gXs
-gXs
-gXs
-apw
-gXs
-gXs
-gXs
-gXs
-gXs
-gXs
-eRz
-ktS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97398,7 +98658,7 @@ abq
 aff
 aeU
 ajA
-akd
+afU
 ahF
 aiB
 abp
@@ -97621,21 +98881,21 @@ aaa
 aaa
 aaa
 aaa
-eRz
-eRz
-eRz
-eRz
-eRz
-eRz
-eRz
-eRz
-gXs
-iDo
-iDo
-iDo
-iDo
-iDo
-ktS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97653,8 +98913,8 @@ aci
 acs
 acR
 afh
-afV
-agB
+agZ
+ahd
 ahd
 ahI
 akO
@@ -97910,8 +99170,8 @@ adn
 agw
 abq
 afg
-afU
-afU
+agQ
+ahO
 ahc
 ahH
 akR
@@ -98149,7 +99409,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
 aaa
 aaa
 aaa
@@ -98384,21 +99644,21 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -98425,7 +99685,7 @@ acF
 abq
 afi
 afW
-afW
+ahP
 ahe
 ahJ
 ais
@@ -98645,17 +99905,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -98902,17 +100162,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -98937,9 +100197,9 @@ abq
 abq
 abq
 abq
-afg
-afY
-afY
+agl
+afU
+afU
 ahg
 ahL
 aiu
@@ -99159,17 +100419,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99190,9 +100450,9 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaf
-abo
+adf
+adJ
+aex
 aeB
 afm
 agb
@@ -99416,17 +100676,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99447,9 +100707,9 @@ aag
 aag
 aaf
 aaf
-aaf
-aaf
-abo
+adk
+abm
+adR
 aeA
 afl
 aga
@@ -99678,12 +100938,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99935,12 +101195,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100192,12 +101452,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100449,12 +101709,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100706,12 +101966,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100963,12 +102223,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -101220,12 +102480,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -101481,8 +102741,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -101738,8 +102998,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -101995,8 +103255,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -102252,8 +103512,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request
• Reworks Boxstation prison and completely revamps it into a modern genpop prison.
• Slightly modifies the rest of security. Mostly aesthetic changes.
• Populates the armoury with more items.
• Brig Physician gets an operating bed so they are better equipped to deal with TG wounds.
• Fixes a ton of horrible mapping errors littering security, mostly tons of wires just leading into nowhere.

## Media
![image](https://user-images.githubusercontent.com/53862927/93081894-df901100-f687-11ea-8e66-6fab9366109b.png)
_The new brig._

![image](https://user-images.githubusercontent.com/53862927/93081926-f2a2e100-f687-11ea-9c6a-399639574118.png)
_The new armoury._

![image](https://user-images.githubusercontent.com/53862927/93082266-87a5da00-f688-11ea-9346-41595dfa2139.png)
_Brig physicians rejoice! It's nicer._

![image](https://user-images.githubusercontent.com/53862927/93082380-c045b380-f688-11ea-8865-a735ed8cbd71.png)
_Slightly updated interrogation room._

![image](https://user-images.githubusercontent.com/53862927/93082493-ef5c2500-f688-11ea-9176-e944da84d12d.png)
_Get ready to enter the priissssooon!_

![image](https://user-images.githubusercontent.com/53862927/93082535-fdaa4100-f688-11ea-95fd-ae720ba3790a.png)
_The previous isolation cells were godawful and the idea behind them was so horrific I'm mind-blown. Stick people in a 1x1 behind a blast door. Seriously? It's now a padded cell with a timer. You can slap them in for five minutes._

![image](https://user-images.githubusercontent.com/53862927/93082706-511c8f00-f689-11ea-901e-60b701ee758d.png)
_Orange wing. It's nice and snug_

![image](https://user-images.githubusercontent.com/53862927/93082865-93de6700-f689-11ea-9c48-2f025507d72b.png)
_Hydroponics! With a view! Grow things in a nice cozy peaceful spot._

![image](https://user-images.githubusercontent.com/53862927/93082997-c8522300-f689-11ea-9d79-bf2344f8d43f.png)
A small pool.

![image](https://user-images.githubusercontent.com/53862927/93083052-e0c23d80-f689-11ea-8f88-7ca5821d51bc.png)
_Purple wing. Yeah this is familiar for some of you folks. It's really girly._

![image](https://user-images.githubusercontent.com/53862927/93083103-fb94b200-f689-11ea-83c7-05bba3c7c12e.png)
_Green wing. It's the most bland of them all, but if you really need the space..._

![image](https://user-images.githubusercontent.com/53862927/93083175-1ff08e80-f68a-11ea-9bbd-2a48e9aa678f.png)
_The library. It's small, no one really uses it. You have a nice private space._

![image](https://user-images.githubusercontent.com/53862927/93083288-4a424c00-f68a-11ea-9800-bd918c09a00b.png)
_The kitchen and cafeteria!_

![image](https://user-images.githubusercontent.com/53862927/93083396-72ca4600-f68a-11ea-9dd4-1c06f3be14fb.png)
_All of the wings have shutters in them. You can lock prisoners into any of the three wings. The rest of the prison is accessible no matter which wings you close off._

## Why It's Good For The Game
In a break from my usual format, I've put the pretty pictures further up. They should be convincing for why this PR is good for the game.
**So, what specific improvements have been made from the original prison?**
1. It's more compact. It's actually smaller. Space has been much better utilised.
2. The horrific blast-door GBJ cells have been replaced by a padded cell that uses a door timer. You now can't lock antags in a 1x1 with a blast door roundstart for the rest of the round with no hopes of them escaping. You can communicate with people whilst in the cell, which means less chances of people just ghosting because they've been placed in ghetto admin jail.
3. Hidden rooms are in, with loot! It's unlikely that you'll get enough loot to actually stage a break-out.
4. It looks considerably better. The old prison doesn't look very good at all
5. This is actually a genpop prison; it actually has genpop lockers.
6. You can close individual wings off. If you're terrified that someone might slap another prisoner, you can lock them in their own wing. All of the prison's features are not directly connected to the wings. All three wings can be closed and the rest of the prison is still perfectly accessible.
7. No space carps that spawn directly outside of the prison which made engineering have to fix the window more rounds than not. Now you can do prisoner stuff without having to sit inside a room whilst engineering fixes the breach and a bad atmos tech leaves the air alarms on refill mode and makes the entire prison 303 kilopascals.

Also, a security records console is now in the brig. Have you brought someone in? Do you want to add a crime to their records? Now you can do it from the brig. You can sit down there and look through the cameras if you want.

The Brig Physician area is now much nicer and because a lot of TG wounds require surgery, they have a surgery table. Without one, the Brig Physician is woefully under-equipped to do anything but fix minor boo-boos. 

## Changelog
:cl:
add: A completely new prison for Boxstation!
tweak: Boxstation Security has received an aesthetic overhaul.
fix: Huge heaps of mapping errors in Boxstation Security have been fixed.
/:cl:
