### PR TITLE
Tweaked Security Officer Positions To 4

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -6,8 +6,8 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	// Skyrat EDIT: 4 open positions
-	total_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
-	spawn_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	total_positions = 4 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	spawn_positions = 4 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#c02f2f"
 	minimal_player_age = 7

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -5,9 +5,9 @@
 	department_head = list("Head of Security")
 	department_flag = ENGSEC
 	faction = "Station"
-	// Skyrat EDIT: from 5 to 8
-	total_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
-	spawn_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	// Skyrat EDIT: 4 open positions
+	total_positions = 4 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	spawn_positions = 4 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#c02f2f"
 	minimal_player_age = 7

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -6,8 +6,8 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	// Skyrat EDIT: 4 open positions
-	total_positions = 4 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
-	spawn_positions = 4 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	total_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
+	spawn_positions = 8 //Handled in /datum/controller/occupations/proc/setup_officer_positions()
 	supervisors = "the head of security, and the head of your assigned department (if applicable)"
 	selection_color = "#c02f2f"
 	minimal_player_age = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes the maximum position amount for Security Officers from 8 to 4 open positions. This would reduce the amount of Security Officer slots in-game by half.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, there's a possibility of up to 14 Security positions open each round, with 8 of them being taken up by Officers. In-game, there is very little for Security Officers to do because of the easy going nature of the server and its threats. This leads to a dog-piling effect when any crewmember steps out of line. By reducing the amount of Officers from 8 to 4, it would give breathing room to crewmembers across the board (Not just antagonists) as they won't have as many Officers breathing down their necks waiting for someone to do anything remotely against Space Law.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed open officer positions from 8 to 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
