### PR TITLE
Restricts self surgery unless the surgery has a self operatable flag, adds that flag to some common robotic surgeries

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -92,7 +92,7 @@
 	if(surgeries.len)
 		if(user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM)
 			for(var/datum/surgery/S in surgeries)
-				if(!S.lying_required || (S.lying_required && lying))
+				if((S.self_operable || user != src) && !S.lying_required || (S.lying_required && lying))
 					if(S.next_step(user,user.a_intent))
 						return 1
 	//skyrat edit

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -22,6 +22,7 @@
 	//skyrat edit
 	var/datum/wound/operated_wound								//The actual wound datum instance we're targeting
 	var/datum/wound/targetable_wound							//The wound type this surgery targets
+	var/self_operable = FALSE									//Can the surgery be performed by the patient himself
 	//
 
 /datum/surgery/New(surgery_target, surgery_location, surgery_bodypart)

--- a/modular_skyrat/code/modules/surgery/robot_organ_manipulation.dm
+++ b/modular_skyrat/code/modules/surgery/robot_organ_manipulation.dm
@@ -3,6 +3,7 @@
 	name = "Prosthesis organ manipulation"
 	possible_locs = ORGAN_BODYPARTS //skyrat edit
 	requires_bodypart_type = BODYPART_ROBOTIC
+	self_operable = TRUE
 	steps = list(
 		/datum/surgery_step/mechanic_open,
 		/datum/surgery_step/open_hatch,

--- a/modular_skyrat/code/modules/surgery/robotic_burn_dressing.dm
+++ b/modular_skyrat/code/modules/surgery/robotic_burn_dressing.dm
@@ -10,6 +10,7 @@
 	possible_locs = ALL_BODYPARTS
 	requires_real_bodypart = TRUE
 	requires_bodypart_type = BODYPART_ROBOTIC
+	self_operable = TRUE
 	targetable_wound = /datum/wound/mechanical/burn
 
 /datum/surgery/debride/can_start(mob/living/user, mob/living/carbon/target)

--- a/modular_skyrat/code/modules/surgery/robotic_repair_puncture.dm
+++ b/modular_skyrat/code/modules/surgery/robotic_repair_puncture.dm
@@ -16,6 +16,7 @@
 	possible_locs = ALL_BODYPARTS
 	requires_real_bodypart = TRUE
 	requires_bodypart_type = BODYPART_ROBOTIC
+	self_operable = TRUE
 	targetable_wound = /datum/wound/mechanical/pierce
 	var/puncture_or_slash = "puncture"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Self surgery is very ridicilous for organics, but for robotics and robotic maintenance makes sense. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: You can no longer self operate with the exception of a couple robotic surgeries (organ manip, burn dressing, punctures)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
