### PR TITLE
[Fastmerge] [Fix] [Phone PR] Fixes accidental bug with biolumi lights

### DIFF
--- a/modular_skyrat/code/game/objects/structures/flora.dm
+++ b/modular_skyrat/code/game/objects/structures/flora.dm
@@ -4,8 +4,8 @@
 	icon = 'modular_skyrat/icons/obj/flora/jungleflora.dmi'
 	icon_state = "stick"
 	gender = PLURAL
-	light_range = 0.5
-	light_power = 10
+	light_range = 15
+	light_power = 0.5
 	max_integrity = 50
 	var/variants = 9
 	var/chosen_light
@@ -50,10 +50,10 @@
 	random_light = list("#6AFF00","#00FFEE", "#D9FF00", "#FFC800")
 
 /obj/structure/flora/biolumi/mine/weaklight
-	light_range = 0.2
+	light_power = 0.3
 
 /obj/structure/flora/biolumi/flower/weaklight
-	light_range = 0.2
+	light_power = 0.3
 
 /obj/structure/flora/biolumi/lamp/weaklight
-	light_range = 0.2
+	light_power = 0.3


### PR DESCRIPTION
##  About The Pull Request
Swaps light range and power around to what was always intended, 15 range and 0.5 power, which creates amazing beautiful lighting.

## Why It's Good For The Game
Bugs are bad and this makes outright beautiful amazing planet lighting thanks to Azzy Lights.

## Changelog
:cl:
fix: Bioluminescent plants are no longer super bright and super short range, now they cast a dim light over a long distance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
