### PR TITLE
Adds a antag species blacklist and applies it to mostly robotic species.

### DIFF
--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -32,8 +32,7 @@
 	reroll_friendly = FALSE
 	enemy_minimum_age = 7
 	round_ends_with_antag_death = FALSE
-
-
+	restriced_species = list("plasmaman", "shadow", "skeleton", "synthliz", "synth", "vampire", "ipc", "dullahan", "android")
 	announce_span = "danger"
 	announce_text = "Filthy, bloodsucking vampires are crawling around disguised as crewmembers!\n\
 	<span class='danger'>Bloodsuckers</span>: The crew are cattle, while you are both shepherd and slaughterhouse.\n\

--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -32,7 +32,7 @@
 	reroll_friendly = FALSE
 	enemy_minimum_age = 7
 	round_ends_with_antag_death = FALSE
-	restriced_species = list("plasmaman", "shadow", "skeleton", "synthliz", "synth", "vampire", "ipc", "dullahan", "android")
+	restricted_species = list("plasmaman", "shadow", "skeleton", "synthliz", "synth", "vampire", "ipc", "dullahan", "android")
 	announce_span = "danger"
 	announce_text = "Filthy, bloodsucking vampires are crawling around disguised as crewmembers!\n\
 	<span class='danger'>Bloodsuckers</span>: The crew are cattle, while you are both shepherd and slaughterhouse.\n\

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -16,7 +16,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
-	restriced_species = list("synthliz", "synth", "ipc", "android")
+	restricted_species = list("synthliz", "synth", "ipc", "android")
 
 	announce_span = "green"
 	announce_text = "Alien changelings have infiltrated the crew!\n\

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -16,6 +16,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
+	restriced_species = list("synthliz", "synth", "ipc", "android")
 
 	announce_span = "green"
 	announce_text = "Alien changelings have infiltrated the crew!\n\

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -25,6 +25,7 @@
 	var/list/restricted_jobs = list()	// Jobs it doesn't make sense to be.  I.E chaplain or AI cultist
 	var/list/protected_jobs = list()	// Jobs that can't be traitors because
 	var/list/required_jobs = list()		// alternative required job groups eg list(list(cap=1),list(hos=1,sec=2)) translates to one captain OR one hos and two secmans
+	var/list/restricted_species = list() //The ID of the species you dont want to be considered for this gamemode's antags, like bloodless species being a bloodsucker.
 	var/required_players = 0
 	var/maximum_players = -1 // -1 is no maximum, positive numbers limit the selection of a mode on overstaffed stations
 	var/required_enemies = 0
@@ -418,6 +419,12 @@
 		for(var/datum/mind/player in candidates)
 			for(var/job in restricted_jobs)					// Remove people who want to be antagonist but have a job already that precludes it
 				if(player.assigned_role == job)
+					candidates -= player
+
+	if(restricted_species)
+		for(var/datum/species/species_datum in candidates)
+			for(var/species_id in restriced_species)
+				if(species_datum.id == species_id)
 					candidates -= player
 
 	if(candidates.len < recommended_enemies && CONFIG_GET(keyed_list/force_antag_count)[config_tag])

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -422,9 +422,10 @@
 					candidates -= player
 
 	if(restricted_species)
-		for(var/datum/species/species_datum in candidates)
-			for(var/species_id in restriced_species)
-				if(species_datum.id == species_id)
+		for(var/datum/mind/player in candidates)
+			for(var/species_id in restricted_species)
+				var/mob/living/carbon/player_mob = player.current
+				if(player_mob.dna.species == restricted_species)
 					candidates -= player
 
 	if(candidates.len < recommended_enemies && CONFIG_GET(keyed_list/force_antag_count)[config_tag])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a way to prevent certain species from being chosen for antagonists.
And It makes robotic species unable be changelings nor bloodsuckers, and all NOBLOOD species bloodsuckers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Robotic species dont work well for a purely organic antag.
Plus bloodsuckers shouldnt be a species that have no blood.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Its now possible to blacklist species from gamemode antagonists
tweak: Made robotic species unable to be changelings, and robotic and bloodless species bloodsuckers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
