### PR TITLE
advanced miner scanner have 1 text line about rock

### DIFF
--- a/modular_skyrat/code/modules/research/xenoarch/strange_rock.dm
+++ b/modular_skyrat/code/modules/research/xenoarch/strange_rock.dm
@@ -96,8 +96,6 @@
 			to_chat(user,"You must stand still to scan.")
 			return
 		playsound(loc, HM.usesound, 50, 1, -1)
-		to_chat(user,"Base Depth: [itembasedepth] centimeters.")
-		to_chat(user,"Safe Depth: [itemsafedepth] centimeters.")
 		to_chat(user,"Item Depth: [itemactualdepth] centimeters.")
 	if(istype(W,/obj/item/xenoarch/help/measuring))
 		var/obj/item/xenoarch/help/measuring/HM = W


### PR DESCRIPTION
## About The Pull Request
Advanced xeno archeology scanner showed 3 lines about rock, but it didnt make any sense, because 3-rd line show actual deep, how much to dig and the other 2 lines only clog up the screen

## Why It's Good For The Game
players on xenoarchaeologists will not suffer from working with adv scanner

## Changelog
:cl: Winter Schock
del: adv xeno archeology scanner didn't shows useless text lines about strange rock
/:cl: