### PR TITLE
Nerfs bone spears by removing two range

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -170,7 +170,6 @@
 	force = 11
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	reach = 2
 	throwforce = 22
 	embedding = list("embedded_impact_pain_multiplier" = 3)
 	armour_penetration = 15				//Enhanced armor piercing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

undoes the bone spear changes to give it two range as it made a weapon that was too overpowered and gave ash walkers a unfair advantage over miners, it was added to help with fighting fauna but really you should work on getting in melee range to hit before pulling away and it was over all just a skill issue

## Why It's Good For The Game

it un does power creep added to the game

## Changelog
:cl:
balance: nerfs bone spears by lowering its range 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
