### PR TITLE
bugfixes

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -430,8 +430,16 @@ GLOBAL_LIST_EMPTY(objectives)
 	var/target_real_name // Has to be stored because the target's real_name can change over the course of the round
 	var/target_missing_id
 
+/datum/objective/escape/escape_with_identity/proc/unsuitable_targets()
+	. = list()
+	for(var/datum/mind/mind in get_crewmember_minds())
+		if(mind.current && iscarbon(mind.current))
+			var/mob/living/carbon/carbon_mob = mind.current
+			if(ROBOTIC_LIMBS in carbon_mob.dna?.species?.species_traits)
+				. |= mind
+
 /datum/objective/escape/escape_with_identity/find_target()
-	target = ..()
+	target = ..(blacklist = unsuitable_targets())
 	update_explanation_text()
 
 /datum/objective/escape/escape_with_identity/update_explanation_text()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -74,6 +74,14 @@
 	emporium_action = new(cellular_emporium)
 
 /datum/antagonist/changeling/on_gain()
+	//the correct approach would be blacklisting synthetics from becoming changelings
+	//but i'm lazy and inefficient.
+	if(owner && iscarbon(owner))
+		var/mob/living/carbon/carbon_mob = owner
+		if(ROBOTIC_LIMBS in carbon_mob.dna?.species?.species_traits)
+			//just no
+			qdel(src)
+			return
 	generate_name()
 	create_actions()
 	reset_powers()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -378,7 +378,7 @@ There are several things that need to be remembered:
 			if(hud_used.inventory_shown)
 				client.screen += wrists
 		update_observer_view(wrists,1)
-		overlays_standing[WRISTS_LAYER] = gloves.build_worn_icon(default_layer = WRISTS_LAYER, default_icon_file = 'modular_skyrat/icons/mob/clothing/wrists.dmi')	
+		overlays_standing[WRISTS_LAYER] = wrists.build_worn_icon(default_layer = WRISTS_LAYER, default_icon_file = 'modular_skyrat/icons/mob/clothing/wrists.dmi')	
 		wrists_overlay = overlays_standing[WRISTS_LAYER]
 		if(OFFSET_WRISTS in dna.species.offset_features)
 			wrists_overlay.pixel_x += dna.species.offset_features[OFFSET_WRISTS][1]

--- a/modular_skyrat/code/datums/wounds/mechanical/burn.dm
+++ b/modular_skyrat/code/datums/wounds/mechanical/burn.dm
@@ -338,7 +338,7 @@
 /datum/wound/mechanical/burn/severe
 	name = "Burnt Transistors"
 	desc = "Patient's limb has suffered considerable damage to it's wiring and internals, causing frequent malfunctions and leaving the limb quite vulnerable to damage."
-	treat_text = "Recommended full internal repair, although cable coil may suffice."
+	treat_text = "Recommended full internal repair, although extensive cable repair can suffice."
 	examine_desc = "appears mildly warped, with partially charred internal components"
 	occur_text = "flares up with a small flame, noxious smoke coming out of it"
 	severity = WOUND_SEVERITY_SEVERE
@@ -360,7 +360,7 @@
 /datum/wound/mechanical/burn/critical
 	name = "Catastrophic Melting"
 	desc = "Patient's limb has been severely deformed by high heat, along with complete charring of many internal components, causing extreme malfunctioning and leaving the limb extremely frail."
-	treat_text = "Full reconstruction or replacement of the affected limb, although cable coil can prevent a worsening situation."
+	treat_text = "Recommended full internal repair, although extensive cable repair can suffice."
 	treatable_by = list()
 	examine_desc = "is completely deformed, constantly sparking and smoking from it's charred components"
 	occur_text = "melts and pools around itself"

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthetic/ipc.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthetic/ipc.dm
@@ -28,6 +28,16 @@
 	languagewhitelist = list("Encoded Audio Language")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc
 
+/datum/species/ipc/spec_life(mob/living/carbon/human/H)
+	. = ..()
+	//This is stupid, performance intensive, and i want to shoot myself but it will shut people up
+	//about this minor fucking bug fuck you
+	if(H.stat == DEAD)
+		if((H.health > revivesbyhealreq) && !H.hellbound)
+			if((NOBLOOD in species_traits) || (H.blood_volume >= BLOOD_VOLUME_OKAY))
+				owner.revive(0)
+				owner.cure_husk(0) // If it has REVIVESBYHEALING, it probably can't be cloned. No husk cure.
+
 /datum/species/ipc/spec_death(gibbed, mob/living/carbon/C)
 	saved_screen = C.dna.features["ipc_screen"]
 	C.dna.features["ipc_screen"] = "BSOD"
@@ -52,6 +62,8 @@
 		O.synthetic = TRUE
 
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
+	if(H.stat == DEAD) //by this point we should be alive
+		return
 	H.dna.features["ipc_screen"] = "BSOD"
 	H.update_body()
 	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthetic/synthliz.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthetic/synthliz.dm
@@ -31,6 +31,16 @@
 	languagewhitelist = list("Encoded Audio Language")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc/synthliz
 
+/datum/species/synthliz/spec_life(mob/living/carbon/human/H)
+	. = ..()
+	//This is stupid, performance intensive, and i want to shoot myself but it will shut people up
+	//about this minor fucking bug fuck you
+	if(H.stat == DEAD)
+		if((H.health > revivesbyhealreq) && !H.hellbound)
+			if((NOBLOOD in species_traits) || (H.blood_volume >= BLOOD_VOLUME_OKAY))
+				owner.revive(0)
+				owner.cure_husk(0) // If it has REVIVESBYHEALING, it probably can't be cloned. No husk cure.
+
 /datum/species/synthliz/on_species_gain(mob/living/carbon/C) // Let's make that IPC actually robotic.
 	. = ..()
 	//C.grant_language(/datum/language/machine)
@@ -45,6 +55,8 @@
 	//C.remove_language(/datum/language/machine)
 
 /datum/species/synthliz/spec_revival(mob/living/carbon/human/H)
+	if(H.stat == DEAD) //by this point we should be alive
+		return
 	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")
 	sleep(3 SECONDS)
 	H.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]...")

--- a/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthetic/synths.dm
+++ b/modular_skyrat/code/modules/mob/living/carbon/human/species_types/synthetic/synths.dm
@@ -44,6 +44,32 @@
 	//Power cord so they no die hungry
 	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 
+/datum/species/ipc/spec_revival(mob/living/carbon/human/H)
+	if(H.stat == DEAD) //by this point we should be alive
+		return
+	H.dna.features["ipc_screen"] = "BSOD"
+	H.update_body()
+	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")
+	sleep(3 SECONDS)
+	H.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]...")
+	sleep(3 SECONDS)
+	H.say("Finalizing setup...")
+	sleep(3 SECONDS)
+	H.say("Unit [H.real_name] is fully functional. Have a nice day.")
+	H.dna.features["ipc_screen"] = saved_screen
+	H.update_body()
+	return 
+
+/datum/species/synth/spec_life(mob/living/carbon/human/H)
+	. = ..()
+	//This is stupid, performance intensive, and i want to shoot myself but it will shut people up
+	//about this minor fucking bug fuck you
+	if(H.stat == DEAD)
+		if((H.health > revivesbyhealreq) && !H.hellbound)
+			if((NOBLOOD in species_traits) || (H.blood_volume >= BLOOD_VOLUME_OKAY))
+				owner.revive(0)
+				owner.cure_husk(0) // If it has REVIVESBYHEALING, it probably can't be cloned. No husk cure.
+
 /datum/species/synth/proc/assume_disguise(datum/species/S, mob/living/carbon/human/H) //rework the proc for it to NOT fuck up with dunmer/other skyrat custom races
 	if(S && !istype(S, type))
 		name = S.name

--- a/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/modular_skyrat/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -182,17 +182,12 @@
 	pH = 7.2
 	color = "#cccccc"
 	process_flags = REAGENT_SYNTHETIC
-	metabolization_rate = 1
+	metabolization_rate = INFINITY //just gets consumed instantly i dont fucking are anymore
 
 /datum/reagent/medicine/kerosene/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
-	if(method == TOUCH)
-		M.adjustOxyLoss(min(-10, -reac_volume))
-	..()
-
-/datum/reagent/medicine/kerosene/on_mob_life(mob/living/L)
-	L.adjustOxyLoss(-1 * REM)
-	..()
-	. = 1
+	. = ..()
+	//i dont fucking care anymore
+	M.setOxyLoss(0)
 
 //Repathed preservahyde
 /datum/reagent/medicine/preservahyde

--- a/modular_skyrat/code/modules/research/techweb/nodes/bepis_nodes.dm
+++ b/modular_skyrat/code/modules/research/techweb/nodes/bepis_nodes.dm
@@ -3,7 +3,7 @@
 	id = "advanced_ipc_construction"
 	display_name = "Advanced Sapient Synthetics"
 	description = "With experimental mechatronic technology, we are able to build near-perfect sapient beings."
-	design_ids = list("android_chassis", "military_synth_chassis", "corporate_chassis")
+	design_ids = list("android_chassis", "military_synth_chassis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 16000)
 	hidden = TRUE
 	experimental = TRUE

--- a/modular_skyrat/code/modules/surgery/bodyparts/_dismemberment.dm
+++ b/modular_skyrat/code/modules/surgery/bodyparts/_dismemberment.dm
@@ -105,9 +105,14 @@
 	
 	return FALSE
 
-/obj/item/bodypart/head/dismember(dam_type = BRUTE, silent = FALSE)
+/obj/item/bodypart/head/can_dismember()
 	. = ..()
-	if(. && (HAS_TRAIT(owner, TRAIT_NODECAP) || HAS_TRAIT(owner, TRAIT_NODISMEMBER)))
+	if(. && (HAS_TRAIT(owner, TRAIT_NODECAP)))
+		return FALSE
+
+/obj/item/bodypart/head/can_disembowel()
+	. = ..()
+	if(. && (HAS_TRAIT(owner, TRAIT_NODECAP)))
 		return FALSE
 
 //Limb removal. The "special" argument is used for swapping a limb with a new one without the effects of losing a limb kicking in.

--- a/modular_skyrat/code/modules/surgery/bodyparts/interactions.dm
+++ b/modular_skyrat/code/modules/surgery/bodyparts/interactions.dm
@@ -32,7 +32,7 @@
 		user.visible_message("<span class='danger'>[user] starts wrenching [victim]'s [name]!</span>", "<span class='danger'>You start wrenching [victim]'s [name]!</span>", ignored_mobs=victim)
 		to_chat(victim, "<span class='userdanger'>[user] starts wrenching your [name]!</span>")
 	
-	if(!do_after(user, time, target=victim))
+	if(!do_mob(user, victim, time))
 		return
 
 	if(prob(30 + prob_mod))

--- a/modular_skyrat/code/modules/surgery/robot_limb_augmentation.dm
+++ b/modular_skyrat/code/modules/surgery/robot_limb_augmentation.dm
@@ -1,69 +1,9 @@
-/////AUGMENTATION SURGERIES//////
-//SURGERY STEPS
-
-/datum/surgery_step/replace_limb
-	name = "Replace limb"
-	implements = list(/obj/item/bodypart = 100, /obj/item/organ_storage = 100)
-	time = 32
-	var/obj/item/bodypart/L = null // L because "limb"
-
-/datum/surgery_step/replace_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(istype(tool, /obj/item/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))
-		tool = tool.contents[1]
-	var/obj/item/bodypart/aug = tool
-	/* Skyrat edit - we don't care if the limb is robotic, this will pretty much serve as a "limb replacement" surgery for extreme wounds.
-	if(!(aug.status & BODYPART_ROBOTIC))
-		to_chat(user, "<span class='warning'>That's not an augment, silly!</span>")
-		return -1
-	*/
-	if(aug.body_zone != target_zone)
-		to_chat(user, "<span class='warning'>[tool] isn't the right type for [parse_zone(target_zone)].</span>")
-		return -1
-	L = surgery.operated_bodypart
-	if(L)
-		display_results(user, target, "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>",
-			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)] with [aug].",
-			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)].")
-	else
-		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
-
-//ACTUAL SURGERIES
-/datum/surgery/augmentation
-	name = "Augmentation"
+/datum/surgery/augmentation/mechanical
+	name = "Mechanical augmentation"
 	steps = list(/datum/surgery_step/mechanic_open,
-				/datum/surgery_step/clamp_bleeders,
-				/datum/surgery_step/retract_skin,
+				/datum/surgery_step/mechanic_unwrench,
 				/datum/surgery_step/replace_limb)
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = ALL_BODYPARTS //skyrat edit
 	requires_real_bodypart = TRUE
-
-//SURGERY STEP SUCCESSES
-/datum/surgery_step/replace_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/bodypart/tool, datum/surgery/surgery)
-	if(L)
-		if(istype(tool, /obj/item/organ_storage))
-			tool.icon_state = initial(tool.icon_state)
-			tool.desc = initial(tool.desc)
-			tool.cut_overlays()
-			tool = tool.contents[1]
-		//skyrat edit
-		if(istype(tool) && user.temporarilyRemoveItemFromInventory(tool))
-			if(tool.body_zone == target_zone)
-				tool.replace_limb(target, TRUE)
-			else if(target_zone in tool.children_zones)
-				var/obj/item/bodypart/BP
-				for(var/obj/item/bodypart/candidate in tool)
-					if(target_zone == candidate.body_zone)
-						BP = candidate
-				if(BP)
-					BP.replace_limb(target, TRUE)
-				else
-					return FALSE
-		//
-		display_results(user, target, "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>",
-			"[user] successfully augments [target]'s [parse_zone(target_zone)] with [tool]!",
-			"[user] successfully augments [target]'s [parse_zone(target_zone)]!")
-		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
-	else
-		to_chat(user, "<span class='warning'>[target] has no [parse_zone(target_zone)] there!</span>")
-	return TRUE
+	requires_bodypart_type = BODYPART_ROBOTIC


### PR DESCRIPTION
removes corporate chassis from bepis node because its broken and unbalanced
fixes dimemberment runtimes
fixes synthetic deadchatting the booting up process
fixes mechanical augmentation surgery not existing period
fixes cling synthetics existing at all
make burn mechanical description less confusing
synth revive without needing to punch them
impersonation objective no loger selects synthetics
kerosene instantly cures all oxyloss on synth, instantly gets metaolized
fixes wrist slot items not overlaying on mobs