### PR TITLE
Change blob shield reflect damage modifier to patch around emitter walls

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -56,7 +56,7 @@
 	explosion_block = 2
 	//SKYRAT EDIT START - BLOB
 	ricochet_chance_mod = 2
-	ricochet_damage_mod = 0.2
+	ricochet_damage_mod = 0.02
 	//SKYRAT EDIT END - BLOB
 
 /obj/structure/blob/shield/reflective/check_projectile_ricochet(obj/item/projectile/P)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the blob shield reflector reflect dmg mod to 0.02. to drastically lower the damage taken by a reflector shield blob.
While still allowing, any other type of projectile to still do damage
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a QoL for players that play blob. currently there is a issue with how the emitter beam reflect code works, so that beams reflected off a shield blob do not follow the path back to the emitter. making it impossible for a blob to defend against walls of emitters.
This removes the damage taken by the shield reflector blob when it is hit by laser fire. thus making it possible to defend from emitter walls.
The better fix would be to overhaul the reflector code, but that's out of my scope, and more than what should be done considering the rebase.
This should not make it Overpowered as the shield reflector blob is weaker to other types of projectiles. so can be easily countered by players by just shooting the reflection blob.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked blob sheild reflector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
