### PR TITLE
All together now! (Roundstard Head of Staff meeting room spawns)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
+++ b/_maps/map_files/BoxStation/BoxStation_Skyrat.dmm
@@ -608,11 +608,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"acr" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "acs" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hos";
@@ -8003,20 +7998,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
-"arZ" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/landmark/start/blueshield,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20911,14 +20892,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"aZq" = (
-/obj/machinery/button/door{
-	id = "heads_meeting";
-	name = "Security Shutters";
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "aZr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -21333,13 +21306,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"bay" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "baz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -21711,13 +21677,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bbC" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bbD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22159,12 +22118,6 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
-"bda" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bdb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22419,12 +22372,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"bdF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "bdG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23620,17 +23567,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bgU" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/captain,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -28209,13 +28145,6 @@
 	dir = 5
 	},
 /area/science/research)
-"bsY" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "bsZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -30425,13 +30354,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"byq" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/research_director,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "byr" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
@@ -31093,14 +31015,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
-"bzT" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/quartermaster,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "bzU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/blue,
@@ -32417,17 +32331,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
-"bCZ" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "bDa" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24
@@ -43208,13 +43111,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cdU" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/chief_engineer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cdW" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/aft";
@@ -56324,6 +56220,16 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ivW" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "iwi" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 5
@@ -56758,6 +56664,12 @@
 /mob/living/simple_animal/opossum,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jcH" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "jcN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -56988,6 +56900,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"juH" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "jvd" = (
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel,
@@ -57056,6 +56974,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jzA" = (
+/obj/machinery/button/door{
+	id = "heads_meeting";
+	name = "Security Shutters";
+	pixel_y = 24
+	},
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "jAg" = (
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -57330,6 +57257,14 @@
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"jKy" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "jKC" = (
 /obj/item/clothing/under/misc/pj/blue,
 /obj/item/clothing/shoes/sneakers/white,
@@ -58219,6 +58154,13 @@
 	},
 /turf/open/floor/plasteel/dark/side,
 /area/security/prison)
+"kJk" = (
+/obj/structure/chair/office/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "kNf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/green,
@@ -59304,6 +59246,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/toilet)
+"mmP" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "mnc" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/tenpercent_basic_tool/weldingtool,
@@ -60090,6 +60040,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"nrh" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "nrZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60448,6 +60404,16 @@
 	dir = 1
 	},
 /area/security/prison)
+"nNb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/landmark/start/quartermaster,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "nNF" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -60911,6 +60877,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ooW" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "opC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -62306,6 +62282,14 @@
 	dir = 1
 	},
 /area/security/prison)
+"qAd" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/captain,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "qBa" = (
 /obj/structure/bed/roller,
 /obj/machinery/button/door{
@@ -62600,6 +62584,13 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"qYO" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "qZF" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -62673,6 +62664,16 @@
 "rfW" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rgW" = (
+/obj/structure/chair/office/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "riI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -62727,15 +62728,6 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"rnt" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "roQ" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -63106,6 +63098,13 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"rSB" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "rTu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64521,6 +64520,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"uhL" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hos)
 "uhX" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -65840,6 +65843,19 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
+"wef" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "weM" = (
 /obj/structure/table,
 /obj/item/nanite_remote,
@@ -88095,7 +88111,7 @@ brN
 brN
 bxx
 byC
-bzT
+kJk
 byl
 bxx
 aaf
@@ -92959,7 +92975,7 @@ aVb
 aWH
 aYm
 aZM
-aZq
+jzA
 bbX
 bbX
 bbX
@@ -93218,8 +93234,8 @@ aYp
 aZM
 aZz
 baI
-bda
-bda
+qYO
+rSB
 bca
 bgJ
 aZP
@@ -93474,10 +93490,10 @@ aWI
 aYo
 aZM
 aZy
-bay
+qAd
 bcZ
 bdY
-bdF
+nNb
 bgI
 aZP
 bjC
@@ -93488,7 +93504,7 @@ bpb
 bqz
 bqq
 brS
-bsY
+nrh
 bue
 bmr
 aMn
@@ -93731,7 +93747,7 @@ aWL
 aPR
 aZM
 bbX
-bay
+mmP
 bbM
 bcN
 bdK
@@ -93989,8 +94005,8 @@ aYq
 aZO
 aZC
 baK
-rnt
-bbC
+ooW
+jKy
 bdI
 bgK
 bgK
@@ -95245,7 +95261,7 @@ fPy
 jGc
 aqb
 iuv
-arZ
+wef
 aoc
 aui
 jGc
@@ -97122,7 +97138,7 @@ cfc
 cgO
 ccj
 cBM
-cdU
+jcH
 cSZ
 ckL
 cmF
@@ -97847,7 +97863,7 @@ bdk
 mRQ
 bek
 bfB
-bgU
+ivW
 bdk
 bjF
 blc
@@ -99588,7 +99604,7 @@ aaf
 aaf
 aaL
 adO
-acr
+uhL
 acQ
 adn
 agw
@@ -107629,7 +107645,7 @@ bvw
 bzq
 uYb
 dLS
-bCZ
+rgW
 bEl
 sgD
 vcY
@@ -114307,7 +114323,7 @@ bro
 buo
 bvJ
 bxj
-byq
+juH
 bwR
 bxY
 bCh

--- a/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_Skyrat.dmm
@@ -19364,19 +19364,6 @@
 /obj/item/stamp/qm,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"aVW" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/start/quartermaster,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aVX" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -19402,19 +19389,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"aVZ" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/quartermaster,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aWa" = (
@@ -30075,11 +30049,6 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel,
 /area/security/main)
-"bts" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/plasteel,
-/area/security/main)
 "btv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -39750,34 +39719,6 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
-"bMq" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
-"bMr" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/comfy/brown,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
-"bMs" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
 "bMt" = (
 /obj/structure/table/wood,
 /obj/item/cigbutt/cigarbutt{
@@ -39936,13 +39877,6 @@
 /area/crew_quarters/heads/captain)
 "bMK" = (
 /turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bML" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/effect/landmark/start/captain,
-/turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "bMM" = (
 /obj/structure/table/wood,
@@ -40827,15 +40761,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/bridge/meeting_room/council)
-"bOy" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
 "bOz" = (
 /obj/structure/table/wood,
 /obj/structure/cable/white{
@@ -40876,13 +40801,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/bridge/meeting_room/council)
-"bOD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/bridge/meeting_room/council)
 "bOE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -41087,24 +41005,6 @@
 "bPc" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
-"bPd" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/blueshield,
-/obj/machinery/button/door{
-	id = "blueshield_blast";
-	name = "Privacy Shutters";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "71"
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -41440,13 +41340,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"bPS" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/chief_engineer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "bPT" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable/white{
@@ -41731,29 +41624,6 @@
 /area/bridge/meeting_room/council)
 "bQz" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
-"bQA" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
-"bQB" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room/council)
-"bQC" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room/council)
 "bQD" = (
@@ -43424,19 +43294,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/chief)
-"bTX" = (
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/chief_engineer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/chief)
 "bTY" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -43884,20 +43741,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"bUM" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#c45c57";
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/captain,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bUN" = (
@@ -45047,16 +44890,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
-"bXh" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/captain,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/captain/private)
 "bXi" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46094,13 +45927,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bYZ" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "bZa" = (
 /turf/open/floor/wood,
@@ -48803,19 +48629,6 @@
 /obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
-"ceF" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/start/captain,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/captain/private)
 "ceG" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -50388,14 +50201,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hop)
-"cia" = (
-/obj/structure/chair/office/dark,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "cib" = (
 /obj/structure/table/wood,
@@ -52987,17 +52792,6 @@
 	pixel_x = -32
 	},
 /obj/item/bedsheet/hop,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/hop)
-"cnX" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "cnY" = (
@@ -79679,18 +79473,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"duN" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/research_director,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
 "duO" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -82519,26 +82301,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"dAG" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/research_director,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hor)
 "dAH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -83511,20 +83273,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
-"dCJ" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -85885,20 +85633,6 @@
 "dHS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/cmo)
-"dHT" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
@@ -96642,6 +96376,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"euQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/wood,
+/area/bridge/meeting_room/council)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -96758,6 +96500,14 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"eJj" = (
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
 "eLw" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/dark,
@@ -96958,6 +96708,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fiR" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/chief)
 "fjt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -97242,6 +97004,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fNx" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "fOw" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/green,
@@ -97301,6 +97075,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fTH" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "fVi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -97317,6 +97097,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"fWs" = (
+/obj/structure/chair/office/dark,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hop)
 "fWv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -97370,6 +97157,18 @@
 /obj/effect/spawner/lootdrop/tenpercent_basic_tool/crowbar,
 /turf/open/floor/plating,
 /area/security/prison)
+"gbf" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "gbV" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -97415,6 +97214,19 @@
 	icon_state = "chapel"
 	},
 /area/security/prison)
+"ghj" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/cmo)
 "giN" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -97545,6 +97357,17 @@
 /obj/structure/fermenting_barrel,
 /turf/open/floor/plating,
 /area/security/prison)
+"gEN" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/hor)
 "gGu" = (
 /obj/effect/spawner/lootdrop/seeds/durathread,
 /obj/effect/spawner/lootdrop/tenpercent_basic_tool/weldingtool,
@@ -98277,6 +98100,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/main)
+"iOA" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/captain/private)
 "iPS" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -98398,6 +98230,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
+"jgY" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/captain)
 "jiJ" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -98503,6 +98341,16 @@
 /mob/living/simple_animal/pet/bumbles,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jzN" = (
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/hop)
 "jBE" = (
 /turf/open/floor/plasteel,
 /area/medical/morgue)
@@ -98556,6 +98404,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"jLX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/security/main)
 "jOB" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -98622,6 +98474,23 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"kaR" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "blueshield_blast";
+	name = "Privacy Shutters";
+	pixel_x = 26;
+	pixel_y = -26;
+	req_access_txt = "71"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "kgu" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice{
@@ -98969,6 +98838,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ldT" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
+"leo" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
 "lgU" = (
 /obj/structure/cable/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -99432,6 +99319,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"mcc" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/comfy/black,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
 "mdU" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -100144,6 +100043,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"oen" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	dir = 1
+	},
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
 "oeS" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -100321,13 +100228,6 @@
 	},
 /turf/open/floor/circuit,
 /area/security/prison)
-"oJV" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/plasteel/grimy,
-/area/crew_quarters/heads/hos)
 "oKh" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/power/apc{
@@ -100701,6 +100601,25 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pzl" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hor)
 "pAp" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32;
@@ -100785,6 +100704,18 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"pJc" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/captain/private)
 "pJJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -101220,6 +101151,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"rfS" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
 "rgm" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
@@ -102037,6 +101979,12 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/security/prison)
+"tcT" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/crew_quarters/heads/hos)
 "tdi" = (
 /obj/machinery/door/airlock/grunge{
 	desc = "Part of the green cell block";
@@ -102366,6 +102314,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tRs" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/captain,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room/council)
 "tRT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -102832,6 +102790,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"vmN" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/cmo)
 "vnm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cola/black,
@@ -103030,6 +103001,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vVq" = (
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	color = "#c45c57";
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "vWh" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -103782,6 +103766,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"yjG" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hop)
 "ykZ" = (
 /obj/machinery/plate_press,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -126564,7 +126554,7 @@ bHV
 bJS
 bLN
 bNQ
-bPS
+fTH
 bRZ
 bTQ
 bWh
@@ -128365,7 +128355,7 @@ bLT
 bNW
 bHV
 bSf
-bTX
+fiR
 bWo
 bYy
 cau
@@ -138184,7 +138174,7 @@ duM
 dwq
 dxY
 dzC
-dAG
+pzl
 dCk
 dlE
 dEB
@@ -138437,7 +138427,7 @@ doP
 dqF
 dsa
 dtt
-duN
+gEN
 dwr
 dxZ
 dzD
@@ -139170,7 +139160,7 @@ caM
 bUB
 bUB
 cmy
-cnX
+jzN
 cpB
 bUB
 csz
@@ -139413,12 +139403,12 @@ bGS
 bIH
 bKA
 bMp
-bOy
+tRs
 bQz
 bSz
 bUB
 bWQ
-bYZ
+yjG
 caN
 ccA
 cep
@@ -139669,9 +139659,9 @@ bFl
 bGT
 bII
 bKB
-bMq
+eJj
 bOz
-bQA
+oen
 bQF
 bUB
 bWR
@@ -139680,7 +139670,7 @@ caO
 bZa
 caO
 bZa
-cia
+fWs
 cjA
 ckW
 cmz
@@ -139926,9 +139916,9 @@ bFl
 bGU
 bII
 bKC
-bMr
+rfS
 bOA
-bQB
+leo
 bSA
 bUB
 bWS
@@ -140183,9 +140173,9 @@ bFm
 bGV
 bII
 bKD
-bMs
+mcc
 bOB
-bQC
+ldT
 bSB
 bUC
 bWT
@@ -140698,7 +140688,7 @@ bGX
 bIK
 bKF
 bMu
-bOD
+euQ
 bQE
 bKF
 bUE
@@ -145070,12 +145060,12 @@ bMJ
 bOR
 bQS
 bSM
-bUM
+vVq
 bXd
 bZm
 cbc
 ccN
-ceF
+pJc
 cgs
 bUQ
 cjK
@@ -145837,7 +145827,7 @@ bFi
 bHo
 bIV
 bKQ
-bML
+jgY
 bOU
 bMK
 bSP
@@ -146356,7 +146346,7 @@ bMN
 bMK
 bSQ
 bUQ
-bXh
+iOA
 bZo
 cbh
 ccR
@@ -148726,7 +148716,7 @@ dCI
 dDY
 dFg
 dDY
-dHT
+ghj
 dJj
 dtK
 dLa
@@ -148979,7 +148969,7 @@ dxc
 dyB
 dAe
 dBl
-dCJ
+vmN
 dDZ
 dFh
 dGy
@@ -149950,7 +149940,7 @@ mSq
 mSq
 mSq
 tbu
-bPd
+kaR
 bRe
 mSq
 bUY
@@ -150180,7 +150170,7 @@ aad
 aQS
 aSw
 aUn
-aVW
+gbf
 aXC
 aZg
 baY
@@ -151208,7 +151198,7 @@ aad
 aQU
 aSz
 aUr
-aVZ
+fNx
 aXG
 aZi
 aad
@@ -156876,7 +156866,7 @@ bmp
 bhd
 bpo
 brt
-bts
+jLX
 buP
 bwi
 yfW
@@ -160219,7 +160209,7 @@ aad
 bCp
 btC
 oPb
-oJV
+tcT
 nhE
 szb
 bCp

--- a/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_Skyrat.dmm
@@ -10112,10 +10112,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ava" = (
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/plasteel,
-/area/security/main)
 "avb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -20420,16 +20416,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"aPj" = (
-/obj/effect/landmark/start/quartermaster,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aPk" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -23213,15 +23199,6 @@
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
-"aUS" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/blueshield,
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
 "aUT" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel/dark,
@@ -26392,14 +26369,6 @@
 /obj/item/cartridge/atmos,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"bbu" = (
-/obj/effect/landmark/start/chief_engineer,
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "bbv" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -27467,14 +27436,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain/private)
-"bdJ" = (
-/obj/structure/toilet{
-	pixel_y = 13
-	},
-/obj/effect/landmark/start/captain,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/heads/captain/private)
 "bdK" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -28410,16 +28371,6 @@
 "bfC" = (
 /obj/structure/chair/comfy/green{
 	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/crew_quarters/heads/captain/private)
-"bfD" = (
-/obj/structure/bed,
-/obj/item/bedsheet/captain,
-/obj/effect/landmark/start/captain,
-/obj/machinery/camera{
-	c_tag = "Captain's Quarters";
-	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/heads/captain/private)
@@ -32915,16 +32866,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"bon" = (
-/obj/effect/landmark/start/head_of_personnel,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
 "boo" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
@@ -34278,13 +34219,6 @@
 "bqX" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
-"bqY" = (
-/obj/effect/landmark/start/captain,
-/obj/structure/chair/comfy/brown,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bqZ" = (
@@ -36738,37 +36672,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"bwo" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/head_of_personnel,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -35
-	},
-/obj/machinery/button/door{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = 25;
-	pixel_y = -36;
-	req_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = -26;
-	req_access_txt = "28"
-	},
-/obj/machinery/button/flasher{
-	id = "hopflash";
-	pixel_x = 38;
-	pixel_y = -25
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
 "bwp" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -37624,21 +37527,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"byf" = (
-/obj/structure/chair/comfy/beige,
-/turf/open/floor/carpet,
-/area/bridge)
-"byg" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/carpet,
-/area/bridge)
-"byh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/chair/comfy/beige,
-/turf/open/floor/carpet,
-/area/bridge)
 "byi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/carpet,
@@ -38456,15 +38344,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"bzU" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge)
 "bzV" = (
 /obj/structure/table/wood,
 /obj/item/folder/white{
@@ -38482,12 +38361,6 @@
 "bzX" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
-/turf/open/floor/carpet,
-/area/bridge)
-"bzY" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/bridge)
 "bzZ" = (
@@ -57728,19 +57601,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"coQ" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "coR" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -59790,29 +59650,6 @@
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"csA" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = -32
-	},
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "csB" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring medbay to ensure patient safety.";
@@ -61417,16 +61254,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hor)
-"cvX" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/obj/effect/landmark/start/research_director,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hor)
 "cvY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -62213,14 +62040,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/aft)
-"cxN" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/research_director,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hor)
 "cxO" = (
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -76718,6 +76537,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"eAD" = (
+/obj/structure/bed,
+/obj/item/bedsheet/captain,
+/obj/machinery/camera{
+	c_tag = "Captain's Quarters";
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/crew_quarters/heads/captain/private)
 "eCC" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -76777,6 +76605,13 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/hydroponics)
+"eTQ" = (
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "eTY" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -76956,6 +76791,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"gek" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hor)
 "geV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -77082,6 +76924,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"gtm" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_y = -32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "gxw" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -77172,6 +77036,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"hbi" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/captain,
+/turf/open/floor/carpet,
+/area/bridge)
 "hbk" = (
 /obj/structure/grille,
 /turf/open/floor/plating{
@@ -77242,6 +77111,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hpt" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -77482,6 +77356,16 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"jdz" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/carpet,
+/area/bridge)
 "jeV" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -77866,6 +77750,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kUo" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hor)
 "kVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -78004,6 +77897,18 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"lIk" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "lMz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78170,6 +78075,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mnN" = (
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/carpet,
+/area/bridge)
 "mnV" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -78301,6 +78211,15 @@
 /obj/item/electronics/electrochromatic_kit,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nhv" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hop)
 "nhy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -78361,6 +78280,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"nAk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "nAG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78500,6 +78428,13 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/sorting)
+"omA" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/carpet,
+/area/bridge)
 "oni" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
@@ -78814,6 +78749,12 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"qac" = (
+/obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "qax" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -78963,6 +78904,13 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qWL" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/carpet,
+/area/bridge)
 "qXt" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -78993,6 +78941,14 @@
 /obj/item/assembly/signaler,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rhd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/carpet,
+/area/bridge)
 "rhE" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -79165,6 +79121,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"suO" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "svl" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
@@ -79316,6 +79280,13 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"trV" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/carpet,
+/area/bridge)
 "tsk" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -79790,6 +79761,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"vJY" = (
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/captain/private)
 "vLD" = (
 /obj/machinery/nuclearbomb/beer{
 	pixel_x = 2;
@@ -79912,6 +79890,36 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wJl" = (
+/obj/structure/chair/office/dark,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 38;
+	pixel_y = -35
+	},
+/obj/machinery/button/door{
+	id = "hopqueue";
+	name = "Queue Shutters Control";
+	pixel_x = 25;
+	pixel_y = -36;
+	req_access_txt = "28"
+	},
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = 25;
+	pixel_y = -26;
+	req_access_txt = "28"
+	},
+/obj/machinery/button/flasher{
+	id = "hopflash";
+	pixel_x = 38;
+	pixel_y = -25
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hop)
 "wOY" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -100515,7 +100523,7 @@ dne
 aLc
 dne
 aNQ
-aPj
+nAk
 aQs
 aRM
 aSX
@@ -103588,7 +103596,7 @@ aaa
 aaa
 aDu
 aKd
-aUS
+suO
 bnj
 bBe
 bHk
@@ -103615,7 +103623,7 @@ bhb
 biT
 bkz
 bmp
-bon
+nhv
 bqC
 bsN
 buo
@@ -104164,7 +104172,7 @@ cjO
 clo
 cmw
 cnE
-coQ
+lIk
 dDt
 crA
 csz
@@ -104424,7 +104432,7 @@ cnF
 coR
 cqo
 crB
-csA
+gtm
 cvt
 ctA
 cyX
@@ -104904,7 +104912,7 @@ bkz
 bsP
 bsQ
 bus
-bwo
+wJl
 byb
 bzP
 bBC
@@ -106705,7 +106713,7 @@ bsU
 bux
 bwt
 bqM
-bqM
+qWL
 bLT
 bDn
 bES
@@ -106962,7 +106970,7 @@ bsV
 bux
 bwu
 bqM
-bzU
+jdz
 bBH
 bDn
 bEP
@@ -107218,7 +107226,7 @@ bqM
 bsW
 buz
 bjc
-byf
+mnN
 bzV
 bBI
 bDn
@@ -107474,8 +107482,8 @@ bov
 bqN
 bsX
 buA
-dCK
-byg
+hpt
+hbi
 bzW
 bBJ
 bDq
@@ -107732,7 +107740,7 @@ bqM
 bsY
 buB
 buE
-byh
+rhd
 bzX
 bBK
 bDs
@@ -107990,7 +107998,7 @@ bsZ
 bsU
 bwv
 byi
-bzY
+trV
 bBL
 bDn
 bEP
@@ -108247,7 +108255,7 @@ bsU
 bsU
 bww
 byj
-bqM
+omA
 bLT
 bDn
 bES
@@ -110512,7 +110520,7 @@ aOl
 ace
 abq
 axm
-ava
+abr
 atZ
 qZY
 mQd
@@ -110548,7 +110556,7 @@ bWn
 aZa
 baX
 bcj
-bdJ
+vJY
 bjg
 bhv
 bfB
@@ -110812,7 +110820,7 @@ bjh
 bkN
 bmI
 boG
-bqY
+qac
 btf
 buI
 bwE
@@ -111577,7 +111585,7 @@ aYX
 bTS
 bcj
 bdN
-bfD
+eAD
 bhz
 bjk
 bkP
@@ -113163,7 +113171,7 @@ hLY
 mkR
 ctj
 cwM
-cxN
+gek
 cuE
 cAt
 cAw
@@ -114193,7 +114201,7 @@ crQ
 cti
 cuT
 cuV
-cvX
+kUo
 cwY
 crQ
 cyJ
@@ -119541,7 +119549,7 @@ axY
 aWz
 aYp
 aZE
-bbu
+eTQ
 bcG
 beh
 aWw

--- a/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation_Skyrat.dmm
@@ -4678,16 +4678,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"amv" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hos)
 "amw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -9634,12 +9624,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"axb" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "axc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -10413,11 +10397,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "aza" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"azb" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/captain,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "azc" = (
@@ -12088,13 +12067,6 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
-"aCQ" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/head_of_personnel,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aCR" = (
@@ -15613,17 +15585,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/blueshield)
-"aLz" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/blueshield,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23968,13 +23929,6 @@
 /obj/machinery/keycard_auth{
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
-"beK" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/quartermaster,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beL" = (
@@ -33805,28 +33759,6 @@
 /mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"bBi" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/cmo)
 "bBj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -35141,11 +35073,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDD" = (
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hor)
-"bDE" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/research_director,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDF" = (
@@ -49840,16 +49767,6 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cqV" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chief_engineer,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cqW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/mineral,
@@ -52651,6 +52568,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cRm" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "cRF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54495,6 +54419,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fXn" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "fZK" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -54581,6 +54514,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"ggO" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/quartermaster,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "giI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -55849,6 +55789,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hXF" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hop)
 "hXK" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -56152,6 +56098,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"iyy" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "iyJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -56448,6 +56400,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"jff" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "jgr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -59848,6 +59805,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/security/prison)
+"oJt" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "oKa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60087,6 +60051,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"paJ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hos)
 "paU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -60240,6 +60213,13 @@
 /obj/structure/musician/piano,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"plK" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/blueshield,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "pmB" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -61333,6 +61313,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"rcC" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/blueshield)
 "rcK" = (
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -61980,6 +61970,10 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ssA" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hor)
 "sty" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/transit_tube/horizontal,
@@ -62066,6 +62060,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"szD" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "szG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -62296,6 +62294,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"tao" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/captain,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "tap" = (
 /obj/structure/reagent_dispensers/keg/aphro,
 /turf/open/floor/wood,
@@ -62575,6 +62578,13 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"ttO" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "ttS" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green,
@@ -62729,6 +62739,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"tIZ" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/research_director,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "tJr" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -63863,6 +63878,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vHi" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/cmo)
 "vIc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -90659,7 +90695,7 @@ aHH
 aIO
 aJI
 aKK
-aLz
+rcC
 aMX
 aOv
 aKJ
@@ -91917,7 +91953,7 @@ ajs
 aka
 akV
 alJ
-amv
+paJ
 anh
 anS
 aiR
@@ -93730,7 +93766,7 @@ auK
 avP
 awW
 axV
-azb
+szD
 aAx
 aBo
 aCB
@@ -94315,7 +94351,7 @@ bSB
 bTr
 bPB
 bUL
-cqV
+fXn
 bWq
 bXi
 bYa
@@ -95065,7 +95101,7 @@ bvl
 bwP
 byv
 bAb
-bBi
+vHi
 bCt
 bDv
 bEF
@@ -95525,9 +95561,9 @@ aqJ
 arK
 asS
 atT
-auR
+tIZ
 avV
-axb
+ttO
 ayb
 azh
 aAB
@@ -95784,7 +95820,7 @@ asR
 atT
 auR
 avW
-axb
+ggO
 ayb
 azi
 aAB
@@ -96039,9 +96075,9 @@ aqI
 arM
 asR
 atU
-auR
+tao
 avX
-axb
+plK
 ayb
 azj
 aAC
@@ -96298,7 +96334,7 @@ asR
 atT
 auR
 avY
-axb
+cRm
 ayb
 azk
 aAB
@@ -96553,9 +96589,9 @@ aqJ
 arO
 asS
 atT
-auR
+jff
 avZ
-axb
+oJt
 ayb
 azh
 aAB
@@ -98359,7 +98395,7 @@ ayg
 azp
 aAG
 aBA
-aCQ
+hXF
 aDS
 pHo
 aAH
@@ -99693,7 +99729,7 @@ byI
 bAr
 bBt
 bCH
-bDE
+ssA
 bEU
 bBp
 bHk
@@ -105068,7 +105104,7 @@ baA
 bbG
 bcB
 bdG
-beK
+iyy
 bfC
 bbE
 aTx


### PR DESCRIPTION

## About The Pull Request

Changes where all command members spawn round start, moving them from their offices to the command meeting room. This effects all current maps in rotation - Box, Meta, Pubby, and Delta.

Special thanks to Yogstation, of whom I stol- I mean, got this idea from.

![image](https://user-images.githubusercontent.com/39163353/96967056-e1e25800-14dc-11eb-9251-9b860b5da72e.png)


## Why It's Good For The Game

Allows Command to converse and talk to each other round start, as well as give the Blueshield and Captain a way of knowing what heads are present. Also allows for antagonists and other unsavory figures a fighting chance to obtain their theft objectives without murder.

## Changelog
:cl:
tweak: Central Command now requires Heads of Staff and members of command to meet up at the Meeting Room pre-shift as part of an employee bonding and interaction program.
/:cl: