### PR TITLE
Fixes cobblestone & grass making lattices upon explosions

### DIFF
--- a/modular_skyrat/code/game/turfs/open/floor/planetfloor.dm
+++ b/modular_skyrat/code/game/turfs/open/floor/planetfloor.dm
@@ -3,7 +3,17 @@
 	desc = "Stone cobbles set into the ground."
 	icon = 'modular_skyrat/icons/turf/floors/planetfloor.dmi'
 	icon_state = "cobblestone1"
-	baseturfs = /turf/open/floor/plating/asteroid
+	baseturfs = /turf/open/floor/plating/smooth/dirt
+	attachment_holes = FALSE
+
+// Although our baseturf is something that will never go to space...//
+/turf/open/floor/plating/cobblestone/burn_tile()
+	return
+/turf/open/floor/plating/cobblestone/break_tile()
+	return
+/turf/open/floor/plating/cobblestone/ReplaceWithLattice()
+	return
+//... we don't want icon changes once bombed to invalid icon-states!//
 
 /turf/open/floor/plating/cobblestone/snow
 	name = "snowy cobblestone"

--- a/modular_skyrat/code/game/turfs/open/floor/plating/lavaland_jungle.dm
+++ b/modular_skyrat/code/game/turfs/open/floor/plating/lavaland_jungle.dm
@@ -74,3 +74,6 @@
 	icon_state = "shallow"
 	color = "#648363"
 	slowdown = 3
+
+/turf/open/floor/plating/smooth/ReplaceWithLattice()
+	return


### PR DESCRIPTION
## About The Pull Request
Cobblestone and Azarak's grass will no longer create lattices once exploding.
Cobblestone now returns procs related to burning. Explosions that cause burns doesn't make cobblestone change icon-states to burnt plating icon-states. Since these icon-states are not in the modular .dmi cobblestone is located in, it would just create a pitch black square.

## Why It's Good For The Game
If I dig up my garden... _if I had one..._ then I won't find lattices underneath. These turfs are mostly used on planets.
Also, bugs are bad. Pitch-black squares are scary!

## Changelog
:cl:
fix: Cobblestone and smooth grass (Azarak's grass on Lavaland) no longer create lattices upon exploding.
fix: Cobblestone doesn't turn pitch black upon exploding.
/:cl:

## Media
![image](https://user-images.githubusercontent.com/53862927/93217300-c73ff500-f760-11ea-959a-03c1fb207e52.png)
_No lattices!_

##Acknowledgements
Thanks to Azarak for helping me condense the fix into as few lines as possible.