### PR TITLE
Various QoL changes for drones

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -20,6 +20,10 @@
 #define MODE_KEY_BINARY "b"
 #define MODE_TOKEN_BINARY ":b"
 
+#define MODE_DRONE "drone"
+#define MODE_KEY_DRONE "r"
+#define MODE_TOKEN_DRONE ":r"
+
 #define MODE_WHISPER "whisper"
 #define MODE_WHISPER_CRIT "whispercrit"
 

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -104,11 +104,11 @@
 		return FALSE
 	return FALSE
 
-/datum/saymode/binary // Drones can use :b for binary, they now fall under binarycheck()
+/datum/saymode/drone // Drones can use :b for binary, they now fall under binarycheck()
 	key = MODE_KEY_DRONE
 	mode = MODE_DRONE
 
-/datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
+/datum/saymode/drone/handle_message(mob/living/user, message, datum/language/language)
 	if(isdrone(user))
 		var/mob/living/simple_animal/drone/D = user
 		D.drone_chat(message)

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -99,15 +99,20 @@
 		var/mob/living/simple_animal/hostile/blob/B = user
 		B.blob_chat(message)
 		return FALSE
-	if(isdrone(user))
-		var/mob/living/simple_animal/drone/D = user
-		D.drone_chat(message)
-		return FALSE
 	if(user.binarycheck())
 		user.robot_talk(message)
 		return FALSE
 	return FALSE
 
+/datum/saymode/binary // Drones can use :b for binary, they now fall under binarycheck()
+	key = MODE_KEY_DRONE
+	mode = MODE_DRONE
+
+/datum/saymode/binary/handle_message(mob/living/user, message, datum/language/language)
+	if(isdrone(user))
+		var/mob/living/simple_animal/drone/D = user
+		D.drone_chat(message)
+		return FALSE
 
 /datum/saymode/holopad
 	key = "h"

--- a/code/modules/keybindings/keybind/robot.dm
+++ b/code/modules/keybindings/keybind/robot.dm
@@ -59,3 +59,12 @@
 	var/mob/living/silicon/robot/R = user.mob
 	R.uneq_active()
 	return TRUE
+
+/datum/keybinding/robot/drone/can_use(client/user)
+	return isdrone(user.mob)
+
+/datum/keybinding/robot/drone/quick_equip // QOL: Drone quickequip
+	hotkey_keys = list("E")
+	name = "quick_equip"
+	full_name = "Quick Equip"
+	description = "Quickly puts an item in the best slot available"

--- a/code/modules/keybindings/keybind/robot.dm
+++ b/code/modules/keybindings/keybind/robot.dm
@@ -63,8 +63,13 @@
 /datum/keybinding/robot/drone/can_use(client/user)
 	return isdrone(user.mob)
 
-/datum/keybinding/robot/drone/quick_equip // QOL: Drone quickequip
+/datum/keybinding/robot/drone/quick_equip_drone // QOL: Drone quickequip
 	hotkey_keys = list("E")
-	name = "quick_equip"
-	full_name = "Quick Equip"
+	name = "quick_equip_drone"
+	full_name = "Quick Equip (Drone)"
 	description = "Quickly puts an item in the best slot available"
+
+/datum/keybinding/robot/drone/quick_equip_drone/down(client/user)
+	var/mob/living/simple_animal/drone/D = user.mob
+	D.quick_equip()
+	return TRUE

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -245,9 +245,10 @@ Key procs
 
 /datum/language_holder/drone
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
+								/datum/language/common = list(LANGUAGE_ATOM),
 								/datum/language/machine = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
+							/datum/language/machine = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate
 	blocked_languages = null

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -27,7 +27,7 @@
 	maxHealth = 30
 	unsuitable_atmos_damage = 0
 	wander = 0
-	speed = -0.75 // Buff to make drone more bearable during time dilation etc
+	speed = 0
 	ventcrawler = VENTCRAWLER_ALWAYS
 	healable = 0
 	density = FALSE

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -81,7 +81,7 @@
 	"<span class='notify'>You can use :d to speak in a special drone-only channel, and :b to speak in the common sillicon channel.</span>\n"+\
 	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>\n"+\
-	"<span class='notify'>You can use :d to speak in a special drone-only channel, and :b to speak in the common sillicon channel.</span>"
+	"<span class='notify'>You can use :r to speak in a special drone-only channel, and :b to speak in the common sillicon channel.</span>"
 
 /mob/living/simple_animal/drone/Initialize()
 	. = ..()
@@ -105,7 +105,10 @@
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
 	
-	droneradio = new /obj/item/radio/headset/headset_eng(src) // Gives drones common and engineering channel
+	droneradio = new /obj/item/radio(src) // Gives drones common and engineering channel
+	droneradio.keyslot = new /obj/item/encryptionkey/headset_eng(src)
+	droneradio.canhear_range = 1
+	droneradio.recalculateChannels()
 
 /mob/living/simple_animal/drone/ComponentInitialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -27,7 +27,7 @@
 	maxHealth = 30
 	unsuitable_atmos_damage = 0
 	wander = 0
-	speed = 0
+	speed = -0.75 // Buff to make drone more bearable during time dilation etc
 	ventcrawler = VENTCRAWLER_ALWAYS
 	healable = 0
 	density = FALSE
@@ -70,6 +70,7 @@
 	var/obj/item/default_hatmask //If this exists, it will spawn in the hat/mask slot if it can fit
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = FALSE //If we have laws to destroy the station
+	var/obj/item/radio/headset/droneradio = null
 	var/flavortext = \
 	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
 	"<span class='notify'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
@@ -77,8 +78,10 @@
 	"<span class='notify'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\
 	"<span class='notify'>     - Interacting with living beings (communication, attacking, healing, etc.)</span>\n"+\
 	"<span class='notify'>     - Interacting with non-living beings (dragging bodies, looting bodies, etc.)</span>\n"+\
+	"<span class='notify'>You can use :d to speak in a special drone-only channel, and :b to speak in the common sillicon channel.</span>\n"+\
 	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
-	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
+	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>\n"+\
+	"<span class='notify'>You can use :d to speak in a special drone-only channel, and :b to speak in the common sillicon channel.</span>"
 
 /mob/living/simple_animal/drone/Initialize()
 	. = ..()
@@ -86,6 +89,7 @@
 	access_card = new /obj/item/card/id(src)
 	var/datum/job/captain/C = new /datum/job/captain
 	access_card.access = C.get_access()
+	access_card.registered_account = SSeconomy.get_dep_account(ACCOUNT_ENG) // Make use of the engineering dept/budget, engi vend will be free etc
 
 	if(default_storage)
 		var/obj/item/I = new default_storage(src)
@@ -100,6 +104,8 @@
 
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)
 		diag_hud.add_to_hud(src)
+	
+	droneradio = new /obj/item/radio/headset/headset_eng(src) // Gives drones common and engineering channel
 
 /mob/living/simple_animal/drone/ComponentInitialize()
 	. = ..()
@@ -288,3 +294,10 @@
 		var/obj/item/clothing/H = head
 		if(H.clothing_flags & SCAN_REAGENTS)
 			return TRUE
+
+/mob/living/simple_animal/drone/binarycheck() // grants binary comms
+	return TRUE
+
+/mob/living/simple_animal/drone/get_idcard(hand_first) // for stuff like engi-vends
+	if(access_card)
+		return access_card


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes requested by a friend (Panzercampwagen/AshInTheWind).

~~Drones have received a speed buff to make playing them more bearable during tidi.~~
Drones now have the 'E' hotkey for quickly storing/equipping stuff.
Drones can now vend various materials and tools they need from vendors, using the engineering budget. (Makes engi-vend etc free.)
Dronechat has been moved to :r (r for repair, trying :d broke admin deadchat). Additionally they can now speak in :b binary.
Drones have received the ability to understand common, but cannot speak it.
Drones now can listen in on the common and engineering radio channel, but cannot speak into it.

A law change to allow slightly more interaction is planned for a seperate PR.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Drone love.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Drones can now speak in :b for binary channel. They can also receive (but not transmit) engineering and common channels.
add: Added 'E' hotkey quick equip functionality to drones.
add: Drones can now use vendors. Engi-vend etc are free, any item that does have a cost will subtract it from the engineering budget.
tweak: Drones can now understand common.
tweak: Dronechat channel moved to :r, for 'repair'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
