### PR TITLE
Moves the Security Protolathe into the Warden's Office on all rotation maps; Replaces Secoff's advanced taser with the alert-locked ERifle

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -4264,13 +4264,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aii" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aij" = (
 /obj/machinery/camera{
@@ -8618,14 +8618,16 @@
 	pixel_y = -40;
 	req_access_txt = "2"
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Brig Control";
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "arz" = (
 /obj/item/coin/gold,
@@ -54990,6 +54992,30 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eKC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/large,
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eMs" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -59996,6 +60022,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"oeZ" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ofU" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -92002,7 +92033,7 @@ aeO
 ahE
 agj
 aii
-afM
+oeZ
 aig
 agp
 agj
@@ -95083,7 +95114,7 @@ afc
 aco
 agU
 ahp
-afd
+eKC
 afd
 afd
 ahB

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -28265,11 +28265,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bpo" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 32
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bpq" = (
@@ -42931,13 +42930,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bTf" = (
-/obj/structure/table/reinforced,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/item/clipboard,
-/obj/item/toy/figure/warden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -42947,7 +42943,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bTg" = (
 /obj/structure/cable/white{
@@ -42995,6 +42993,15 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/large,
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -47373,6 +47380,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/clipboard,
+/obj/item/toy/figure/warden,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "cbE" = (

--- a/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
@@ -8790,7 +8790,7 @@
 /area/security/main)
 "aso" = (
 /obj/machinery/light,
-/obj/machinery/rnd/production/protolathe/department/security,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "asp" = (
@@ -10717,6 +10717,15 @@
 /obj/item/melee/baton/loaded{
 	pixel_y = 3
 	},
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/large,
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "awc" = (
@@ -11281,8 +11290,8 @@
 /obj/structure/sign/poster/official/nt_storm_officer{
 	pixel_x = -32
 	},
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
+/obj/machinery/rnd/production/protolathe/department/security,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "axg" = (

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -2654,7 +2654,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ail" = (
-/obj/vehicle/ridden/secway,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aim" = (
@@ -3889,11 +3889,18 @@
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akN" = (
-/obj/effect/landmark/event_spawn,
 /obj/structure/rack,
-/obj/item/key/security,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
+	},
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/large,
+/obj/item/gun/energy/e_gun/large{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
@@ -4549,6 +4556,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amm" = (
@@ -52466,7 +52475,9 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/chapel/monastery)
 "cCS" = (
-/obj/machinery/rnd/production/techfab/department/security,
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "cCT" = (
@@ -88314,7 +88325,7 @@ xwo
 xwo
 ahL
 aik
-aiM
+ail
 ajh
 ajR
 akN
@@ -88570,7 +88581,7 @@ aby
 abI
 abI
 ahL
-ail
+aiM
 aiN
 aji
 ajS

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld
-	suit_store = /obj/item/gun/energy/e_gun/advtaser
+	suit_store = /obj/item/gun/energy/e_gun/large
 	backpack_contents = list(/obj/item/melee/baton/loaded=1)
 
 	backpack = /obj/item/storage/backpack/security


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I meant to do this in the original LabsSec PR, but it needed a further balance pass. This is said balance pass.
ALL Protolathes on all maps in **in rotation** have been moved to the Warden's Office. No more pocket-armory for Security Officers.
In exchange for this however, Security gets the Energy Rifle, a bulky energy-based gun which can fire 25 disabler shots and 12 (weak) lethal blasts. **Lethal functionality is locked to Blue Alert or higher security levels.**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Security running around with a small armory on their packs is bad, but they still need to be able to do their job against things that cannot be disabled (such as carp). This is a good middle ground to both of these issues.
No more pocket supersoldiers, but you can still do your job against things that require lethal force. A perfect balance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: All Security Lathes have been moved into the Warden's Office.
balance: Security Officers now get an Energy Rifle roundstart, essentially a bulkier disabler with a longer charge duration and ALERT LEVEL LOCKED lethal functionality.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
