### PR TITLE
Makes vampires able to forcefully level up++

### DIFF
--- a/code/modules/antagonists/bloodsucker/bloodsucker_sunlight.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_sunlight.dm
@@ -81,7 +81,7 @@
 				  	  "<span class = 'announce'>The solar flare has ended, and the daylight danger has passed...for now.</span>")
 		amDay = FALSE
 		day_end()   // Remove VANISHING ACT power from all vamps who have it! Clear Warnings (sunlight, locker protection)
-		nightime_duration += 100 //Each day makes the night a minute longer.
+		//nightime_duration += 100 //Used to make night-time a minute longer per night; No.
 		message_admins("BLOODSUCKER NOTICE: Daylight Ended. Resetting to Night (Lasts for [nightime_duration / 60] minutes.)")
 
 

--- a/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
+++ b/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
@@ -252,11 +252,25 @@
 		owner.hasSoul = TRUE
 //owner.current.hellbound = FALSE
 
-/datum/antagonist/bloodsucker/proc/RankUp()
+/datum/antagonist/bloodsucker/proc/ForcedRankUp()
 	set waitfor = FALSE
 	if(!owner || !owner.current)
 		return
 	bloodsucker_level_unspent ++
+	// Spend Rank Immediately?
+	if(istype(owner.current.loc, /obj/structure/closet/crate/coffin))
+		SpendRank()
+	else
+		to_chat(owner, "<EM><span class='notice'>You have forced your powers to further through the power of blood; Sleep within your lair to claim your boon.</span></EM>")
+		if(bloodsucker_level_unspent >= 2)
+			to_chat(owner, "<span class='announce'>Bloodsucker Tip: If you cannot find or steal a coffin to use, you can build one from wooden planks.</span><br>")
+
+
+/datum/antagonist/bloodsucker/proc/RankUp() //Adjusted due to nighttime changes.
+	set waitfor = FALSE
+	if(!owner || !owner.current)
+		return
+	bloodsucker_level_unspent + 5 //5x the levels
 	// Spend Rank Immediately?
 	if(istype(owner.current.loc, /obj/structure/closet/crate/coffin))
 		SpendRank()

--- a/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
+++ b/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
@@ -179,6 +179,7 @@
 	BuyPower(new /datum/action/bloodsucker/feed)
 	BuyPower(new /datum/action/bloodsucker/masquerade)
 	BuyPower(new /datum/action/bloodsucker/veil)
+	BuyPower(new /datum/action/bloodsucker/levelup)//SKYRAT EDIT
 	// Traits
 	for(var/T in defaultTraits)
 		ADD_TRAIT(owner.current, T, BLOODSUCKER_TRAIT)
@@ -252,7 +253,7 @@
 		owner.hasSoul = TRUE
 //owner.current.hellbound = FALSE
 
-/datum/antagonist/bloodsucker/proc/ForcedRankUp()
+/datum/antagonist/bloodsucker/proc/ForcedRankUp() //Big ol SKYRAT EDIT
 	set waitfor = FALSE
 	if(!owner || !owner.current)
 		return
@@ -270,7 +271,7 @@
 	set waitfor = FALSE
 	if(!owner || !owner.current)
 		return
-	bloodsucker_level_unspent + 5 //5x the levels
+	bloodsucker_level_unspent += 5 //5x the levels
 	// Spend Rank Immediately?
 	if(istype(owner.current.loc, /obj/structure/closet/crate/coffin))
 		SpendRank()

--- a/code/modules/antagonists/bloodsucker/powers/forcelevel.dm
+++ b/code/modules/antagonists/bloodsucker/powers/forcelevel.dm
@@ -2,13 +2,11 @@
 	name = "Forced Evolution"
 	desc = "Spend the lovely sanguine running through your veins; aging you at an accelerated rate."
 	button_icon_state = "power_feed"
-	bloodcost = prev_cost * total_uses
+	var/total_uses = 1
+	bloodcost = 50
 	cooldown = 50
 	bloodsucker_can_buy = TRUE
 
-
-	var/prev_cost = 50
-	var/total_uses = 1
 
 /datum/action/bloodsucker/levelup/CheckCanUse(display_error)
 	. = ..()
@@ -19,8 +17,9 @@
 
 
 /datum/action/bloodsucker/levelup/ActivatePower()
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.has_antag_datum(ANTAG_DATUM_BLOODSUCKER)
+	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER)
 	if(istype(bloodsuckerdatum))
 		bloodsuckerdatum.ForcedRankUp()	// Rank up! Must still be in a coffin to level!
 
 	total_uses++
+	bloodcost = total_uses * 50

--- a/code/modules/antagonists/bloodsucker/powers/forcelevel.dm
+++ b/code/modules/antagonists/bloodsucker/powers/forcelevel.dm
@@ -1,0 +1,26 @@
+/datum/action/bloodsucker/levelup
+	name = "Forced Evolution"
+	desc = "Spend the lovely sanguine running through your veins; aging you at an accelerated rate."
+	button_icon_state = "power_feed"
+	bloodcost = prev_cost * total_uses
+	cooldown = 50
+	bloodsucker_can_buy = TRUE
+
+
+	var/prev_cost = 50
+	var/total_uses = 1
+
+/datum/action/bloodsucker/levelup/CheckCanUse(display_error)
+	. = ..()
+	if(!.)
+		return
+
+	return TRUE
+
+
+/datum/action/bloodsucker/levelup/ActivatePower()
+	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.has_antag_datum(ANTAG_DATUM_BLOODSUCKER)
+	if(istype(bloodsuckerdatum))
+		bloodsuckerdatum.ForcedRankUp()	// Rank up! Must still be in a coffin to level!
+
+	total_uses++

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1456,6 +1456,7 @@
 #include "code\modules\antagonists\bloodsucker\powers\brawn.dm"
 #include "code\modules\antagonists\bloodsucker\powers\cloak.dm"
 #include "code\modules\antagonists\bloodsucker\powers\feed.dm"
+#include "code\modules\antagonists\bloodsucker\powers\forcelevel.dm"
 #include "code\modules\antagonists\bloodsucker\powers\fortitude.dm"
 #include "code\modules\antagonists\bloodsucker\powers\go_home.dm"
 #include "code\modules\antagonists\bloodsucker\powers\haste.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Firstly; buffs how many levels they get per night.
Secondly; Allows vampires to level up for a _stacking_ blood cost; atop of the cost it actually required to thicken their blood; meaning vampires get _quickly_ diminishing returns from the act of forcefully levelling themselves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Useroth made nights much, _much_ longer; this is to counteract that (vamp level is directly tied to how many nights there are.)
Also disables nights becoming longer and longer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Vampires can now forcefully level themselves up
tweak: Vampires now level up five times per night.
tweak: Nights no longer get stackingly longer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
