### PR TITLE
Bloodsucker tweaks to make them less restrictive for roleplay

### DIFF
--- a/code/modules/antagonists/bloodsucker/bloodsucker_sunlight.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_sunlight.dm
@@ -1,6 +1,6 @@
 #define TIME_BLOODSUCKER_DAY_WARN	90 		// 1.5 minutes
 #define TIME_BLOODSUCKER_DAY_FINAL_WARN	25 	// 25 sec
-#define TIME_BLOODSUCKER_DAY	60 			// 1.5 minutes // 10 is a second, 600 is a minute.
+#define TIME_BLOODSUCKER_DAY	180 		// 3 minutes
 #define TIME_BLOODSUCKER_BURN_INTERVAL	40 	// 4 sec
 
 
@@ -10,7 +10,7 @@
 	var/cancel_me = FALSE
 	var/amDay = FALSE
 	var/time_til_cycle = 0
-	var/nightime_duration = 900 //15 Minutes
+	var/nightime_duration = 3600 //60 Minutes
 
 /obj/effect/sunlight/Initialize()
 	countdown()

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -49,7 +49,7 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= 0.75 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
+	C.blood_volume -= 0.25 //Will take roughly 60 minutes to die from standard blood volume, a LOT longer from max blood volume. Vampires are now less of blood junkies.
 	if(C.blood_volume <= (BLOOD_VOLUME_SURVIVE*C.blood_ratio))
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		C.dust()


### PR DESCRIPTION
## About The Pull Request

Quadrupled the length of the night portion of the day/night cycle, bringing it up to 60 minutes.
Doubled the length of the day portion of the day/night cycle, bringing it to 3 minutes.
Passive blood depletion rate brought down to one third.

## Why It's Good For The Game

It's on request of a couple of people, who find the very short day cycle restricting in terms of more lengthy roleplay, as well as the blood depletion rate causing vampires to be pretty much blood junkies.
Technically this is for the most part buffs, but they're not _that, significant.

## Changelog
:cl:
tweak: Quadrupled the length of the night portion of the bloodsucker day/night cycle
tweak: Doubled the length of the day portion of the bloodsucker day/night cycle
tweak: Bloodsucker passive blood depletion rate brought down to one third.
/:cl:

