### PR TITLE
Chemistry Bag Quality of Life

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -410,7 +410,7 @@
 	/obj/item/reagent_containers/dropper,//SR addition begins here.
 	/obj/item/reagent_containers/medspray,
 	/obj/item/reagent_containers/syringe,
-	/obj/item/reagent_containers/cup/vial,//Addition End
+	/obj/item/reagent_containers/glass/bottle/vial,//Addition End
 	))
 
 /*

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -402,7 +402,7 @@
 	STR.storage_flags = STORAGE_FLAGS_VOLUME_DEFAULT
 	STR.max_volume = STORAGE_VOLUME_CHEMISTRY_BAG
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/syringe/dart, /obj/item/reagent_containers/chem_pack, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/glass/bottle/vial,))
+	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/syringe/dart, /obj/item/reagent_containers/chem_pack, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/glass/bottle/vial))
 
 /*
  *  Biowaste bag (mostly for xenobiologists)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -402,16 +402,7 @@
 	STR.storage_flags = STORAGE_FLAGS_VOLUME_DEFAULT
 	STR.max_volume = STORAGE_VOLUME_CHEMISTRY_BAG
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill,
-	/obj/item/reagent_containers/glass/beaker, 
-	/obj/item/reagent_containers/glass/bottle, 
-	/obj/item/reagent_containers/syringe/dart, 
-	/obj/item/reagent_containers/chem_pack,
-	/obj/item/reagent_containers/dropper,//SR addition begins here.
-	/obj/item/reagent_containers/medspray,
-	/obj/item/reagent_containers/syringe,
-	/obj/item/reagent_containers/glass/bottle/vial,//Addition End
-	))
+	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/syringe/dart, /obj/item/reagent_containers/chem_pack, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/glass/bottle/vial,))
 
 /*
  *  Biowaste bag (mostly for xenobiologists)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -402,7 +402,16 @@
 	STR.storage_flags = STORAGE_FLAGS_VOLUME_DEFAULT
 	STR.max_volume = STORAGE_VOLUME_CHEMISTRY_BAG
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/syringe/dart, /obj/item/reagent_containers/chem_pack))
+	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill,
+	/obj/item/reagent_containers/glass/beaker, 
+	/obj/item/reagent_containers/glass/bottle, 
+	/obj/item/reagent_containers/syringe/dart, 
+	/obj/item/reagent_containers/chem_pack,
+	/obj/item/reagent_containers/dropper,//SR addition begins here.
+	/obj/item/reagent_containers/medspray,
+	/obj/item/reagent_containers/syringe,
+	/obj/item/reagent_containers/cup/vial,//Addition End
+	))
 
 /*
  *  Biowaste bag (mostly for xenobiologists)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the Chemistry Bag the ability to hold hypovials, droppers, syringes, and medical sprays.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of Life change, makes transporting medicines made from the chemmaster easier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Allows the chemistry bag to hold other items made from the chemmaster and commonly used in medical treatment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
