### PR TITLE
Cleaning up the weapons crafting menu

### DIFF
--- a/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -24,6 +24,7 @@
 	subcategory = CAT_MELEE
 
 /*Should the parts requirement on the transforming weapons be switched from the rifle stock to the pistol grip, or would that make it too cheap to craft?
+*/
 /datum/crafting_recipe/switchblade_ms
 	name = "Switchblade"
 	result = /obj/item/switchblade/crafted

--- a/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/modular_skyrat/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -9,7 +9,7 @@
 				/obj/item/shard = 1)
 	time = 30
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/halberd
 	name = "Makeshift halberd"
@@ -21,8 +21,9 @@
 				/obj/item/hatchet = 1)
 	time = 60
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
+/*Should the parts requirement on the transforming weapons be switched from the rifle stock to the pistol grip, or would that make it too cheap to craft?
 /datum/crafting_recipe/switchblade_ms
 	name = "Switchblade"
 	result = /obj/item/switchblade/crafted
@@ -33,7 +34,7 @@
 	tools = list(TOOL_WELDER)
 	time = 45
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/balisong
 	name = "Butterfly Knife"
@@ -45,7 +46,7 @@
 	tools = list(TOOL_WELDER)
 	time = 60
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/switchblade_deluxe
 	name = "Deluxe Switchblade"
@@ -62,7 +63,7 @@
 	time = 250
 	tools = list(TOOL_WELDER)
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/trayshield
 	name = "Tray shield"
@@ -72,7 +73,7 @@
 				/obj/item/stack/cable_coil = 5)
 	time = 60
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/shank
 	name = "Shank"
@@ -82,7 +83,7 @@
 				/obj/item/shard = 1)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 //////////////////
 ///GUNS CRAFTING//
@@ -217,7 +218,7 @@
 	tools = list(TOOL_WELDER)
 	time = 75
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/lockermechdrill
 	name = "Makeshift exosuit drill"
@@ -277,7 +278,7 @@
 	reqs = list(/obj/item/rack_parts = 1)
 	time = 35
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/cylinder
 	name = "Aluminum cylinder"
@@ -286,7 +287,7 @@
 	tools = list(TOOL_WIRECUTTER)
 	time = 35
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/cylinderassembly
 	name = "Cylinder assembly"
@@ -294,7 +295,7 @@
 	reqs = list(/obj/item/aluminum_cylinder = 2)
 	time = 40
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/barrel
 	name = "Makeshift gun barrel"
@@ -303,7 +304,7 @@
 	tools = list(TOOL_WELDER)
 	time = 40
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/reservoir
 	name = "Fuel reservoir"
@@ -312,7 +313,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/blade
 	name = "Metal blade"
@@ -321,7 +322,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/largeblade
 	name = "Large metal blade"
@@ -330,7 +331,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/sword
 	name = "Makeshift sword"
@@ -341,7 +342,7 @@
 	tools = list(TOOL_WELDER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_MELEE
 
 /datum/crafting_recipe/rails
 	name = "Metal rails"
@@ -351,7 +352,7 @@
 	tools = list(TOOL_WELDER)
 	time = 50
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 /* I don't think porting the revialver is worth it
 /datum/crafting_recipe/beakercylinder
 	name = "Beaker cylinder"
@@ -360,7 +361,7 @@
 	tools = list(TOOL_SCREWDRIVER)
 	time = 20
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 */
 /datum/crafting_recipe/assemblygeneral
 	name = "General gun assembly"
@@ -370,7 +371,7 @@
 	tools = list(TOOL_WRENCH, TOOL_WELDER)
 	time = 150
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/assemblygeneralbarreled
 	name = "General barreled gun assembly"
@@ -380,7 +381,7 @@
 	tools = list(TOOL_WRENCH)
 	time = 100
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/railgun_assembly
 	name = "Rail gun assembly"
@@ -394,7 +395,7 @@
 	tools = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WRENCH)
 	time = 200
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS
 
 /datum/crafting_recipe/railgun
 	name = "Rail gun"
@@ -423,4 +424,4 @@
 				/obj/item/wrench = 1)
 	time = 30
 	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
+	subcategory = CAT_PARTS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Declutters the CAT_WEAPON category, which had previously been a catch-all before the subcategories were added. This should put most if not all of the leftovers of the switch to the subcategory system into their proper subcategories. 

Also, see the comment on the craftable switchblade. Its recipe hasn't been updated since the guncrafting update. There's a more appropriate part for the recipe now but it might dick around with game balance because that part's cheaper to make. I'll leave that change up to someone who's been contributing longer than I have.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shit is where you expect it to be instead of getting lumped into Ranged Weapons. No more searching line-by-line for a makeshift shield recipe!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Decluttered 'Ranged Weapon' crafting category, which used to be the only subcategory for weapons and had leftovers from that bygone era.
code: All items in weapons_and_ammo crafting file have (probably) been removed from the CAT_WEAPON subcategory if they don't need to be there. Parts are in CAT_PARTS, shields and blades into CAT_MELEE, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
