### PR TITLE
[MEME-PR] Adds morale officer as an alt-title for the assistant

### DIFF
--- a/modular_skyrat/code/modules/jobs/job_types/_job_alt_titles.dm
+++ b/modular_skyrat/code/modules/jobs/job_types/_job_alt_titles.dm
@@ -26,7 +26,7 @@
 
 //Service
 /datum/job/assistant
-	alt_titles = list("Civilian", "Visitor", "Businessman", "Trader", "Entertainer", "Off-duty Employee")
+	alt_titles = list("Civilian", "Visitor", "Businessman", "Trader", "Entertainer", "Morale Officer", "Off-duty Employee")
 
 /datum/job/cook
 	alt_titles = list("Cook", "Culinary Artist", "Butcher", "Chef")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds "Morale Officer" to the assistant's alt titles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fancier name for entertainer. ~~I am also drunk so do not mind me.~~
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
_Should I even bother?_

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
