### PR TITLE
Deletes combat knife cargo order.

### DIFF
--- a/code/modules/cargo/packs/goodies.dm
+++ b/code/modules/cargo/packs/goodies.dm
@@ -4,12 +4,6 @@
 	group = "Goodies"
 	goody = PACK_GOODY_PRIVATE
 
-/datum/supply_pack/goody/combatknives_single
-	name = "Combat Knife Single-Pack"
-	desc = "Contains one sharpened combat knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
-	cost = 800
-	contains = list(/obj/item/kitchen/knife/combat)
-
 /datum/supply_pack/goody/sologamermitts
 	name = "Insulated Gloves Single-Pack"
 	desc = "The backbone of modern society. Barely ever ordered for actual engineering."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the combat knife cargo order.

## Why It's Good For The Game

Xyverious told me to remove this, and honestly, it should have been removed a long time ago.

Energy Sword - ~21 (Looking at Esword Code is hard.)
Plastinium Rapier - 15 force
Officer's Sabre - 18 force
Unwielded Spear - 15 force
Wielded Spear - 15 force
Survival Knife - 15 force

**Combat Knife - 20 force.**

This is more powerful than most weapons you can find or obtain, and easier to get than a survival knife. I've been told by multiple people that many people, including security officers, casually order these roundstart. Something this powerful should not be available that easily. I could literally buy this by doing a single bounty for cargo and cashing in the favor, bringing in 2-3 crate, or by being literally any job but assistant (including clown, or prisoner).

## Changelog
:cl:
del: You can no longer order Combat Knives in Cargo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
