### PR TITLE
EORG will no longer teleport ghosts

### DIFF
--- a/modular_skyrat/code/_HELPERS/roundend.dm
+++ b/modular_skyrat/code/_HELPERS/roundend.dm
@@ -7,7 +7,7 @@
 		m.client.verbs += /client/proc/eorg_teleport
 		if (m.client && m.client.prefs && m.client.prefs.eorg_teleport)
 			var/eorg_tele_loc = pick(GLOB.eorg_teleport.loc)
-			if (!ishuman(m))
+			if (!isobserver(m))
 				continue
 			m.forceMove(eorg_tele_loc)
 			to_chat(m, "<BR><span class='narsiesmall'>You have chosen not to EORG. Do not commit EORG or you will be banned!</span>")

--- a/modular_skyrat/code/_HELPERS/roundend.dm
+++ b/modular_skyrat/code/_HELPERS/roundend.dm
@@ -7,7 +7,7 @@
 		m.client.verbs += /client/proc/eorg_teleport
 		if (m.client && m.client.prefs && m.client.prefs.eorg_teleport)
 			var/eorg_tele_loc = pick(GLOB.eorg_teleport.loc)
-			if (!isobserver(m))
+			if (isobserver(m))
 				continue
 			m.forceMove(eorg_tele_loc)
 			to_chat(m, "<BR><span class='narsiesmall'>You have chosen not to EORG. Do not commit EORG or you will be banned!</span>")

--- a/modular_skyrat/code/_HELPERS/roundend.dm
+++ b/modular_skyrat/code/_HELPERS/roundend.dm
@@ -7,6 +7,8 @@
 		m.client.verbs += /client/proc/eorg_teleport
 		if (m.client && m.client.prefs && m.client.prefs.eorg_teleport)
 			var/eorg_tele_loc = pick(GLOB.eorg_teleport.loc)
+			if (!ishuman(m))
+				continue
 			m.forceMove(eorg_tele_loc)
 			to_chat(m, "<BR><span class='narsiesmall'>You have chosen not to EORG. Do not commit EORG or you will be banned!</span>")
 			to_chat(m, "<BR><BR><span class='notice'>You have been successfully recovered from SS13 and are on your way to the nearest transit interchange. There's some time before the next shuttle home comes though, time to relax.</span>")


### PR DESCRIPTION
## About The Pull Request
• Adds an ishuman check that will send people along if they aren't human.

## Why It's Good For The Game
Less annoying for ghosts. Also less annoying for admins doing tickets.

## Issues
This also means silicones don't get teleported automatically, but they should still be able to teleport manually with the verb. The verb is given before the ishuman check, so if you have the preference you can still manually teleport.

## Changelog
:cl:
fix: Ghosts don't get teleported to the cafe to avoid EORG anymore.
/:cl:
