### PR TITLE
no bonking on surgeries

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -94,7 +94,11 @@
 			for(var/datum/surgery/S in surgeries)
 				if(!S.lying_required || (S.lying_required && lying))
 					if(S.next_step(user,user.a_intent))
-						return 1
+						return TRUE
+			//if it's a tool and it's on help intent, just always avoid attacking
+			if((user.a_intent == INTENT_HELP) && I.tool_behaviour)
+				return TRUE
+			
 	//skyrat edit
 	if(!all_wounds || !all_wounds.len || !(user.a_intent == INTENT_HELP || user == src))
 		return ..()


### PR DESCRIPTION
## About The Pull Request

tools on help intent will never bonk someone who's having surgery
thats it

## Why It's Good For The Game

no more synth bonks because wrong tool yada yada just use harm intent if you want to bonk

## Changelog
:cl:
tweak: Tools of any kind can no longer bonk people having surgery if used on help intent.
/:cl:
