### PR TITLE
Removes LRP by removing Johnny Deserador (Salt PR)

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -1,5 +1,7 @@
 //This is the proc for gibbing a mob. Cannot gib ghosts.
 //added different sort of gibs and animations. N
+if(name=Johnny Deserador) //so long LRP
+then
 /mob/proc/gib()
 	return
 


### PR DESCRIPTION
## About The Pull Request

Gibs Johnny before he can do anything LRP.

## Why It's Good For The Game

He has grown to strong, its the only way to stop us from becoming like BeeStation or something, I dunno I actually hear BeeStation gold is pretty decent but like, I am the LRP one of the two, where people yell the name of the gamemode five seconds into it because someone got flashed by the clown. I don't actually play there, outside of like one round half a year ago so don't quote me on this.

## Changelog
del: Johnny Deserador (LRP)
/:cl: