### PR TITLE
Rebalances Buckshot,Beanbag,and Slug, Taking 6+ Pellets from a cloud now knocks you on the ground .

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,14 +1,15 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 60
+	damage = 40
 	sharpness = SHARP_POINTY
+	armour_penetration = 20
 	bare_wound_bonus = 10
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
-	stamina = 70
+	stamina = 55
 	//skyrat edit
-	damage = 10
+	damage = 5
 	bare_wound_bonus = 10
 	sharpness = SHARP_NONE
 	//
@@ -84,7 +85,8 @@
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
 	//skyrat edit
-	damage = 7.5
+	damage = 12.5
+	armour_penetration = -30
 	bare_wound_bonus = 10
 	wound_falloff_tile = -2.5 // TG does this; it makes sense to do.
 	//

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,15 +1,15 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 40
+	damage = 40 // Skyrat edit , changed from 60 to 40
 	sharpness = SHARP_POINTY
-	armour_penetration = 20
+	armour_penetration = 20 // Skyrat edit , changed from 0 to 20
 	bare_wound_bonus = 10
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
-	stamina = 55
+	stamina = 55 // Skyrat edit , changed from 70 to 55
 	//skyrat edit
-	damage = 5
+	damage = 5 // Changed from 10 to 5
 	bare_wound_bonus = 10
 	sharpness = SHARP_NONE
 	//

--- a/modular_skyrat/code/datums/components/pellet_cloud.dm
+++ b/modular_skyrat/code/datums/components/pellet_cloud.dm
@@ -245,6 +245,15 @@
 			target = hit_part.owner
 			if(initial(P.damtype) != BURN)
 				hit_part.painless_wound_roll(initial(P.sharpness), damage_dealt, initial(P.wound_bonus), initial(P.bare_wound_bonus))
+		if((num_hits > 5)&&iscarbon(target))
+			target.visible_message("<span class='danger'>[target] takes a full load of [proj_name]s,causing them to get knocked back!</span>", null, null, COMBAT_MESSAGE_RANGE, target)
+			to_chat(target, "<span class='userdanger'>You take a full load of [proj_name]s , and get knocked away!</span>")
+			var/mob/living/carbon/C = target
+			var/atom/movable/D = target
+			var/atom/throw_target = get_edge_target_turf(D, get_dir(shooter, get_step_away(D, shooter)))
+			D.safe_throw_at(throw_target, 2, 2)
+			C.DefaultCombatKnockdown(15, 0)
+			C.adjustStaminaLoss(20)
 		if(num_hits > 1)
 			target.visible_message("<span class='danger'>[target] is hit by [num_hits] [proj_name]s[hit_part ? " in the [hit_part.name]" : ""]!</span>", null, null, COMBAT_MESSAGE_RANGE, target)
 			to_chat(target, "<span class='userdanger'>You're hit by [num_hits] [proj_name]s[hit_part ? " in the [hit_part.name]" : ""]!</span>")


### PR DESCRIPTION
## About The Pull Request
1.Buffs buckshot to 12.5 Damage per projectile(75 Total) , Makes it have -30 armour penetration
2.Nerfs Slug to 40 Damage per slug (From 60), gives it 20 armour penetration.
3.Nerfs beanbag slug from 80 Total damage to 60 Total (55 Stamina , 5 Damage)
4.Taking 6+ Pellet hits will now knock you down , Dealing some Stamina damage.
## Why It's Good For The Game
Pellets were always useless , the recent nerf made them even more useless , making them deal 45 damage for a full blast (with no armour accounted) , this change aims to buff pellet based weapons and to make them fearsome in close combat, as they are meant to be.
Video of the feature:
https://youtu.be/EyWr6GveXVA

## Changelog
:cl:
add: Weaponary that uses pellets will now knock down anyone that takes 6  pellet hits.
balance: Damage per buckshot projectile is now 12.5(75 If all pellets hit , no armour) from 7.5(45 If all pellets hit , no armour) , they have a 30% armour debuff.
balance: Damage per slug projectile is now 40 , decreased from 60 , It now penetrates armor by 20%
balance: Reduced the total damage of the Beanbag from 80 to 60 .
/:cl:
