### PR TITLE
Changes to Dinnerware Vendors on Boxstation and Cook starting amount of ingredients

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -17622,7 +17622,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMw" = (
-/obj/machinery/vending/dinnerware, //Skyrat change
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMx" = (
@@ -19500,7 +19500,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aRA" = (
-/obj/machinery/vending/dinnerware, //Skyrat Change
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRB" = (
@@ -20414,10 +20414,10 @@
 "aTN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour, //Skyrat Change Start
+/obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice, //Skyrat Change Stop
+/obj/item/reagent_containers/food/condiment/rice,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)

--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -17622,13 +17622,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMw" = (
-/obj/machinery/vending/dinnerware{
-	contraband = list(/obj/item/reagent_containers/food/condiment/flour = 4);
-	desc = "This vendor is full of condiments to put on food.";
-	name = "\improper Condiments Vendor";
-	product_ads = "Get your sauces here!;No slave labour was used to make these products!;Nanotrasen Approved?!";
-	products = list(/obj/item/storage/bag/tray = 8, /obj/item/reagent_containers/food/drinks/drinkingglass = 10, /obj/item/storage/box/cups = 5, /obj/item/reagent_containers/food/condiment/pack/ketchup = 20, /obj/item/reagent_containers/food/condiment/pack/mustard = 20, /obj/item/reagent_containers/food/condiment/pack/hotsauce = 20, /obj/item/reagent_containers/food/condiment/pack/astrotame = 20, /obj/item/reagent_containers/food/condiment/saltshaker = 20, /obj/item/reagent_containers/food/condiment/peppermill = 20)
-	},
+/obj/machinery/vending/dinnerware, //Skyrat change
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMx" = (
@@ -19506,9 +19500,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aRA" = (
-/obj/machinery/vending/dinnerware{
-	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2, /obj/item/reagent_containers/food/condiment/flour = 4)
-	},
+/obj/machinery/vending/dinnerware, //Skyrat Change
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRB" = (
@@ -20422,6 +20414,10 @@
 "aTN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour, //Skyrat Change Start
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice, //Skyrat Change Stop
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)


### PR DESCRIPTION
## About The Pull Request

Removes custom attributes to the Dinnerware Vendors in Kitchen and Brig Kitchen as they do not add anything new and prevent the Vendors from updating from the vendor modules if they were to change
The only thing that is being removed is flour from the Kitchen _'Contraband'_ which I made up for by adding two more bags of rice and flour to spawn on the table at round start

## Why It's Good For The Game

Allows changes made to the Dinnerware Vendors in modules to properly sync to Boxstation Dinnerware Vendors and for the Cook to have more ingredients at round start without needing to hack his own vendor to get access to 'contraband' flour

## Changelog
:cl:
Removed custom properties from Brig Kitchen and Cook's Kitchen Dinnerware vendor
Added two more bags of rice and flour to the Cook's Kitchen table at round start
/:cl:
